### PR TITLE
data: template spell effects and family section preservation

### DIFF
--- a/monster_families/bestiary/dog.json
+++ b/monster_families/bestiary/dog.json
@@ -30,70 +30,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "name": "Rabies",
-                "saving_throw": [
-                  {
-                    "dc": 17,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 17 Fortitude",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "sickened 1 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "sickened 2 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "confusion (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 4",
-                    "subtype": "affliction_stage",
-                    "text": "dead",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Rabies')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -103,7 +54,6 @@
         ],
         "name": "Rabies",
         "subtype": "monster_family",
-        "text": "While many societies adore dogs and value them for their loyalty as pets, no affliction other than rabies can reverse sentiments about these creatures quite so easily. While many animals can be afflicted with this debilitating illness, something about a loyal family pet growing feral and violent as a result of the disease makes it that much worse.",
         "type": "stat_block_section"
       }
     ],
@@ -111,6 +61,94 @@
   },
   "name": "Dog",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "affliction",
+          "name": "Rabies",
+          "saving_throw": [
+            {
+              "dc": 17,
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "DC 17 Fortitude",
+              "type": "stat_block_section"
+            }
+          ],
+          "stages": [
+            {
+              "name": "Stage 1",
+              "subtype": "affliction_stage",
+              "text": "sickened 1 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 2",
+              "subtype": "affliction_stage",
+              "text": "sickened 2 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 3",
+              "subtype": "affliction_stage",
+              "text": "confusion (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 4",
+              "subtype": "affliction_stage",
+              "text": "dead",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        }
+      ],
+      "name": "Rabies",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary pg. 102",
+            "aonid": 2,
+            "game-obj": "Sources",
+            "name": "Bestiary pg. 102",
+            "type": "link"
+          },
+          "name": "Bestiary",
+          "page": 102,
+          "type": "source"
+        }
+      ],
+      "text": "While many societies adore dogs and value them for their loyalty as pets, no affliction other than rabies can reverse sentiments about these creatures quite so easily. While many animals can be afflicted with this debilitating illness, something about a loyal family pet growing feral and violent as a result of the disease makes it that much worse.  \n**Rabies** (disease); **Saving Throw** DC 17 Fortitude; **Stage 1** sickened 1 (1 day); **Stage 2** sickened 2 (1 day); **Stage 3** confusion (1 day); **Stage 4** dead",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/bestiary/dragon_black.json
+++ b/monster_families/bestiary/dragon_black.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Chromatic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -359,6 +155,288 @@
       ],
       "name": "Dragon, Chromatic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 104",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 104",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 104,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Chromatic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_blue.json
+++ b/monster_families/bestiary/dragon_blue.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Chromatic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -359,6 +155,288 @@
       ],
       "name": "Dragon, Chromatic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 106",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 106",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 106,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Chromatic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_brass.json
+++ b/monster_families/bestiary/dragon_brass.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Metallic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -359,6 +155,288 @@
       ],
       "name": "Dragon, Metallic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 117",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 117",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 117,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation); The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Metallic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_bronze.json
+++ b/monster_families/bestiary/dragon_bronze.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Metallic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -359,6 +155,288 @@
       ],
       "name": "Dragon, Metallic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 119",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 119",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 119,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation); The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Metallic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_chromatic.json
+++ b/monster_families/bestiary/dragon_chromatic.json
@@ -63,245 +63,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -311,7 +108,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -320,6 +116,288 @@
   "name": "Dragon, Chromatic",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 11,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary pg. 104",
+            "aonid": 2,
+            "game-obj": "Sources",
+            "name": "Bestiary pg. 104",
+            "type": "link"
+          },
+          "name": "Bestiary",
+          "page": 104,
+          "type": "source"
+        }
+      ],
+      "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+      "type": "section"
+    },
     {
       "name": "Chromatic Dragon Spellcasters",
       "sources": [

--- a/monster_families/bestiary/dragon_copper.json
+++ b/monster_families/bestiary/dragon_copper.json
@@ -78,245 +78,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Metallic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -326,7 +123,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -368,6 +164,288 @@
       ],
       "name": "Dragon, Metallic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 121",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 121",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 121,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation); The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Metallic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_gold.json
+++ b/monster_families/bestiary/dragon_gold.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Metallic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -359,6 +155,288 @@
       ],
       "name": "Dragon, Metallic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 123",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 123",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 123,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation); The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Metallic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_green.json
+++ b/monster_families/bestiary/dragon_green.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Chromatic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -401,6 +197,288 @@
       ],
       "name": "Dragon, Chromatic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 109",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 109",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 109,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Chromatic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_metallic.json
+++ b/monster_families/bestiary/dragon_metallic.json
@@ -72,245 +72,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -320,7 +117,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -329,6 +125,288 @@
   "name": "Dragon, Metallic",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 11,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary pg. 116",
+            "aonid": 2,
+            "game-obj": "Sources",
+            "name": "Bestiary pg. 116",
+            "type": "link"
+          },
+          "name": "Bestiary",
+          "page": 116,
+          "type": "source"
+        }
+      ],
+      "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+      "type": "section"
+    },
     {
       "name": "Metallic Dragon Spellcasters",
       "sources": [

--- a/monster_families/bestiary/dragon_red.json
+++ b/monster_families/bestiary/dragon_red.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Chromatic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -359,6 +155,288 @@
       ],
       "name": "Dragon, Chromatic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 111",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 111",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 111,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Chromatic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_silver.json
+++ b/monster_families/bestiary/dragon_silver.json
@@ -85,245 +85,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Metallic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -333,7 +130,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -375,6 +171,288 @@
       ],
       "name": "Dragon, Metallic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 125",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 125",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 125,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation); The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage modifiers with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Metallic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/dragon_white.json
+++ b/monster_families/bestiary/dragon_white.json
@@ -69,245 +69,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dragon, Chromatic')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -317,7 +114,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -359,6 +155,288 @@
       ],
       "name": "Dragon, Chromatic",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 113",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 113",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 113,
+              "type": "source"
+            }
+          ],
+          "text": "Some dragons can take humanoid form, allowing them to infiltrate settlements or influence others without revealing their true nature. They gain the following ability:  \n**Change Shape** [#] (arcane, concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn\u2019t change its Speed or attack and damage bonuses with its Strikes, but might change the damage type its Strikes deal (typically to bludgeoning).",
+          "type": "section"
+        },
         {
           "name": "Chromatic Dragon Spellcasters",
           "sources": [

--- a/monster_families/bestiary/elemental_water.json
+++ b/monster_families/bestiary/elemental_water.json
@@ -30,27 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The elemental melts into a column of boiling steam. For 1 minute or until the elemental is dealt cold damage, whichever comes first, any Strikes or abilities that deal cold damage instead deal fire damage, and the elemental's cold immunity and fire vulnerability are reversed.",
-                "name": "Vent Steam",
-                "subtype": "ability",
-                "trigger": "The elemental takes fire damage and is reduced to half its health or lower",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Melting Elementals')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -84,7 +68,6 @@
         ],
         "name": "Melting Elementals",
         "subtype": "monster_family",
-        "text": "Add the following optional reaction to the icicle snake, blizzardborn, and icewyrm water elementalsfor a water elemental that changes phase in response to players' actions.",
         "type": "stat_block_section"
       }
     ],
@@ -254,6 +237,64 @@
         }
       ],
       "text": "Though fire and water classically oppose one another, in the right mixture they can become a dangerous combination. Water elementals heated to a scalding temperature through natural factors such as underwater volcanoes might deal 1d6 persistent fire damage with their Strikes, while fire elementals infused with moisture might exude clouds of obscuring or even blinding steam.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The elemental melts into a column of boiling steam. For 1 minute or until the elemental is dealt cold damage, whichever comes first, any Strikes or abilities that deal cold damage instead deal fire damage, and the elemental's cold immunity and fire vulnerability are reversed.",
+          "name": "Vent Steam",
+          "subtype": "ability",
+          "trigger": "The elemental takes fire damage and is reduced to half its health or lower",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "icicle snake",
+          "aonid": 663,
+          "game-obj": "Monsters",
+          "name": "icicle snake",
+          "type": "link"
+        },
+        {
+          "alt": "blizzardborn",
+          "aonid": 665,
+          "game-obj": "Monsters",
+          "name": "blizzardborn",
+          "type": "link"
+        },
+        {
+          "alt": "icewyrm",
+          "aonid": 666,
+          "game-obj": "Monsters",
+          "name": "icewyrm",
+          "type": "link"
+        }
+      ],
+      "name": "Melting Elementals",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary pg. 152",
+            "aonid": 2,
+            "game-obj": "Sources",
+            "name": "Bestiary pg. 152",
+            "type": "link"
+          },
+          "name": "Bestiary",
+          "page": 152,
+          "type": "source"
+        }
+      ],
+      "text": "Add the following optional reaction to the icicle snake, blizzardborn, and icewyrm water elementalsfor a water elemental that changes phase in response to players' actions.  \n**Vent Steam** [@] **Trigger** The elemental takes fire damage and is reduced to half its health or lower; **Effect** The elemental melts into a column of boiling steam. For 1 minute or until the elemental is dealt cold damage, whichever comes first, any Strikes or abilities that deal cold damage instead deal fire damage, and the elemental's cold immunity and fire vulnerability are reversed.",
       "type": "section"
     },
     {

--- a/monster_families/bestiary/ghost.json
+++ b/monster_families/bestiary/ghost.json
@@ -109,289 +109,126 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Site Bound",
-                "subtype": "ability",
-                "text": "A typical ghost can stray only a short distance from where it was killed or the place it haunts. A typical limit is 120 feet. Some ghosts are instead bound to a room, building, item, or creature that was special to it rather than a location.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Rejuvenation",
-                "subtype": "ability",
-                "text": "When a ghost is destroyed, it re-forms after 2d4 days within the location it's bound to, fully healed. A ghost can be permanently destroyed only if someone determines the reason for its existence and sets right whatever prevents the spirit from resting.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, precision, unconscious",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "force",
-                    "aonid": 75,
-                    "game-obj": "Traits",
-                    "name": "force",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ghost touch",
-                    "aonid": 297,
-                    "game-obj": "Equipment",
-                    "name": "ghost touch",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "positive",
-                    "aonid": 128,
-                    "game-obj": "Traits",
-                    "name": "positive",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magical",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "all damage 5 (except force, ghost touch, or positive; double resistance to non-magical). This resistance increases to 10 at 9th level and 15 at 16th level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Fly Speed",
-                "subtype": "ability",
-                "text": "equal to its Speed",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "finesse",
-                    "aonid": 179,
-                    "game-obj": "Traits",
-                    "name": "finesse",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magical",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ghostly Hand",
-                "subtype": "ability",
-                "text": "All ghosts have a ghostly hand unarmed attack that deals negative damage. It typically has the agile, finesse, and magical traits. Some ghosts wield ghostly memories of weapons they held in life, but the effect is the same.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Ghost')].sections[?(@.name=='Ghost Abilities A ghost gains the incorporeal, spirit, and undead traits. Many become evil. If the base creature has any abilities or traits that come from it being a living, corporeal creature, it loses them. You might also need to adjust some abilities that conflict with the theme of a ghost. All ghosts gain the following abilities.')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "force",
+                "aonid": 75,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              {
+                "alt": "ghost touch",
+                "aonid": 297,
+                "game-obj": "Equipment",
+                "name": "ghost touch",
+                "type": "link"
+              },
+              {
+                "alt": "positive",
+                "aonid": 128,
+                "game-obj": "Traits",
+                "name": "positive",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "finesse",
+                "aonid": 179,
+                "game-obj": "Traits",
+                "name": "finesse",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -406,285 +243,105 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "negative",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Corrupting Gaze",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost stares at a creature it can see within 30 feet. The target takes 1d6 negative damage + 1d6 per 2 levels with a basic Will save. A creature that fails its save is also stupefied 1 for 1 minute.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Draining Touch",
-                "subtype": "ability",
-                "text": "With a touch, the ghost attempts to drain a living creature's life force. It makes a ghostly hand Strike but deals no damage on a hit. Instead, the target becomes drained 1 for 1 day, and the ghost regains HP equal to half its own level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "frightened 2",
-                    "aonid": 19,
-                    "game-obj": "Conditions",
-                    "name": "frightened 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Frightful Moan",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost laments its fate, forcing each living creature within 30 feet to attempt a Will save. On a failure, a creature becomes frightened 2 (or frightened 3 on a critical failure). On a success, a creature is temporarily immune to this ghost's frightful moan for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 16,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "animated object",
-                    "aonid": 1,
-                    "game-obj": "Rituals",
-                    "name": "animated object",
-                    "type": "link"
-                  }
-                ],
-                "name": "Inhabit Object",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "within 20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost possesses an object of size Large or smaller within 20 feet, making it an animated object. This animated object's level can be no higher than the ghost's level \u2013 2. If the target object is being held by a creature, the bearer can attempt a Will save to prevent the possession. This possession ends when the object is destroyed or the ghost leaves it. At this point, the ghost reappears in the object's square and can't Inhabit an Object again for 1d4 rounds.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "possession",
-                    "aonid": 225,
-                    "game-obj": "Spells",
-                    "name": "possession",
-                    "type": "link"
-                  }
-                ],
-                "name": "Malevolent Possession",
-                "subtype": "ability",
-                "text": "The ghost attempts to possess an adjacent corporeal creature. This has the same effect as the possession spell, except since the ghost doesn't have a physical body, it is unaffected by that restriction of the spell.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Telekinetic Assault",
-                "subtype": "ability",
-                "text": "The ghost cries out in pain and anguish as small objects and debris fly about in a 30-foot emanation. Creatures in this area take 1d6 bludgeoning damage + 1d6 per 2 levels, subject to a basic Reflex save.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Ghost')].sections[?(@.name=='Special Abilities Select one or two of the following abilities, or potentially three if the ghost is 9th level or higher. These abilities should relate to the ghost\\'s death or its history. You can also create new abilities or adapt those from monsters or classes to fit the theme. For DCs, use 2 + the DC of the ghost\\'s level.')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "stupefied 1",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 16,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 2",
+                "aonid": 19,
+                "game-obj": "Conditions",
+                "name": "frightened 2",
+                "type": "link"
+              },
+              {
+                "alt": "animated object",
+                "aonid": 1,
+                "game-obj": "Rituals",
+                "name": "animated object",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 225,
+                "game-obj": "Spells",
+                "name": "possession",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -699,54 +356,28 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ghost has an unusually pitiable appearance or can change its features to look like someone close to the attacker, which causes the target to pull back on its attack. The triggering creature must attempt a Will save. On a failure, the creature takes a \u20131 circumstance penalty to its attack roll (\u20132 on a critical failure).",
-                "name": "Beatific Appearance",
-                "requirement": "A creature the ghost is aware of targets the ghost with an attack",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Beatific Appearance')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -756,90 +387,47 @@
         ],
         "name": "Beatific Appearance",
         "subtype": "monster_family",
-        "text": "When dealing with ghosts, appearances can be deceiving. For every gory specter exists an innocent-looking spirit, their cherubic mien enhanced with magic to lull victims to their deaths.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "cold",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cold Spot",
-                "range": {
-                  "range": 5,
-                  "subtype": "range",
-                  "text": "5 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The air within 5 feet of the ghost is supernaturally cold. Characters that enter or begin their turn in the ghost's aura take 1d6 cold damage per 3 levels the ghost has (basic Fortitude save).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "cold",
-                      "aonid": 27,
-                      "game-obj": "Traits",
-                      "name": "cold",
-                      "type": "link"
-                    },
-                    "name": "cold",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Cold Spot')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 27,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -849,56 +437,33 @@
         ],
         "name": "Cold Spot",
         "subtype": "monster_family",
-        "text": "Ghosts are often associated with unnatural cold, and one of the first signs of a ghostly presence is an uncanny cold spot in the air.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "incorporeal",
-                    "aonid": 222,
-                    "game-obj": "Traits",
-                    "name": "incorporeal",
-                    "type": "link"
-                  }
-                ],
-                "name": "Corporeal Manifestation",
-                "subtype": "ability",
-                "text": "The ghost loses the incorporeal trait, temporarily increasing its Strength modifier to equal its Charisma modifier. The ghost loses its immunity to precision damage and its resistance to all damage while corporeal. The ghost can resume being incorporeal by using this action again.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Corporeal Manifestation')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "incorporeal",
+                "aonid": 222,
+                "game-obj": "Traits",
+                "name": "incorporeal",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -908,75 +473,47 @@
         ],
         "name": "Corporeal Manifestation",
         "subtype": "monster_family",
-        "text": "Traditionally, ghosts are thought of as wispy, insubstantial things, but not all ghosts follow this rule.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "nightmare",
-                    "aonid": 208,
-                    "game-obj": "Spells",
-                    "name": "nightmare",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dreamwalker",
-                "subtype": "ability",
-                "text": "Anyone who meets the ghost or visits its bound site can become subject to this effect. The first time the subject sleeps after their ghostly encounter, they're targeted by a *nightmare* spell, with the nightmares being somehow related to the ghost. Most often this means that the subject relives the ghost's last moments alive, but there are other possibilities. If the ghost wishes, it can manipulate the dreams to send messages or even hold entire conversations with dreamers.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 92,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Dreamwalker')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 92,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "nightmare",
+                "aonid": 208,
+                "game-obj": "Spells",
+                "name": "nightmare",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -986,68 +523,40 @@
         ],
         "name": "Dreamwalker",
         "subtype": "monster_family",
-        "text": "People who encounter ghosts are often plagued by nightmares, sometimes supernatural ones. Only powerful ghosts of 6th level or higher have this ability.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "invisible",
-                    "aonid": 26,
-                    "game-obj": "Conditions",
-                    "name": "invisible",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fade",
-                "subtype": "ability",
-                "text": "The ghost becomes invisible until the beginning of its next turn.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 92,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Fade')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 92,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "invisible",
+                "aonid": 26,
+                "game-obj": "Conditions",
+                "name": "invisible",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1057,82 +566,54 @@
         ],
         "name": "Fade",
         "subtype": "monster_family",
-        "text": "Ghosts are notorious for appearing and disappearing when least expected.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "illusory creature",
-                    "aonid": 158,
-                    "game-obj": "Spells",
-                    "name": "illusory creature",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Deception",
-                    "aonid": 5,
-                    "game-obj": "Skills",
-                    "name": "Deception",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fetch",
-                "subtype": "ability",
-                "text": "The ghost creates an illusory double of a creature. The fetch functions as a 2nd-level *illusory creature*, except that the ghost doesn't control the fetch, and the spell lasts for 1d4 hours instead of needing to Sustain the Spell. The fetch has a rudimentary intelligence and tries to imitate its original (it has a Deception skill value equal to the ghost's highest skill) but comes across as confused or vague. A ghost can have only one fetch at a time. If the creature doubled by the fetch encounters it, the creature must succeed at a Will save or become stupefied 1 (stupefied 2 on a Critical Failure) for as long as they can see the fetch.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 92,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Fetch')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 92,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "illusory creature",
+                "aonid": 158,
+                "game-obj": "Spells",
+                "name": "illusory creature",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 1",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1142,101 +623,61 @@
         ],
         "name": "Fetch",
         "subtype": "monster_family",
-        "text": "A fetch is a person's double, often associated with hauntings and considered a mark of great ill omen.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "moving against the wind",
-                    "aonid": 400,
-                    "game-obj": "Rules",
-                    "name": "moving against the wind",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concentrate",
-                    "aonid": 32,
-                    "game-obj": "Traits",
-                    "name": "concentrate",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ghost Storm",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "Wind surrounds the ghost out to a range of 30 feet. The wind extinguishes small non-magical fires, disperses fog and mist, blows objects of light Bulk or less around, and pushes larger objects. Squares in the ghost's aura are difficult terrain and flying creatures are always considered to be moving against the wind. The ghost can dismiss or resume the wind as an action, which has the concentrate trait.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "air",
-                      "aonid": 5,
-                      "game-obj": "Traits",
-                      "name": "air",
-                      "type": "link"
-                    },
-                    "name": "air",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Ghost Storm')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "air",
+                "aonid": 5,
+                "game-obj": "Traits",
+                "name": "air",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              {
+                "alt": "moving against the wind",
+                "aonid": 400,
+                "game-obj": "Rules",
+                "name": "moving against the wind",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1246,43 +687,26 @@
         ],
         "name": "Ghost Storm",
         "subtype": "monster_family",
-        "text": "Most ghosts can summon a wind to rattle a window or bang a shutter, but some angry spirits can do far worse.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ghost extends its presence throughout its bound site until the end of its next turn. Within this area, the ghost can extend its senses, gaining the benefits of all-around vision, and can make ghostly hand attacks or use special abilities originating from any part of the area.",
-                "frequency": "once every 10 minutes",
-                "links": [
-                  {
-                    "alt": "all-around vision",
-                    "aonid": 1,
-                    "game-obj": "MonsterAbilities",
-                    "name": "all-around vision",
-                    "type": "link"
-                  }
-                ],
-                "name": "Haunted House",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Haunted House')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "all-around vision",
+                "aonid": 1,
+                "game-obj": "MonsterAbilities",
+                "name": "all-around vision",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1292,63 +716,40 @@
         ],
         "name": "Haunted House",
         "subtype": "monster_family",
-        "text": "Ghosts tend to haunt a specific place, remaining for eternity within a tightly bound space. They might haunt their graves or the sites of their death, but either way they rarely venture far. In their home, though, a ghost holds great power.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "undead",
-                    "aonid": 160,
-                    "game-obj": "Traits",
-                    "name": "undead",
-                    "type": "link"
-                  }
-                ],
-                "name": "Lynchpin",
-                "subtype": "ability",
-                "text": "The ghost extends some of its nature to one or more undead of equal or lower level, who are connected to the ghost's story and unfinished business. These undead gain the ghost's Rejuvenation ability and can't be permanently destroyed so long as the ghost exists. If the ghost is laid to rest, all linked undead are likewise instantly destroyed. Linked undead  often, but not always, share the ghost's Site-Bound ability as well. The ghost doesn't have any control over such undead, and indeed the ghost and their partners in eternity may be unremittingly hostile to one another.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Lynchpin')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "undead",
+                "aonid": 160,
+                "game-obj": "Traits",
+                "name": "undead",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1358,103 +759,54 @@
         ],
         "name": "Lynchpin",
         "subtype": "monster_family",
-        "text": "Ghosts are typically thought of as solitary beings, but sometimes their will and rage are so strong that they drag others back from the grave as well.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "mental",
-                    "formula": "1d4",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "persistent mental damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent mental damage",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concealed",
-                    "aonid": 4,
-                    "game-obj": "Conditions",
-                    "name": "concealed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Memento Mori",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost causes one creature within 30 feet to relive the ghost's death. The target must succeed at a Will save or see and feel what the ghost did, taking 1d4 persistent mental damage per 2 levels the ghost has. All other creatures are concealed to the target until the persistent damage ends.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 92,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Memento Mori')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 92,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "persistent mental damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent mental damage",
+                "type": "link"
+              },
+              {
+                "alt": "concealed",
+                "aonid": 4,
+                "game-obj": "Conditions",
+                "name": "concealed",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1464,116 +816,68 @@
         ],
         "name": "Memento Mori",
         "subtype": "monster_family",
-        "text": "For most ghosts, death is a traumatic event, and an angry spirit is perfectly willing to share their pain with others.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Seek",
-                    "aonid": 84,
-                    "game-obj": "Actions",
-                    "name": "Seek",
-                    "type": "link"
-                  }
-                ],
-                "name": "Phantasmagoria",
-                "subtype": "ability",
-                "text": "The ghost causes all or part of its bound site to look, sound, feel, and smell like a different kind of place, and can populate it with simple illusions of people or animals. Typically, the ghost can recreate only a handful of images, usually different versions of its bound site as it appeared during the ghost's life. This can't disguise any creatures in the area, though it can cause minor, cosmetic changes (like causing a creature's clothing to appear nicer for a party or bloodstained for a battle). Any creature that touches the illusion or uses the Seek action to examine it can attempt to disbelieve it. Creatures can't leave the area of the illusion until they successfully disbelieve it.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 16,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 92,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "olfactory",
-                      "aonid": 246,
-                      "game-obj": "Traits",
-                      "name": "olfactory",
-                      "type": "link"
-                    },
-                    "name": "olfactory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Phanstamagoria')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "auditory",
+                "aonid": 16,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 92,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "olfactory",
+                "aonid": 246,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "Seek",
+                "aonid": 84,
+                "game-obj": "Actions",
+                "name": "Seek",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1583,95 +887,47 @@
         ],
         "name": "Phanstamagoria",
         "subtype": "monster_family",
-        "text": "Ghost are rarely aware of the passage of time and see no difference between the homes they lived in long ago and the ruins they haunt now. Some ghosts can spread that delusion to others.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "fire",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Pyre's Memory",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost causes great gouts of flame to erupt without warning. The ghost picks three 5-foot squares within 30 feet. Creatures that start in or enter one of these squares take 1d6 fire damage per 2 levels the ghost has, subject to a basic Reflex save. The flames last for 1 minute and don't set other things alight unless the ghost wishes. If the ghost uses this ability again, it dismisses any existing flames.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fire",
-                      "aonid": 72,
-                      "game-obj": "Traits",
-                      "name": "fire",
-                      "type": "link"
-                    },
-                    "name": "fire",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Pyre\\'s Memory')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 72,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1681,78 +937,61 @@
         ],
         "name": "Pyre's Memory",
         "subtype": "monster_family",
-        "text": "Burning is one of the most painful ways to die, and ghosts that burned to death are often more aggressive and violent than other incorporeal creatures. Their bound site is often scorched or scarred with some other evidence of fire.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ghost possesses and transforms an adjacent corpse (this requires 2 actions if the ghost is possessing its own corpse; otherwise, it takes an hour). The possessed corpse uses the statistics of a non-incorporeal undead 2 levels lower than the ghost, and the ghost possesses it as if using the *possession* spell. The specific undead is determined by the nature of the ghost and the corpse\u2014ghoul, wights, and dullahans are all common, but almost any undead is possible. If the ghost ceases to possess the corpse, the corporeal undead is immediately destroyed.",
-                "links": [
-                  {
-                    "alt": "incorporeal",
-                    "aonid": 222,
-                    "game-obj": "Traits",
-                    "name": "incorporeal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "undead",
-                    "aonid": 160,
-                    "game-obj": "Traits",
-                    "name": "undead",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "possession",
-                    "aonid": 225,
-                    "game-obj": "Spells",
-                    "name": "possession",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ghoul",
-                    "aonid": 52,
-                    "game-obj": "MonsterFamilies",
-                    "name": "ghoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "wights",
-                    "aonid": 163,
-                    "game-obj": "MonsterFamilies",
-                    "name": "wights",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "dullahans",
-                    "aonid": 171,
-                    "game-obj": "Monsters",
-                    "name": "dullahans",
-                    "type": "link"
-                  }
-                ],
-                "name": "Revenant",
-                "subtype": "ability",
-                "text": "or 1 hour;",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].sections[?(@.name=='Revenant')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "incorporeal",
+                "aonid": 222,
+                "game-obj": "Traits",
+                "name": "incorporeal",
+                "type": "link"
+              },
+              {
+                "alt": "undead",
+                "aonid": 160,
+                "game-obj": "Traits",
+                "name": "undead",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 225,
+                "game-obj": "Spells",
+                "name": "possession",
+                "type": "link"
+              },
+              {
+                "alt": "ghoul",
+                "aonid": 52,
+                "game-obj": "MonsterFamilies",
+                "name": "ghoul",
+                "type": "link"
+              },
+              {
+                "alt": "wights",
+                "aonid": 163,
+                "game-obj": "MonsterFamilies",
+                "name": "wights",
+                "type": "link"
+              },
+              {
+                "alt": "dullahans",
+                "aonid": 171,
+                "game-obj": "Monsters",
+                "name": "dullahans",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1762,7 +1001,6 @@
         ],
         "name": "Revenant",
         "subtype": "monster_family",
-        "text": "Not all ghosts try to possess the living. Some prefer to ride corpses instead, wrenching bodies from shallow graves to serve as their hosts.",
         "type": "stat_block_section"
       }
     ],
@@ -1773,6 +1011,825 @@
   "sections": [
     {
       "name": "Creating a Ghost",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "name": "Site Bound",
+              "subtype": "ability",
+              "text": "A typical ghost can stray only a short distance from where it was killed or the place it haunts. A typical limit is 120 feet. Some ghosts are instead bound to a room, building, item, or creature that was special to it rather than a location.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Rejuvenation",
+              "subtype": "ability",
+              "text": "When a ghost is destroyed, it re-forms after 2d4 days within the location it's bound to, fully healed. A ghost can be permanently destroyed only if someone determines the reason for its existence and sets right whatever prevents the spirit from resting.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, precision, unconscious",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "force",
+                  "aonid": 75,
+                  "game-obj": "Traits",
+                  "name": "force",
+                  "type": "link"
+                },
+                {
+                  "alt": "ghost touch",
+                  "aonid": 297,
+                  "game-obj": "Equipment",
+                  "name": "ghost touch",
+                  "type": "link"
+                },
+                {
+                  "alt": "positive",
+                  "aonid": 128,
+                  "game-obj": "Traits",
+                  "name": "positive",
+                  "type": "link"
+                },
+                {
+                  "alt": "magical",
+                  "aonid": 103,
+                  "game-obj": "Traits",
+                  "name": "magical",
+                  "type": "link"
+                }
+              ],
+              "name": "Resistances",
+              "subtype": "ability",
+              "text": "all damage 5 (except force, ghost touch, or positive; double resistance to non-magical). This resistance increases to 10 at 9th level and 15 at 16th level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Fly Speed",
+              "subtype": "ability",
+              "text": "equal to its Speed",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 170,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                },
+                {
+                  "alt": "finesse",
+                  "aonid": 179,
+                  "game-obj": "Traits",
+                  "name": "finesse",
+                  "type": "link"
+                },
+                {
+                  "alt": "magical",
+                  "aonid": 103,
+                  "game-obj": "Traits",
+                  "name": "magical",
+                  "type": "link"
+                }
+              ],
+              "name": "Ghostly Hand",
+              "subtype": "ability",
+              "text": "All ghosts have a ghostly hand unarmed attack that deals negative damage. It typically has the agile, finesse, and magical traits. Some ghosts wield ghostly memories of weapons they held in life, but the effect is the same.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "force",
+              "aonid": 75,
+              "game-obj": "Traits",
+              "name": "force",
+              "type": "link"
+            },
+            {
+              "alt": "ghost touch",
+              "aonid": 297,
+              "game-obj": "Equipment",
+              "name": "ghost touch",
+              "type": "link"
+            },
+            {
+              "alt": "positive",
+              "aonid": 128,
+              "game-obj": "Traits",
+              "name": "positive",
+              "type": "link"
+            },
+            {
+              "alt": "magical",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "finesse",
+              "aonid": 179,
+              "game-obj": "Traits",
+              "name": "finesse",
+              "type": "link"
+            },
+            {
+              "alt": "magical",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            }
+          ],
+          "name": "Ghost Abilities A ghost gains the incorporeal, spirit, and undead traits. Many become evil. If the base creature has any abilities or traits that come from it being a living, corporeal creature, it loses them. You might also need to adjust some abilities that conflict with the theme of a ghost. All ghosts gain the following abilities.",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 166",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 166",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 166,
+              "type": "source"
+            },
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "**Darkvision**  \n**Site Bound** A typical ghost can stray only a short distance from where it was killed or the place it haunts. A typical limit is 120 feet. Some ghosts are instead bound to a room, building, item, or creature that was special to it rather than a location.  \n**Negative Healing**  \n**Rejuvenation** (divine, necromancy) When a ghost is destroyed, it re-forms after 2d4 days within the location it's bound to, fully healed. A ghost can be permanently destroyed only if someone determines the reason for its existence and sets right whatever prevents the spirit from resting.  \n**Immunities** death effects, disease, paralyzed, poison, precision, unconscious  \n**Resistances** all damage 5 (except force, ghost touch, or positive; double resistance to non-magical). This resistance increases to 10 at 9th level and 15 at 16th level.  \n**Fly Speed** equal to its Speed  \n**Ghostly Hand** All ghosts have a ghostly hand unarmed attack that deals negative damage. It typically has the agile, finesse, and magical traits. Some ghosts wield ghostly memories of weapons they held in life, but the effect is the same.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "negative",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "stupefied 1",
+                  "aonid": 37,
+                  "game-obj": "Conditions",
+                  "name": "stupefied 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Corrupting Gaze",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "within 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The ghost stares at a creature it can see within 30 feet. The target takes 1d6 negative damage + 1d6 per 2 levels with a basic Will save. A creature that fails its save is also stupefied 1 for 1 minute.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Draining Touch",
+              "subtype": "ability",
+              "text": "With a touch, the ghost attempts to drain a living creature's life force. It makes a ghostly hand Strike but deals no damage on a hit. Instead, the target becomes drained 1 for 1 day, and the ghost regains HP equal to half its own level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "frightened 2",
+                  "aonid": 19,
+                  "game-obj": "Conditions",
+                  "name": "frightened 2",
+                  "type": "link"
+                }
+              ],
+              "name": "Frightful Moan",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "within 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The ghost laments its fate, forcing each living creature within 30 feet to attempt a Will save. On a failure, a creature becomes frightened 2 (or frightened 3 on a critical failure). On a success, a creature is temporarily immune to this ghost's frightful moan for 1 minute.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "auditory",
+                    "aonid": 16,
+                    "game-obj": "Traits",
+                    "name": "auditory",
+                    "type": "link"
+                  },
+                  "name": "auditory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 60,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fear",
+                    "aonid": 68,
+                    "game-obj": "Traits",
+                    "name": "fear",
+                    "type": "link"
+                  },
+                  "name": "fear",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "animated object",
+                  "aonid": 1,
+                  "game-obj": "Rituals",
+                  "name": "animated object",
+                  "type": "link"
+                }
+              ],
+              "name": "Inhabit Object",
+              "range": {
+                "range": 20,
+                "subtype": "range",
+                "text": "within 20 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The ghost possesses an object of size Large or smaller within 20 feet, making it an animated object. This animated object's level can be no higher than the ghost's level \u2013 2. If the target object is being held by a creature, the bearer can attempt a Will save to prevent the possession. This possession ends when the object is destroyed or the ghost leaves it. At this point, the ghost reappears in the object's square and can't Inhabit an Object again for 1d4 rounds.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "possession",
+                  "aonid": 225,
+                  "game-obj": "Spells",
+                  "name": "possession",
+                  "type": "link"
+                }
+              ],
+              "name": "Malevolent Possession",
+              "subtype": "ability",
+              "text": "The ghost attempts to possess an adjacent corporeal creature. This has the same effect as the possession spell, except since the ghost doesn't have a physical body, it is unaffected by that restriction of the spell.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "emanation",
+                  "size": 30,
+                  "subtype": "area",
+                  "text": "30-foot emanation",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "damage_type": "bludgeoning",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Telekinetic Assault",
+              "subtype": "ability",
+              "text": "The ghost cries out in pain and anguish as small objects and debris fly about in a 30-foot emanation. Creatures in this area take 1d6 bludgeoning damage + 1d6 per 2 levels, subject to a basic Reflex save.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "evocation",
+                    "aonid": 65,
+                    "game-obj": "Traits",
+                    "name": "evocation",
+                    "type": "link"
+                  },
+                  "name": "evocation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "stupefied 1",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "auditory",
+              "aonid": 16,
+              "game-obj": "Traits",
+              "name": "auditory",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 60,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 68,
+              "game-obj": "Traits",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "frightened 2",
+              "aonid": 19,
+              "game-obj": "Conditions",
+              "name": "frightened 2",
+              "type": "link"
+            },
+            {
+              "alt": "animated object",
+              "aonid": 1,
+              "game-obj": "Rituals",
+              "name": "animated object",
+              "type": "link"
+            },
+            {
+              "alt": "possession",
+              "aonid": 225,
+              "game-obj": "Spells",
+              "name": "possession",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "evocation",
+              "aonid": 65,
+              "game-obj": "Traits",
+              "name": "evocation",
+              "type": "link"
+            }
+          ],
+          "name": "Special Abilities Select one or two of the following abilities, or potentially three if the ghost is 9th level or higher. These abilities should relate to the ghost's death or its history. You can also create new abilities or adapt those from monsters or classes to fit the theme. For DCs, use 2 + the DC of the ghost's level.",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 166",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 166",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 166,
+              "type": "source"
+            },
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "**Corrupting Gaze** [##] The ghost stares at a creature it can see within 30 feet. The target takes 1d6 negative damage + 1d6 per 2 levels with a basic Will save. A creature that fails its save is also stupefied 1 for 1 minute.  \n**Draining Touch** [##] With a touch, the ghost attempts to drain a living creature's life force. It makes a ghostly hand Strike but deals no damage on a hit. Instead, the target becomes drained 1 for 1 day, and the ghost regains HP equal to half its own level.  \n**Frightful Moan** [##] (auditory, divine, emotion, enchantment, fear, mental) The ghost laments its fate, forcing each living creature within 30 feet to attempt a Will save. On a failure, a creature becomes frightened 2 (or frightened 3 on a critical failure). On a success, a creature is temporarily immune to this ghost's frightful moan for 1 minute.  \n**Inhabit Object** [#] The ghost possesses an object of size Large or smaller within 20 feet, making it an animated object. This animated object's level can be no higher than the ghost's level \u2013 2. If the target object is being held by a creature, the bearer can attempt a Will save to prevent the possession. This possession ends when the object is destroyed or the ghost leaves it. At this point, the ghost reappears in the object's square and can't Inhabit an Object again for 1d4 rounds.  \n**Malevolent Possession** [##] The ghost attempts to possess an adjacent corporeal creature. This has the same effect as the possession spell, except since the ghost doesn't have a physical body, it is unaffected by that restriction of the spell.  \n**Telekinetic Assault** [##] (divine, evocation) The ghost cries out in pain and anguish as small objects and debris fly about in a 30-foot emanation. Creatures in this area take 1d6 bludgeoning damage + 1d6 per 2 levels, subject to a basic Reflex save.",
+          "type": "section"
+        }
+      ],
       "sources": [
         {
           "link": {
@@ -1804,6 +1861,1426 @@
     {
       "name": "Special Abilities",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The ghost has an unusually pitiable appearance or can change its features to look like someone close to the attacker, which causes the target to pull back on its attack. The triggering creature must attempt a Will save. On a failure, the creature takes a \u20131 circumstance penalty to its attack roll (\u20132 on a critical failure).",
+              "name": "Beatific Appearance",
+              "requirement": "A creature the ghost is aware of targets the ghost with an attack",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            }
+          ],
+          "name": "Beatific Appearance",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "When dealing with ghosts, appearances can be deceiving. For every gory specter exists an innocent-looking spirit, their cherubic mien enhanced with magic to lull victims to their deaths.   \n  \n**Beatific Appearance** [@] (divine, enchantment) **Requirements** A creature the ghost is aware of targets the ghost with an attack; **Effect** The ghost has an unusually pitiable appearance or can change its features to look like someone close to the attacker, which causes the target to pull back on its attack. The triggering creature must attempt a Will save. On a failure, the creature takes a \u20131 circumstance penalty to its attack roll (\u20132 on a critical failure).",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "cold",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Cold Spot",
+              "range": {
+                "range": 5,
+                "subtype": "range",
+                "text": "5 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The air within 5 feet of the ghost is supernaturally cold. Characters that enter or begin their turn in the ghost's aura take 1d6 cold damage per 3 levels the ghost has (basic Fortitude save).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "cold",
+                    "aonid": 27,
+                    "game-obj": "Traits",
+                    "name": "cold",
+                    "type": "link"
+                  },
+                  "name": "cold",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 27,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Cold Spot",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Ghosts are often associated with unnatural cold, and one of the first signs of a ghostly presence is an uncanny cold spot in the air.   \n  \n**Cold Spot** (aura, cold, divine) 5 feet. The air within 5 feet of the ghost is supernaturally cold. Characters that enter or begin their turn in the ghost's aura take 1d6 cold damage per 3 levels the ghost has (basic Fortitude save).",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "incorporeal",
+                  "aonid": 222,
+                  "game-obj": "Traits",
+                  "name": "incorporeal",
+                  "type": "link"
+                }
+              ],
+              "name": "Corporeal Manifestation",
+              "subtype": "ability",
+              "text": "The ghost loses the incorporeal trait, temporarily increasing its Strength modifier to equal its Charisma modifier. The ghost loses its immunity to precision damage and its resistance to all damage while corporeal. The ghost can resume being incorporeal by using this action again.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "incorporeal",
+              "aonid": 222,
+              "game-obj": "Traits",
+              "name": "incorporeal",
+              "type": "link"
+            }
+          ],
+          "name": "Corporeal Manifestation",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Traditionally, ghosts are thought of as wispy, insubstantial things, but not all ghosts follow this rule.   \n  \n**Corporeal Manifestation** [#] (concentrate) The ghost loses the incorporeal trait, temporarily increasing its Strength modifier to equal its Charisma modifier. The ghost loses its immunity to precision damage and its resistance to all damage while corporeal. The ghost can resume being incorporeal by using this action again.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "nightmare",
+                  "aonid": 208,
+                  "game-obj": "Spells",
+                  "name": "nightmare",
+                  "type": "link"
+                }
+              ],
+              "name": "Dreamwalker",
+              "subtype": "ability",
+              "text": "Anyone who meets the ghost or visits its bound site can become subject to this effect. The first time the subject sleeps after their ghostly encounter, they're targeted by a *nightmare* spell, with the nightmares being somehow related to the ghost. Most often this means that the subject relives the ghost's last moments alive, but there are other possibilities. If the ghost wishes, it can manipulate the dreams to send messages or even hold entire conversations with dreamers.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "illusion",
+                    "aonid": 92,
+                    "game-obj": "Traits",
+                    "name": "illusion",
+                    "type": "link"
+                  },
+                  "name": "illusion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "illusion",
+              "aonid": 92,
+              "game-obj": "Traits",
+              "name": "illusion",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "nightmare",
+              "aonid": 208,
+              "game-obj": "Spells",
+              "name": "nightmare",
+              "type": "link"
+            }
+          ],
+          "name": "Dreamwalker",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "People who encounter ghosts are often plagued by nightmares, sometimes supernatural ones. Only powerful ghosts of 6th level or higher have this ability.   \n  \n**Dreamwalker** (divine, illusion, mental) Anyone who meets the ghost or visits its bound site can become subject to this effect. The first time the subject sleeps after their ghostly encounter, they're targeted by a *nightmare* spell, with the nightmares being somehow related to the ghost. Most often this means that the subject relives the ghost's last moments alive, but there are other possibilities. If the ghost wishes, it can manipulate the dreams to send messages or even hold entire conversations with dreamers.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "invisible",
+                  "aonid": 26,
+                  "game-obj": "Conditions",
+                  "name": "invisible",
+                  "type": "link"
+                }
+              ],
+              "name": "Fade",
+              "subtype": "ability",
+              "text": "The ghost becomes invisible until the beginning of its next turn.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "illusion",
+                    "aonid": 92,
+                    "game-obj": "Traits",
+                    "name": "illusion",
+                    "type": "link"
+                  },
+                  "name": "illusion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "illusion",
+              "aonid": 92,
+              "game-obj": "Traits",
+              "name": "illusion",
+              "type": "link"
+            },
+            {
+              "alt": "invisible",
+              "aonid": 26,
+              "game-obj": "Conditions",
+              "name": "invisible",
+              "type": "link"
+            }
+          ],
+          "name": "Fade",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Ghosts are notorious for appearing and disappearing when least expected.   \n  \n**Fade** [#] (divine, illusion) The ghost becomes invisible until the beginning of its next turn.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "illusory creature",
+                  "aonid": 158,
+                  "game-obj": "Spells",
+                  "name": "illusory creature",
+                  "type": "link"
+                },
+                {
+                  "alt": "Deception",
+                  "aonid": 5,
+                  "game-obj": "Skills",
+                  "name": "Deception",
+                  "type": "link"
+                },
+                {
+                  "alt": "stupefied 1",
+                  "aonid": 37,
+                  "game-obj": "Conditions",
+                  "name": "stupefied 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Fetch",
+              "subtype": "ability",
+              "text": "The ghost creates an illusory double of a creature. The fetch functions as a 2nd-level *illusory creature*, except that the ghost doesn't control the fetch, and the spell lasts for 1d4 hours instead of needing to Sustain the Spell. The fetch has a rudimentary intelligence and tries to imitate its original (it has a Deception skill value equal to the ghost's highest skill) but comes across as confused or vague. A ghost can have only one fetch at a time. If the creature doubled by the fetch encounters it, the creature must succeed at a Will save or become stupefied 1 (stupefied 2 on a Critical Failure) for as long as they can see the fetch.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "illusion",
+                    "aonid": 92,
+                    "game-obj": "Traits",
+                    "name": "illusion",
+                    "type": "link"
+                  },
+                  "name": "illusion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "illusion",
+              "aonid": 92,
+              "game-obj": "Traits",
+              "name": "illusion",
+              "type": "link"
+            },
+            {
+              "alt": "illusory creature",
+              "aonid": 158,
+              "game-obj": "Spells",
+              "name": "illusory creature",
+              "type": "link"
+            },
+            {
+              "alt": "Deception",
+              "aonid": 5,
+              "game-obj": "Skills",
+              "name": "Deception",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied 1",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            }
+          ],
+          "name": "Fetch",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "A fetch is a person's double, often associated with hauntings and considered a mark of great ill omen.   \n  \n**Fetch** [##] (divine, illusion) The ghost creates an illusory double of a creature. The fetch functions as a 2nd-level *illusory creature*, except that the ghost doesn't control the fetch, and the spell lasts for 1d4 hours instead of needing to Sustain the Spell. The fetch has a rudimentary intelligence and tries to imitate its original (it has a Deception skill value equal to the ghost's highest skill) but comes across as confused or vague. A ghost can have only one fetch at a time. If the creature doubled by the fetch encounters it, the creature must succeed at a Will save or become stupefied 1 (stupefied 2 on a Critical Failure) for as long as they can see the fetch.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "moving against the wind",
+                  "aonid": 400,
+                  "game-obj": "Rules",
+                  "name": "moving against the wind",
+                  "type": "link"
+                },
+                {
+                  "alt": "concentrate",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "name": "concentrate",
+                  "type": "link"
+                }
+              ],
+              "name": "Ghost Storm",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "Wind surrounds the ghost out to a range of 30 feet. The wind extinguishes small non-magical fires, disperses fog and mist, blows objects of light Bulk or less around, and pushes larger objects. Squares in the ghost's aura are difficult terrain and flying creatures are always considered to be moving against the wind. The ghost can dismiss or resume the wind as an action, which has the concentrate trait.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "air",
+                    "aonid": 5,
+                    "game-obj": "Traits",
+                    "name": "air",
+                    "type": "link"
+                  },
+                  "name": "air",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "evocation",
+                    "aonid": 65,
+                    "game-obj": "Traits",
+                    "name": "evocation",
+                    "type": "link"
+                  },
+                  "name": "evocation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "air",
+              "aonid": 5,
+              "game-obj": "Traits",
+              "name": "air",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "evocation",
+              "aonid": 65,
+              "game-obj": "Traits",
+              "name": "evocation",
+              "type": "link"
+            },
+            {
+              "alt": "moving against the wind",
+              "aonid": 400,
+              "game-obj": "Rules",
+              "name": "moving against the wind",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            }
+          ],
+          "name": "Ghost Storm",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Most ghosts can summon a wind to rattle a window or bang a shutter, but some angry spirits can do far worse.   \n  \n**Ghost Storm** (air, aura, divine, evocation) 30 feet. Wind surrounds the ghost out to a range of 30 feet. The wind extinguishes small non-magical fires, disperses fog and mist, blows objects of light Bulk or less around, and pushes larger objects. Squares in the ghost's aura are difficult terrain and flying creatures are always considered to be moving against the wind. The ghost can dismiss or resume the wind as an action, which has the concentrate trait.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The ghost extends its presence throughout its bound site until the end of its next turn. Within this area, the ghost can extend its senses, gaining the benefits of all-around vision, and can make ghostly hand attacks or use special abilities originating from any part of the area.",
+              "frequency": "once every 10 minutes",
+              "links": [
+                {
+                  "alt": "all-around vision",
+                  "aonid": 1,
+                  "game-obj": "MonsterAbilities",
+                  "name": "all-around vision",
+                  "type": "link"
+                }
+              ],
+              "name": "Haunted House",
+              "subtype": "ability",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "all-around vision",
+              "aonid": 1,
+              "game-obj": "MonsterAbilities",
+              "name": "all-around vision",
+              "type": "link"
+            }
+          ],
+          "name": "Haunted House",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Ghosts tend to haunt a specific place, remaining for eternity within a tightly bound space. They might haunt their graves or the sites of their death, but either way they rarely venture far. In their home, though, a ghost holds great power.   \n  \n**Haunted House** [#] **Frequency** once every 10 minutes; **Effect** The ghost extends its presence throughout its bound site until the end of its next turn. Within this area, the ghost can extend its senses, gaining the benefits of all-around vision, and can make ghostly hand attacks or use special abilities originating from any part of the area.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "undead",
+                  "aonid": 160,
+                  "game-obj": "Traits",
+                  "name": "undead",
+                  "type": "link"
+                }
+              ],
+              "name": "Lynchpin",
+              "subtype": "ability",
+              "text": "The ghost extends some of its nature to one or more undead of equal or lower level, who are connected to the ghost's story and unfinished business. These undead gain the ghost's Rejuvenation ability and can't be permanently destroyed so long as the ghost exists. If the ghost is laid to rest, all linked undead are likewise instantly destroyed. Linked undead  often, but not always, share the ghost's Site-Bound ability as well. The ghost doesn't have any control over such undead, and indeed the ghost and their partners in eternity may be unremittingly hostile to one another.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "undead",
+              "aonid": 160,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            }
+          ],
+          "name": "Lynchpin",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Ghosts are typically thought of as solitary beings, but sometimes their will and rage are so strong that they drag others back from the grave as well.   \n  \n**Lynchpin** (divine, necromancy) The ghost extends some of its nature to one or more undead of equal or lower level, who are connected to the ghost's story and unfinished business. These undead gain the ghost's Rejuvenation ability and can't be permanently destroyed so long as the ghost exists. If the ghost is laid to rest, all linked undead are likewise instantly destroyed. Linked undead often, but not always, share the ghost's Site-Bound ability as well. The ghost doesn't have any control over such undead, and indeed the ghost and their partners in eternity may be unremittingly hostile to one another.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "mental",
+                  "formula": "1d4",
+                  "persistent": true,
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "persistent mental damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent mental damage",
+                  "type": "link"
+                },
+                {
+                  "alt": "concealed",
+                  "aonid": 4,
+                  "game-obj": "Conditions",
+                  "name": "concealed",
+                  "type": "link"
+                }
+              ],
+              "name": "Memento Mori",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "within 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The ghost causes one creature within 30 feet to relive the ghost's death. The target must succeed at a Will save or see and feel what the ghost did, taking 1d4 persistent mental damage per 2 levels the ghost has. All other creatures are concealed to the target until the persistent damage ends.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "illusion",
+                    "aonid": 92,
+                    "game-obj": "Traits",
+                    "name": "illusion",
+                    "type": "link"
+                  },
+                  "name": "illusion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "illusion",
+              "aonid": 92,
+              "game-obj": "Traits",
+              "name": "illusion",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "persistent mental damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent mental damage",
+              "type": "link"
+            },
+            {
+              "alt": "concealed",
+              "aonid": 4,
+              "game-obj": "Conditions",
+              "name": "concealed",
+              "type": "link"
+            }
+          ],
+          "name": "Memento Mori",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "For most ghosts, death is a traumatic event, and an angry spirit is perfectly willing to share their pain with others.   \n  \n**Memento Mori** [##] (divine, illusion, mental) The ghost causes one creature within 30 feet to relive the ghost's death. The target must succeed at a Will save or see and feel what the ghost did, taking 1d4 persistent mental damage per 2 levels the ghost has. All other creatures are concealed to the target until the persistent damage ends.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Three Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "Seek",
+                  "aonid": 84,
+                  "game-obj": "Actions",
+                  "name": "Seek",
+                  "type": "link"
+                }
+              ],
+              "name": "Phantasmagoria",
+              "subtype": "ability",
+              "text": "The ghost causes all or part of its bound site to look, sound, feel, and smell like a different kind of place, and can populate it with simple illusions of people or animals. Typically, the ghost can recreate only a handful of images, usually different versions of its bound site as it appeared during the ghost's life. This can't disguise any creatures in the area, though it can cause minor, cosmetic changes (like causing a creature's clothing to appear nicer for a party or bloodstained for a battle). Any creature that touches the illusion or uses the Seek action to examine it can attempt to disbelieve it. Creatures can't leave the area of the illusion until they successfully disbelieve it.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "auditory",
+                    "aonid": 16,
+                    "game-obj": "Traits",
+                    "name": "auditory",
+                    "type": "link"
+                  },
+                  "name": "auditory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "illusion",
+                    "aonid": 92,
+                    "game-obj": "Traits",
+                    "name": "illusion",
+                    "type": "link"
+                  },
+                  "name": "illusion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "olfactory",
+                    "aonid": 246,
+                    "game-obj": "Traits",
+                    "name": "olfactory",
+                    "type": "link"
+                  },
+                  "name": "olfactory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "visual",
+                    "aonid": 163,
+                    "game-obj": "Traits",
+                    "name": "visual",
+                    "type": "link"
+                  },
+                  "name": "visual",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "auditory",
+              "aonid": 16,
+              "game-obj": "Traits",
+              "name": "auditory",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "illusion",
+              "aonid": 92,
+              "game-obj": "Traits",
+              "name": "illusion",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "olfactory",
+              "aonid": 246,
+              "game-obj": "Traits",
+              "name": "olfactory",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "Seek",
+              "aonid": 84,
+              "game-obj": "Actions",
+              "name": "Seek",
+              "type": "link"
+            }
+          ],
+          "name": "Phanstamagoria",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Ghost are rarely aware of the passage of time and see no difference between the homes they lived in long ago and the ruins they haunt now. Some ghosts can spread that delusion to others.   \n  \n**Phantasmagoria** [###] (auditory, divine, illusion, mental, olfactory, visual) The ghost causes all or part of its bound site to look, sound, feel, and smell like a different kind of place, and can populate it with simple illusions of people or animals. Typically, the ghost can recreate only a handful of images, usually different versions of its bound site as it appeared during the ghost's life. This can't disguise any creatures in the area, though it can cause minor, cosmetic changes (like causing a creature's clothing to appear nicer for a party or bloodstained for a battle). Any creature that touches the illusion or uses the Seek action to examine it can attempt to disbelieve it. Creatures can't leave the area of the illusion until they successfully disbelieve it.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Three Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "fire",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Pyre's Memory",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "within 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The ghost causes great gouts of flame to erupt without warning. The ghost picks three 5-foot squares within 30 feet. Creatures that start in or enter one of these squares take 1d6 fire damage per 2 levels the ghost has, subject to a basic Reflex save. The flames last for 1 minute and don't set other things alight unless the ghost wishes. If the ghost uses this ability again, it dismisses any existing flames.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "evocation",
+                    "aonid": 65,
+                    "game-obj": "Traits",
+                    "name": "evocation",
+                    "type": "link"
+                  },
+                  "name": "evocation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fire",
+                    "aonid": 72,
+                    "game-obj": "Traits",
+                    "name": "fire",
+                    "type": "link"
+                  },
+                  "name": "fire",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "evocation",
+              "aonid": 65,
+              "game-obj": "Traits",
+              "name": "evocation",
+              "type": "link"
+            },
+            {
+              "alt": "fire",
+              "aonid": 72,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Pyre's Memory",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Burning is one of the most painful ways to die, and ghosts that burned to death are often more aggressive and violent than other incorporeal creatures. Their bound site is often scorched or scarred with some other evidence of fire.   \n  \n**Pyre's Memory** [###] (divine, evocation, fire) The ghost causes great gouts of flame to erupt without warning. The ghost picks three 5-foot squares within 30 feet. Creatures that start in or enter one of these squares take 1d6 fire damage per 2 levels the ghost has, subject to a basic Reflex save. The flames last for 1 minute and don't set other things alight unless the ghost wishes. If the ghost uses this ability again, it dismisses any existing flames.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The ghost possesses and transforms an adjacent corpse (this requires 2 actions if the ghost is possessing its own corpse; otherwise, it takes an hour). The possessed corpse uses the statistics of a non-incorporeal undead 2 levels lower than the ghost, and the ghost possesses it as if using the *possession* spell. The specific undead is determined by the nature of the ghost and the corpse\u2014ghoul, wights, and dullahans are all common, but almost any undead is possible. If the ghost ceases to possess the corpse, the corporeal undead is immediately destroyed.",
+              "links": [
+                {
+                  "alt": "incorporeal",
+                  "aonid": 222,
+                  "game-obj": "Traits",
+                  "name": "incorporeal",
+                  "type": "link"
+                },
+                {
+                  "alt": "undead",
+                  "aonid": 160,
+                  "game-obj": "Traits",
+                  "name": "undead",
+                  "type": "link"
+                },
+                {
+                  "alt": "possession",
+                  "aonid": 225,
+                  "game-obj": "Spells",
+                  "name": "possession",
+                  "type": "link"
+                },
+                {
+                  "alt": "ghoul",
+                  "aonid": 52,
+                  "game-obj": "MonsterFamilies",
+                  "name": "ghoul",
+                  "type": "link"
+                },
+                {
+                  "alt": "wights",
+                  "aonid": 163,
+                  "game-obj": "MonsterFamilies",
+                  "name": "wights",
+                  "type": "link"
+                },
+                {
+                  "alt": "dullahans",
+                  "aonid": 171,
+                  "game-obj": "Monsters",
+                  "name": "dullahans",
+                  "type": "link"
+                }
+              ],
+              "name": "Revenant",
+              "subtype": "ability",
+              "text": "or 1 hour;",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "incorporeal",
+              "aonid": 222,
+              "game-obj": "Traits",
+              "name": "incorporeal",
+              "type": "link"
+            },
+            {
+              "alt": "undead",
+              "aonid": 160,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "possession",
+              "aonid": 225,
+              "game-obj": "Spells",
+              "name": "possession",
+              "type": "link"
+            },
+            {
+              "alt": "ghoul",
+              "aonid": 52,
+              "game-obj": "MonsterFamilies",
+              "name": "ghoul",
+              "type": "link"
+            },
+            {
+              "alt": "wights",
+              "aonid": 163,
+              "game-obj": "MonsterFamilies",
+              "name": "wights",
+              "type": "link"
+            },
+            {
+              "alt": "dullahans",
+              "aonid": 171,
+              "game-obj": "Monsters",
+              "name": "dullahans",
+              "type": "link"
+            }
+          ],
+          "name": "Revenant",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "href": "https://paizo.com/products/btq024xm",
+                "name": "Pathfinder #165: Eyes of Empty Death pg. 69",
+                "type": "link"
+              },
+              "name": "Pathfinder #165: Eyes of Empty Death",
+              "page": 69,
+              "type": "source"
+            }
+          ],
+          "text": "Not all ghosts try to possess the living. Some prefer to ride corpses instead, wrenching bodies from shallow graves to serve as their hosts.   \n  \n**Revenant** [##] or 1 hour; **Effect** The ghost possesses and transforms an adjacent corpse (this requires 2 actions if the ghost is possessing its own corpse; otherwise, it takes an hour). The possessed corpse uses the statistics of a non-incorporeal undead 2 levels lower than the ghost, and the ghost possesses it as if using the *possession* spell. The specific undead is determined by the nature of the ghost and the corpse\u2014ghoul, wights, and dullahans are all common, but almost any undead is possible. If the ghost ceases to possess the corpse, the corporeal undead is immediately destroyed.",
+          "type": "section"
+        },
         {
           "name": "A Rebirth in Death",
           "sources": [

--- a/monster_families/bestiary/ghoul.json
+++ b/monster_families/bestiary/ghoul.json
@@ -170,317 +170,70 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, unconscious",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the creature had hands, it gains a claw Strike (an agile unarmed attack that deals slashing damage plus paralysis). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Jaws",
-                "subtype": "ability",
-                "text": "If the creature had a mouth, it gains a jaws Strike (an unarmed attack that deals slashing damage plus ghoul fever and paralysis). The damage amount should be the same as the creature's non-agile attacks.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ghoul devours a chunk of the corpse and regains 1d6 Hit Points plus 1d6 for every 2 levels it has. It can regain Hit Points from any given corpse only once.",
-                "name": "Consume Flesh",
-                "requirement": "The ghoul is adjacent to the corpse of a creature that died within the last hour.",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 104,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "name": "Ghoul Fever",
-                "saving_throw": [
-                  {
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "Fortitude",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "carrier with no ill effect (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "2d6 negative damage and regains half as many Hit Points from all healing (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "as stage 2 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 4",
-                    "subtype": "affliction_stage",
-                    "text": "2d6 negative damage and gains no benefit from healing (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 5",
-                    "subtype": "affliction_stage",
-                    "text": "as stage 4 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 6",
-                    "subtype": "affliction_stage",
-                    "text": "dead, and rises as a ghoul the next midnight.",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Paralysis",
-                "subtype": "ability",
-                "text": "Any living, non-elf creature hit by a ghoul's attack must succeed at a Fortitude save or become paralyzed. It can attempt a new save at the end of each of its turns, and the DC cumulatively decreases by 1 on each such save.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Swift Leap",
-                "subtype": "ability",
-                "text": "The ghoul jumps up to half its Speed. This movement doesn't trigger reactions.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "move",
-                      "aonid": 114,
-                      "game-obj": "Traits",
-                      "name": "move",
-                      "type": "link"
-                    },
-                    "name": "move",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Ghouls')].sections[?(@.name=='Ghoul Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 104,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "move",
+                "aonid": 114,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -490,314 +243,61 @@
         ],
         "name": "Ghoul Abilities",
         "subtype": "monster_family",
-        "text": "A ghoul gains the undead and ghoul traits, and it usually becomes evil. If the base creature has any abilities that come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the theme of a ghoul. All ghouls gain the following abilities. The save DC for all abilities uses the DC of the ghoul's level.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Stench",
-                "range": {
-                  "range": 10,
-                  "subtype": "range",
-                  "text": "10 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "A creature entering the aura or starting its turn in the aura must succeed at a Fortitude save (use a DC based on the monster's level; Core Rulebook 503) or become sickened 1 (plus slowed 1 as long as it\u001bs sickened on a critical failure). While within the aura, the creature takes a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "olfactory",
-                      "aonid": 246,
-                      "game-obj": "Traits",
-                      "name": "olfactory",
-                      "type": "link"
-                    },
-                    "name": "olfactory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 76,
-                  "edition": "remastered",
-                  "game-id": "84b6ec99f4ecdeb47e51d74db2ad2de5",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "sickened 1",
-                      "aonid": 91,
-                      "game-obj": "Conditions",
-                      "name": "sickened 1",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "sickened",
-                      "aonid": 91,
-                      "game-obj": "Conditions",
-                      "name": "sickened",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Stench",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature entering the aura or starting its turn in the area must succeed at a Fortitude save or become sickened 1 (plus slowed 1 as long as it's sickened on a critical failure). A creature that succeeds at its save or recovers from being sickened is temporarily immune to all stench auras for 1 minute.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 206,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "5315505cfd3f3ba2685e9747898193b2",
-                      "game-obj": "Traits",
-                      "name": "Aura",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 453",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 453",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 453,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An aura is an emanation that continually ebbs out from you, affecting creatures within a certain radius. Aura can also refer to the magical signature of an item.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 246,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "1612b09b1aa256bf5512a119600505a6",
-                      "game-obj": "Traits",
-                      "name": "Olfactory",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 459",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 459",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 459,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An olfactory effect can affect only creatures that can smell it. This applies only to olfactory parts of the effect, as determined by the GM.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Claws and Jaws",
-                "subtype": "ability",
-                "text": "As ghoul, but apply ghast fever instead of ghoul fever.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Consume Flesh",
-                "subtype": "ability",
-                "text": "As ghoul, but it regains 1d6 additional Hit Points.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "name": "Ghast Fever",
-                "saving_throw": [
-                  {
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "Fortitude",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "carrier with no ill effect (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "3d8 negative damage and regains half as many Hit Points from all healing (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "as stage 2 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 4",
-                    "subtype": "affliction_stage",
-                    "text": "3d8 negative damage and gains no benefit from healing (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 5",
-                    "subtype": "affliction_stage",
-                    "text": "as stage 4 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 6",
-                    "subtype": "affliction_stage",
-                    "text": "dead, and rises as a ghast the next midnight",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Paralysis",
-                "subtype": "ability",
-                "text": "As ghoul, but elves are not immune.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Ghouls')].sections[?(@.name=='Ghast Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "olfactory",
+                "aonid": 246,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -807,7 +307,6 @@
         ],
         "name": "Ghast Abilities",
         "subtype": "monster_family",
-        "text": "A ghast has all the abilities above, plus following additions.",
         "type": "stat_block_section"
       }
     ],
@@ -819,6 +318,747 @@
     {
       "name": "Creating Ghouls",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, unconscious",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Claws",
+              "subtype": "ability",
+              "text": "If the creature had hands, it gains a claw Strike (an agile unarmed attack that deals slashing damage plus paralysis). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Jaws",
+              "subtype": "ability",
+              "text": "If the creature had a mouth, it gains a jaws Strike (an unarmed attack that deals slashing damage plus ghoul fever and paralysis). The damage amount should be the same as the creature's non-agile attacks.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The ghoul devours a chunk of the corpse and regains 1d6 Hit Points plus 1d6 for every 2 levels it has. It can regain Hit Points from any given corpse only once.",
+              "name": "Consume Flesh",
+              "requirement": "The ghoul is adjacent to the corpse of a creature that died within the last hour.",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  },
+                  "name": "manipulate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "affliction",
+              "name": "Ghoul Fever",
+              "saving_throw": [
+                {
+                  "save_type": "Fort",
+                  "subtype": "save_dc",
+                  "text": "Fortitude",
+                  "type": "stat_block_section"
+                }
+              ],
+              "stages": [
+                {
+                  "name": "Stage 1",
+                  "subtype": "affliction_stage",
+                  "text": "carrier with no ill effect (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 2",
+                  "subtype": "affliction_stage",
+                  "text": "2d6 negative damage and regains half as many Hit Points from all healing (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 3",
+                  "subtype": "affliction_stage",
+                  "text": "as stage 2 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 4",
+                  "subtype": "affliction_stage",
+                  "text": "2d6 negative damage and gains no benefit from healing (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 5",
+                  "subtype": "affliction_stage",
+                  "text": "as stage 4 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 6",
+                  "subtype": "affliction_stage",
+                  "text": "dead, and rises as a ghoul the next midnight.",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Paralysis",
+              "subtype": "ability",
+              "text": "Any living, non-elf creature hit by a ghoul's attack must succeed at a Fortitude save or become paralyzed. It can attempt a new save at the end of each of its turns, and the DC cumulatively decreases by 1 on each such save.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Swift Leap",
+              "subtype": "ability",
+              "text": "The ghoul jumps up to half its Speed. This movement doesn't trigger reactions.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "move",
+                    "aonid": 114,
+                    "game-obj": "Traits",
+                    "name": "move",
+                    "type": "link"
+                  },
+                  "name": "move",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "manipulate",
+              "aonid": 104,
+              "game-obj": "Traits",
+              "name": "manipulate",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "move",
+              "aonid": 114,
+              "game-obj": "Traits",
+              "name": "move",
+              "type": "link"
+            }
+          ],
+          "name": "Ghoul Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 168",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 168",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 168,
+              "type": "source"
+            }
+          ],
+          "text": "A ghoul gains the undead and ghoul traits, and it usually becomes evil. If the base creature has any abilities that come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the theme of a ghoul. All ghouls gain the following abilities. The save DC for all abilities uses the DC of the ghoul's level.  \n**Darkvision**  \n**Negative Healing**  \n**Immunities** death effects, disease, paralyzed, poison, unconscious  \n**Claws** If the creature had hands, it gains a claw Strike (an agile unarmed attack that deals slashing damage plus paralysis). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.  \n**Jaws** If the creature had a mouth, it gains a jaws Strike (an unarmed attack that deals slashing damage plus ghoul fever and paralysis). The damage amount should be the same as the creature's non-agile attacks.  \n**Consume Flesh** [#] (manipulate) **Requirements** The ghoul is adjacent to the corpse of a creature that died within the last hour. **Effect** The ghoul devours a chunk of the corpse and regains 1d6 Hit Points plus 1d6 for every 2 levels it has. It can regain Hit Points from any given corpse only once.  \n**Ghoul Fever** (disease) **Saving Throw** Fortitude; **Stage 1** carrier with no ill effect (1 day); **Stage 2** 2d6 negative damage and regains half as many Hit Points from all healing (1 day); **Stage 3** as stage 2 (1 day); **Stage 4** 2d6 negative damage and gains no benefit from healing (1 day); **Stage 5** as stage 4 (1 day); **Stage 6** dead, and rises as a ghoul the next midnight.  \n**Paralysis** (incapacitation, occult, necromancy) Any living, non-elf creature hit by a ghoul's attack must succeed at a Fortitude save or become paralyzed. It can attempt a new save at the end of each of its turns, and the DC cumulatively decreases by 1 on each such save.  \n**Swift Leap** [#] (move) The ghoul jumps up to half its Speed. This movement doesn't trigger reactions.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Stench",
+              "range": {
+                "range": 10,
+                "subtype": "range",
+                "text": "10 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "A creature entering the aura or starting its turn in the aura must succeed at a Fortitude save (use a DC based on the monster's level; Core Rulebook 503) or become sickened 1 (plus slowed 1 as long as it\u001bs sickened on a critical failure). While within the aura, the creature takes a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "olfactory",
+                    "aonid": 246,
+                    "game-obj": "Traits",
+                    "name": "olfactory",
+                    "type": "link"
+                  },
+                  "name": "olfactory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 76,
+                "edition": "remastered",
+                "game-id": "84b6ec99f4ecdeb47e51d74db2ad2de5",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "sickened 1",
+                    "aonid": 91,
+                    "game-obj": "Conditions",
+                    "name": "sickened 1",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "sickened",
+                    "aonid": 91,
+                    "game-obj": "Conditions",
+                    "name": "sickened",
+                    "type": "link"
+                  }
+                ],
+                "name": "Stench",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 360",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 360",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 360,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature entering the aura or starting its turn in the area must succeed at a Fortitude save or become sickened 1 (plus slowed 1 as long as it's sickened on a critical failure). A creature that succeeds at its save or recovers from being sickened is temporarily immune to all stench auras for 1 minute.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 206,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "5315505cfd3f3ba2685e9747898193b2",
+                    "game-obj": "Traits",
+                    "name": "Aura",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 453",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 453",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 453,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An aura is an emanation that continually ebbs out from you, affecting creatures within a certain radius. Aura can also refer to the magical signature of an item.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 246,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "1612b09b1aa256bf5512a119600505a6",
+                    "game-obj": "Traits",
+                    "name": "Olfactory",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 459",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 459",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 459,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An olfactory effect can affect only creatures that can smell it. This applies only to olfactory parts of the effect, as determined by the GM.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Claws and Jaws",
+              "subtype": "ability",
+              "text": "As ghoul, but apply ghast fever instead of ghoul fever.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Consume Flesh",
+              "subtype": "ability",
+              "text": "As ghoul, but it regains 1d6 additional Hit Points.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "affliction",
+              "name": "Ghast Fever",
+              "saving_throw": [
+                {
+                  "save_type": "Fort",
+                  "subtype": "save_dc",
+                  "text": "Fortitude",
+                  "type": "stat_block_section"
+                }
+              ],
+              "stages": [
+                {
+                  "name": "Stage 1",
+                  "subtype": "affliction_stage",
+                  "text": "carrier with no ill effect (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 2",
+                  "subtype": "affliction_stage",
+                  "text": "3d8 negative damage and regains half as many Hit Points from all healing (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 3",
+                  "subtype": "affliction_stage",
+                  "text": "as stage 2 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 4",
+                  "subtype": "affliction_stage",
+                  "text": "3d8 negative damage and gains no benefit from healing (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 5",
+                  "subtype": "affliction_stage",
+                  "text": "as stage 4 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 6",
+                  "subtype": "affliction_stage",
+                  "text": "dead, and rises as a ghast the next midnight",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Paralysis",
+              "subtype": "ability",
+              "text": "As ghoul, but elves are not immune.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "olfactory",
+              "aonid": 246,
+              "game-obj": "Traits",
+              "name": "olfactory",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            }
+          ],
+          "name": "Ghast Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 168",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 168",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 168,
+              "type": "source"
+            }
+          ],
+          "text": "A ghast has all the abilities above, plus following additions.  \n**Stench** (aura, olfactory) 10 feet. A creature entering the aura or starting its turn in the aura must succeed at a Fortitude save (use a DC based on the monster's level; Core Rulebook 503) or become sickened 1 (plus slowed 1 as long as it\u001bs sickened on a critical failure). While within the aura, the creature takes a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute.  \n**Claws and Jaws** As ghoul, but apply ghast fever instead of ghoul fever.  \n**Consume Flesh** [#] As ghoul, but it regains 1d6 additional Hit Points.  \n**Ghast Fever** (disease) **Saving Throw** Fortitude; **Stage 1** carrier with no ill effect (1 day); **Stage 2** 3d8 negative damage and regains half as many Hit Points from all healing (1 day); **Stage 3** as stage 2 (1 day); **Stage 4** 3d8 negative damage and gains no benefit from healing (1 day); **Stage 5** as stage 4 (1 day); **Stage 6** dead, and rises as a ghast the next midnight  \n**Paralysis** (incapacitation, occult, necromancy) As ghoul, but elves are not immune.",
+          "type": "section"
+        },
         {
           "name": "Ghoulish Society",
           "sources": [

--- a/monster_families/bestiary/golem.json
+++ b/monster_families/bestiary/golem.json
@@ -24,21 +24,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Harmed By",
-                "subtype": "ability",
-                "text": "Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Golem Antimagic')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -58,7 +48,6 @@
         ],
         "name": "Golem Antimagic",
         "subtype": "monster_family",
-        "text": "A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as \u201ccold and water\u201d), either type of spell can affect the golem.\n* \n* **Healed By** Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical.\n* **Slowed By** Any magic of this type that targets the golem causes it to be slowed 1 for 2d6 rounds instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round.\n* **Vulnerable To** Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.",
         "type": "stat_block_section"
       }
     ],
@@ -66,6 +55,46 @@
   },
   "name": "Golem",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Harmed By",
+          "subtype": "ability",
+          "text": "Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "slowed",
+          "aonid": 35,
+          "game-obj": "Conditions",
+          "name": "slowed",
+          "type": "link"
+        }
+      ],
+      "name": "Golem Antimagic",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary pg. 184",
+            "aonid": 2,
+            "game-obj": "Sources",
+            "name": "Bestiary pg. 184",
+            "type": "link"
+          },
+          "name": "Bestiary",
+          "page": 184,
+          "type": "source"
+        }
+      ],
+      "text": "A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as \u201ccold and water\u201d), either type of spell can affect the golem.\n* **Harmed By** Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.\n* **Healed By** Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical.\n* **Slowed By** Any magic of this type that targets the golem causes it to be slowed 1 for 2d6 rounds instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round.\n* **Vulnerable To** Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/bestiary/lich.json
+++ b/monster_families/bestiary/lich.json
@@ -78,636 +78,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "positive",
-                    "aonid": 128,
-                    "game-obj": "Traits",
-                    "name": "positive",
-                    "type": "link"
-                  }
-                ],
-                "name": "Saving Throws",
-                "subtype": "ability",
-                "text": "+1 status bonus to all saves vs. positive",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Rejuvenation",
-                "subtype": "ability",
-                "text": "When a lich is destroyed, its soul immediately transfers to its soul cage. A lich can be permanently destroyed only if its soul cage is found and destroyed.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, unconscious",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "cold",
-                    "aonid": 27,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magic",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "cold 20, physical 15 (except magic bludgeoning)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Frightful Presence",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "saving_throw": [
-                  {
-                    "dc": 30,
-                    "subtype": "save_dc",
-                    "text": "DC 30",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 17,
-                  "critical_failure": "The creature is frightened 4.",
-                  "critical_success": "The creature is unaffected by the presence.",
-                  "failure": "The creature is frightened 2.",
-                  "game-id": "997c1f976fddaf717cc13e9d65a5c921",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "frightened 1",
-                      "aonid": 19,
-                      "game-obj": "Conditions",
-                      "name": "frightened 1",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "frightened 2",
-                      "aonid": 19,
-                      "game-obj": "Conditions",
-                      "name": "frightened 2",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "frightened 4",
-                      "aonid": 19,
-                      "game-obj": "Conditions",
-                      "name": "frightened 4",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Frightful Presence",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "success": "The creature is frightened 1.",
-                  "text": "A creature that first enters the area must attempt a Will save. Regardless of the result of the saving throw, the creature is temporarily immune to this monster\u2019s Frightful Presence for 1 minute.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 206,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "5315505cfd3f3ba2685e9747898193b2",
-                      "game-obj": "Traits",
-                      "name": "Aura",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 453",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 453",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 453,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An aura is an emanation that continually ebbs out from you, affecting creatures within a certain radius. Aura can also refer to the magical signature of an item.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 60,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "fb5f8b3d849b073e1514a6a025810470",
-                      "game-obj": "Traits",
-                      "name": "Emotion",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 455",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 455",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 455,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This effect alters a creature\u2019s emotions. Effects with this trait always have the mental trait as well. Creatures with special training or that have mechanical or artificial intelligence are immune to emotion effects.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 68,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "9a5cea6bfb849deb16206c68f8d113a5",
-                      "game-obj": "Traits",
-                      "name": "Fear",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 456",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 456",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 456,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Fear effects evoke the emotion of fear. Effects with this trait always have the mental and emotion traits as well.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 106,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "6a1f80610baa3617c1597f49c6406313",
-                      "game-obj": "Traits",
-                      "name": "Mental",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 458",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 458",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 458,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "A mental effect can alter the target\u2019s mind. It has no effect on an object or a mindless creature.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "negative",
-                    "formula": "1d8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "finesse",
-                    "aonid": 179,
-                    "game-obj": "Traits",
-                    "name": "finesse",
-                    "type": "link"
-                  }
-                ],
-                "name": "Hand of the Lich",
-                "subtype": "ability",
-                "text": "All liches have a hand unarmed attack that deals 1d8 negative damage for every 3 levels and inflicts a paralyzing touch. This attack has the finesse trait.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The lich taps into its soul cage's power to cast any arcane spell up to the highest level the lich can cast, even if the spell being cast is not one of the lich's prepared spells. The lich's soul cage doesn't need to be present for the lich to use this ability.",
-                "frequency": "once per day",
-                "name": "Drain Soul Cage",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "prone",
-                    "aonid": 31,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Medicine",
-                    "aonid": 9,
-                    "game-obj": "Skills",
-                    "name": "Medicine",
-                    "type": "link"
-                  }
-                ],
-                "name": "Paralyzing Touch",
-                "saving_throw": [
-                  {
-                    "dc": 25,
-                    "subtype": "save_dc",
-                    "text": "DC 25",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "A creature damaged by the lich's hand Strike must succeed at a Fortitude save against the lich's spell DC \u2013 4. The creature becomes paralyzed for 1 round on a failure. On a critical failure, the creature is paralyzed permanently, falls prone, and seems dead. A DC 25 Medicine check reveals the victim is alive.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 38,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Lich')].sections[?(@.name=='Lich Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -718,6 +93,174 @@
                 "game-obj": "Traits",
                 "name": "undead",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "positive",
+                "aonid": 128,
+                "game-obj": "Traits",
+                "name": "positive",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 27,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "magic",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magic",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "finesse",
+                "aonid": 179,
+                "game-obj": "Traits",
+                "name": "finesse",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "prone",
+                "aonid": 31,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "Medicine",
+                "aonid": 9,
+                "game-obj": "Skills",
+                "name": "Medicine",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -727,177 +270,68 @@
         ],
         "name": "Lich Abilities",
         "subtype": "monster_family",
-        "text": "A lich gains the undead trait and becomes evil. Liches lose all abilities that come from being a living creature.  \n A lich gains the following abilities.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Blasphemous Utterances",
-                "range": {
-                  "range": 10,
-                  "subtype": "range",
-                  "text": "10 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "saving_throw": [
-                  {
-                    "dc": 10,
-                    "save_type": "Flat Check",
-                    "subtype": "save_dc",
-                    "text": "DC 10 flat check",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The lich is accompanied by a constant echo of blasphemous murmurs and tainted whispers. A creature in the aura takes a \u20132 circumstance penalty to saves against mental effects and can't take actions that have the concentrate trait unless they succeed at a DC 10 flat check. Failing this check wastes the action.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Cold Beyond Cold",
-                "subtype": "ability",
-                "text": "The lich's hand Strike deals cold damage instead of negative, and instead of being paralyzed, the target is slowed 2. A successful Fortitude save reduces this to slowed 1 (or negates it on a critical success).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Dark Deliverance",
-                "subtype": "ability",
-                "text": "The lich has resistance to positive equal to its level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The lich regains Hit Points equal to half the damage dealt.",
-                "name": "Siphon Life",
-                "subtype": "ability",
-                "trigger": "The lich deals damage with its hand Strike.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Void Shroud",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The lich is surrounded by an aura of death, drawing forth souls to be consumed by the lich's constant hunger. Living creatures in the emanation take a \u20132 status penalty to saves against fear and death effects. In addition, any creature that starts its turn in the area gains the doomed 1 condition unless it succeeds at a Will save against the lich's spell DC \u2013 4.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "death",
-                      "aonid": 40,
-                      "game-obj": "Traits",
-                      "name": "death",
-                      "type": "link"
-                    },
-                    "name": "death",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Lich')].sections[?(@.name=='Bestiary')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -912,368 +346,161 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "animated object",
-                    "aonid": 4,
-                    "game-obj": "MonsterFamilies",
-                    "name": "animated object",
-                    "type": "link"
-                  }
-                ],
-                "name": "Animate Cage",
-                "subtype": "ability",
-                "text": "The lich has placed their soul cage inside an animated object that fights fiercely to defend itself, or at the very least to elude capture. If the lich's body is destroyed, the lich can control this animated object directly, although they can't cast any spells while inside the vessel. The lich's body is often restored inside this object, being ejected from the animated object after 1d10 days in the normal manner for a soul cage. The animated object is usually at least 4 levels lower than the lich, but it doesn't engage in combat unless directly threatened or if the lich is in control of it.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Aura of Rot",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "saving_throw": [
-                  {
-                    "dc": 5,
-                    "save_type": "Flat Check",
-                    "subtype": "save_dc",
-                    "text": "DC 5 flat check",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The lich is surrounded by pervasive, supernatural rot. Unattended food and drink within 30 feet of the lich immediately spoils. Anyone attempting to eat or drink within this area must succeed at a DC 5 flat check or become sickened 1 as the sustenance spoils before it can be ingested (ruining potions and other magical food and drink). Ordinary plants that remain within this aura for more than 1 minute wither and begin to die (depending on their size, this might take significantly longer).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "familiar",
-                    "aonid": 160,
-                    "game-obj": "Rules",
-                    "name": "familiar",
-                    "type": "link"
-                  }
-                ],
-                "name": "Familiar Soul",
-                "subtype": "ability",
-                "text": "The lich has an undead familiar (using the familiar rules, except it's undead instead of an animal). Instead of a traditional soul cage, this lich stores their soul in the body of their undead familiar. While doing so makes it significantly more vulnerable, the moment the lich's body is destroyed, it can take over the body of the familiar. After 1 hour, the lich can use this body to cast spells, assuming it has an appendage capable of making somatic components. After 1d10 days, the lich's body reforms as normal.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Mask Death",
-                "subtype": "ability",
-                "text": "The lich changes their appearance to look as they did in life. This effect lasts indefinitely, but if the lich takes damage, their rotten flesh beneath becomes visible until this ability is used again.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Metamagic Alteration",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "range of 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "If the lich's next action is to Cast a Spell, they can alter it in one of two ways. \n* Increase the range of that spell by 30 feet (giving it a range of 30 feet if it's a touch spell).\n* Alternatively, the lich can change the area of the spell if the spell has an area and doesn't have a duration. If the spell is a burst with a radius of at least 10 feet, increase the radius by 5 feet. If it is a line or a cone that has an area of 15 feet or smaller, add 10 feet to the area.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "metamagic",
-                      "aonid": 107,
-                      "game-obj": "Traits",
-                      "name": "metamagic",
-                      "type": "link"
-                    },
-                    "name": "metamagic",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The lich pulls a memory or thought from the target's mind. The lich Recalls Information with a skill of their choice, using the target's bonus with the skill instead of their own. If there's a very specific piece of information the lich hopes to uncover, and the target knows that information, the target can attempt a Will save to keep it secret. On a critical success, the target can give the lich faulty information instead.",
-                "links": [
-                  {
-                    "alt": "Recalls Information",
-                    "aonid": 26,
-                    "game-obj": "Actions",
-                    "name": "Recalls Information",
-                    "type": "link"
-                  }
-                ],
-                "name": "Pillage Mind",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divination",
-                      "aonid": 47,
-                      "game-obj": "Traits",
-                      "name": "divination",
-                      "type": "link"
-                    },
-                    "name": "divination",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "The lich deals damage with their hand Strike",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The creature must attempt one final Fortitude save. On a failure, the lich siphons the soul from the dying creature, storing it in a black mote of energy that orbits the lich's skull. The creature can't be brought back from the dead while its soul is trapped in this way. Once per day, as a single action, the lich can consume a mote to heal a number of Hit Points equal to double the soul's level. This utterly destroys the soul, making the creature impossible to bring back to life without a *wish*, *miracle*, or similar magic. The lich can have a number of motes orbiting them equal to their Charisma modifier (to a minimum of one mote); if the lich gains an additional mote, the oldest one is released, its soul free to travel to the afterlife.",
-                "frequency": "Once per day",
-                "links": [
-                  {
-                    "alt": "wish",
-                    "aonid": 377,
-                    "game-obj": "Spells",
-                    "name": "wish",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "miracle",
-                    "aonid": 196,
-                    "game-obj": "Spells",
-                    "name": "miracle",
-                    "type": "link"
-                  }
-                ],
-                "name": "Steal Soul",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evil",
-                      "aonid": 64,
-                      "game-obj": "Traits",
-                      "name": "evil",
-                      "type": "link"
-                    },
-                    "name": "evil",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "A creature dies within 30 feet of the lich",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "evil",
-                    "formula": "2d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "evil",
-                    "formula": "1d4",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "evil",
-                    "aonid": 64,
-                    "game-obj": "Traits",
-                    "name": "evil",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent evil damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent evil damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Unholy Touch",
-                "subtype": "ability",
-                "text": "The lich's touch is suffused with evil, dealing evil damage instead of negative. On a critical hit, the target also takes persistent evil damage equal to half the lich's level.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Lich')].sections[?(@.name=='Book of the Dead')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "animated object",
+                "aonid": 4,
+                "game-obj": "MonsterFamilies",
+                "name": "animated object",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "familiar",
+                "aonid": 160,
+                "game-obj": "Rules",
+                "name": "familiar",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "metamagic",
+                "aonid": 107,
+                "game-obj": "Traits",
+                "name": "metamagic",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "Recalls Information",
+                "aonid": 26,
+                "game-obj": "Actions",
+                "name": "Recalls Information",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "evil",
+                "aonid": 64,
+                "game-obj": "Traits",
+                "name": "evil",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "wish",
+                "aonid": 377,
+                "game-obj": "Spells",
+                "name": "wish",
+                "type": "link"
+              },
+              {
+                "alt": "miracle",
+                "aonid": 196,
+                "game-obj": "Spells",
+                "name": "miracle",
+                "type": "link"
+              },
+              {
+                "alt": "evil",
+                "aonid": 64,
+                "game-obj": "Traits",
+                "name": "evil",
+                "type": "link"
+              },
+              {
+                "alt": "persistent evil damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent evil damage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1295,6 +522,827 @@
       "name": "Creating a Lich",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "positive",
+                  "aonid": 128,
+                  "game-obj": "Traits",
+                  "name": "positive",
+                  "type": "link"
+                }
+              ],
+              "name": "Saving Throws",
+              "subtype": "ability",
+              "text": "+1 status bonus to all saves vs. positive",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Rejuvenation",
+              "subtype": "ability",
+              "text": "When a lich is destroyed, its soul immediately transfers to its soul cage. A lich can be permanently destroyed only if its soul cage is found and destroyed.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, unconscious",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "cold",
+                  "aonid": 27,
+                  "game-obj": "Traits",
+                  "name": "cold",
+                  "type": "link"
+                },
+                {
+                  "alt": "magic",
+                  "aonid": 103,
+                  "game-obj": "Traits",
+                  "name": "magic",
+                  "type": "link"
+                }
+              ],
+              "name": "Resistances",
+              "subtype": "ability",
+              "text": "cold 20, physical 15 (except magic bludgeoning)",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Frightful Presence",
+              "range": {
+                "range": 60,
+                "subtype": "range",
+                "text": "60 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "saving_throw": [
+                {
+                  "dc": 30,
+                  "subtype": "save_dc",
+                  "text": "DC 30",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 60,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fear",
+                    "aonid": 68,
+                    "game-obj": "Traits",
+                    "name": "fear",
+                    "type": "link"
+                  },
+                  "name": "fear",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 17,
+                "critical_failure": "The creature is frightened 4.",
+                "critical_success": "The creature is unaffected by the presence.",
+                "failure": "The creature is frightened 2.",
+                "game-id": "997c1f976fddaf717cc13e9d65a5c921",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "frightened 1",
+                    "aonid": 19,
+                    "game-obj": "Conditions",
+                    "name": "frightened 1",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "frightened 2",
+                    "aonid": 19,
+                    "game-obj": "Conditions",
+                    "name": "frightened 2",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "frightened 4",
+                    "aonid": 19,
+                    "game-obj": "Conditions",
+                    "name": "frightened 4",
+                    "type": "link"
+                  }
+                ],
+                "name": "Frightful Presence",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "success": "The creature is frightened 1.",
+                "text": "A creature that first enters the area must attempt a Will save. Regardless of the result of the saving throw, the creature is temporarily immune to this monster\u2019s Frightful Presence for 1 minute.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 206,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "5315505cfd3f3ba2685e9747898193b2",
+                    "game-obj": "Traits",
+                    "name": "Aura",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 453",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 453",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 453,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An aura is an emanation that continually ebbs out from you, affecting creatures within a certain radius. Aura can also refer to the magical signature of an item.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 60,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "fb5f8b3d849b073e1514a6a025810470",
+                    "game-obj": "Traits",
+                    "name": "Emotion",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 455",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 455",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 455,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This effect alters a creature\u2019s emotions. Effects with this trait always have the mental trait as well. Creatures with special training or that have mechanical or artificial intelligence are immune to emotion effects.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 68,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "9a5cea6bfb849deb16206c68f8d113a5",
+                    "game-obj": "Traits",
+                    "name": "Fear",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 456",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 456",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 456,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Fear effects evoke the emotion of fear. Effects with this trait always have the mental and emotion traits as well.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 106,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "6a1f80610baa3617c1597f49c6406313",
+                    "game-obj": "Traits",
+                    "name": "Mental",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 458",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 458",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 458,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "A mental effect can alter the target\u2019s mind. It has no effect on an object or a mindless creature.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "negative",
+                  "formula": "1d8",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "finesse",
+                  "aonid": 179,
+                  "game-obj": "Traits",
+                  "name": "finesse",
+                  "type": "link"
+                }
+              ],
+              "name": "Hand of the Lich",
+              "subtype": "ability",
+              "text": "All liches have a hand unarmed attack that deals 1d8 negative damage for every 3 levels and inflicts a paralyzing touch. This attack has the finesse trait.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The lich taps into its soul cage's power to cast any arcane spell up to the highest level the lich can cast, even if the spell being cast is not one of the lich's prepared spells. The lich's soul cage doesn't need to be present for the lich to use this ability.",
+              "frequency": "once per day",
+              "name": "Drain Soul Cage",
+              "subtype": "ability",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "prone",
+                  "aonid": 31,
+                  "game-obj": "Conditions",
+                  "name": "prone",
+                  "type": "link"
+                },
+                {
+                  "alt": "Medicine",
+                  "aonid": 9,
+                  "game-obj": "Skills",
+                  "name": "Medicine",
+                  "type": "link"
+                }
+              ],
+              "name": "Paralyzing Touch",
+              "saving_throw": [
+                {
+                  "dc": 25,
+                  "subtype": "save_dc",
+                  "text": "DC 25",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "A creature damaged by the lich's hand Strike must succeed at a Fortitude save against the lich's spell DC \u2013 4. The creature becomes paralyzed for 1 round on a failure. On a critical failure, the creature is paralyzed permanently, falls prone, and seems dead. A DC 25 Medicine check reveals the victim is alive.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "curse",
+                    "aonid": 38,
+                    "game-obj": "Traits",
+                    "name": "curse",
+                    "type": "link"
+                  },
+                  "name": "curse",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 160,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "positive",
+              "aonid": 128,
+              "game-obj": "Traits",
+              "name": "positive",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 27,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "magic",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magic",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 60,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 68,
+              "game-obj": "Traits",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "finesse",
+              "aonid": 179,
+              "game-obj": "Traits",
+              "name": "finesse",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "curse",
+              "aonid": 38,
+              "game-obj": "Traits",
+              "name": "curse",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "prone",
+              "aonid": 31,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            },
+            {
+              "alt": "Medicine",
+              "aonid": 9,
+              "game-obj": "Skills",
+              "name": "Medicine",
+              "type": "link"
+            }
+          ],
+          "name": "Lich Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 220",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 220",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 220,
+              "type": "source"
+            }
+          ],
+          "text": "A lich gains the undead trait and becomes evil. Liches lose all abilities that come from being a living creature.  \n A lich gains the following abilities.  \n**Darkvision**  \n**Saving Throws** +1 status bonus to all saves vs. positive  \n**Negative Healing**  \n**Rejuvenation** (arcane, necromancy) When a lich is destroyed, its soul immediately transfers to its soul cage. A lich can be permanently destroyed only if its soul cage is found and destroyed.  \n**Immunities** death effects, disease, paralyzed, poison, unconscious  \n**Resistances** cold 20, physical 15 (except magic bludgeoning)  \n**Frightful Presence** (aura, emotion, fear, mental) 60 feet, DC 30  \n**Hand of the Lich** All liches have a hand unarmed attack that deals 1d8 negative damage for every 3 levels and inflicts a paralyzing touch. This attack has the finesse trait.  \n**Drain Soul Cage** [-] **Frequency** once per day; **Effect** The lich taps into its soul cage's power to cast any arcane spell up to the highest level the lich can cast, even if the spell being cast is not one of the lich's prepared spells. The lich's soul cage doesn't need to be present for the lich to use this ability.  \n**Paralyzing Touch** (arcane, curse, incapacitation, necromancy) A creature damaged by the lich's hand Strike must succeed at a Fortitude save against the lich's spell DC \u2013 4. The creature becomes paralyzed for 1 round on a failure. On a critical failure, the creature is paralyzed permanently, falls prone, and seems dead. A DC 25 Medicine check reveals the victim is alive.",
+          "type": "section"
+        },
+        {
           "name": "Alternate Lich Abilities",
           "sources": [
             {
@@ -1311,6 +1359,759 @@
             }
           ],
           "text": "Although the abilities above are standard for a lich, you can create a more unusual lich by substituting any one of the following abilities for frightful presence, hand of the lich, Drain Soul Cage, or paralyzing touch.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Blasphemous Utterances",
+              "range": {
+                "range": 10,
+                "subtype": "range",
+                "text": "10 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "saving_throw": [
+                {
+                  "dc": 10,
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 10 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "The lich is accompanied by a constant echo of blasphemous murmurs and tainted whispers. A creature in the aura takes a \u20132 circumstance penalty to saves against mental effects and can't take actions that have the concentrate trait unless they succeed at a DC 10 flat check. Failing this check wastes the action.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Cold Beyond Cold",
+              "subtype": "ability",
+              "text": "The lich's hand Strike deals cold damage instead of negative, and instead of being paralyzed, the target is slowed 2. A successful Fortitude save reduces this to slowed 1 (or negates it on a critical success).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Dark Deliverance",
+              "subtype": "ability",
+              "text": "The lich has resistance to positive equal to its level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The lich regains Hit Points equal to half the damage dealt.",
+              "name": "Siphon Life",
+              "subtype": "ability",
+              "trigger": "The lich deals damage with its hand Strike.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Void Shroud",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The lich is surrounded by an aura of death, drawing forth souls to be consumed by the lich's constant hunger. Living creatures in the emanation take a \u20132 status penalty to saves against fear and death effects. In addition, any creature that starts its turn in the area gains the doomed 1 condition unless it succeeds at a Will save against the lich's spell DC \u2013 4.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "death",
+                    "aonid": 40,
+                    "game-obj": "Traits",
+                    "name": "death",
+                    "type": "link"
+                  },
+                  "name": "death",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            }
+          ],
+          "name": "Bestiary",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 220",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 220",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 220,
+              "type": "source"
+            }
+          ],
+          "text": "**Blasphemous Utterances** (arcane, aura, enchantment, mental) 10 feet. The lich is accompanied by a constant echo of blasphemous murmurs and tainted whispers. A creature in the aura takes a \u20132 circumstance penalty to saves against mental effects and can't take actions that have the concentrate trait unless they succeed at a DC 10 flat check. Failing this check wastes the action.  \n**Cold Beyond Cold** The lich's hand Strike deals cold damage instead of negative, and instead of being paralyzed, the target is slowed 2. A successful Fortitude save reduces this to slowed 1 (or negates it on a critical success).  \n**Dark Deliverance** The lich has resistance to positive equal to its level.  \n**Siphon Life** [@] **Trigger** The lich deals damage with its hand Strike. **Effect** The lich regains Hit Points equal to half the damage dealt.  \n**Void Shroud** (aura, death, necromancy) 30 feet. The lich is surrounded by an aura of death, drawing forth souls to be consumed by the lich's constant hunger. Living creatures in the emanation take a \u20132 status penalty to saves against fear and death effects. In addition, any creature that starts its turn in the area gains the doomed 1 condition unless it succeeds at a Will save against the lich's spell DC \u2013 4.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "animated object",
+                  "aonid": 4,
+                  "game-obj": "MonsterFamilies",
+                  "name": "animated object",
+                  "type": "link"
+                }
+              ],
+              "name": "Animate Cage",
+              "subtype": "ability",
+              "text": "The lich has placed their soul cage inside an animated object that fights fiercely to defend itself, or at the very least to elude capture. If the lich's body is destroyed, the lich can control this animated object directly, although they can't cast any spells while inside the vessel. The lich's body is often restored inside this object, being ejected from the animated object after 1d10 days in the normal manner for a soul cage. The animated object is usually at least 4 levels lower than the lich, but it doesn't engage in combat unless directly threatened or if the lich is in control of it.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "sickened 1",
+                  "aonid": 34,
+                  "game-obj": "Conditions",
+                  "name": "sickened 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Aura of Rot",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "within 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "saving_throw": [
+                {
+                  "dc": 5,
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 5 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "The lich is surrounded by pervasive, supernatural rot. Unattended food and drink within 30 feet of the lich immediately spoils. Anyone attempting to eat or drink within this area must succeed at a DC 5 flat check or become sickened 1 as the sustenance spoils before it can be ingested (ruining potions and other magical food and drink). Ordinary plants that remain within this aura for more than 1 minute wither and begin to die (depending on their size, this might take significantly longer).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "familiar",
+                  "aonid": 160,
+                  "game-obj": "Rules",
+                  "name": "familiar",
+                  "type": "link"
+                }
+              ],
+              "name": "Familiar Soul",
+              "subtype": "ability",
+              "text": "The lich has an undead familiar (using the familiar rules, except it's undead instead of an animal). Instead of a traditional soul cage, this lich stores their soul in the body of their undead familiar. While doing so makes it significantly more vulnerable, the moment the lich's body is destroyed, it can take over the body of the familiar. After 1 hour, the lich can use this body to cast spells, assuming it has an appendage capable of making somatic components. After 1d10 days, the lich's body reforms as normal.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Mask Death",
+              "subtype": "ability",
+              "text": "The lich changes their appearance to look as they did in life. This effect lasts indefinitely, but if the lich takes damage, their rotten flesh beneath becomes visible until this ability is used again.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Metamagic Alteration",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "range of 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "If the lich's next action is to Cast a Spell, they can alter it in one of two ways. \n* Increase the range of that spell by 30 feet (giving it a range of 30 feet if it's a touch spell).\n* Alternatively, the lich can change the area of the spell if the spell has an area and doesn't have a duration. If the spell is a burst with a radius of at least 10 feet, increase the radius by 5 feet. If it is a line or a cone that has an area of 15 feet or smaller, add 10 feet to the area.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "metamagic",
+                    "aonid": 107,
+                    "game-obj": "Traits",
+                    "name": "metamagic",
+                    "type": "link"
+                  },
+                  "name": "metamagic",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The lich pulls a memory or thought from the target's mind. The lich Recalls Information with a skill of their choice, using the target's bonus with the skill instead of their own. If there's a very specific piece of information the lich hopes to uncover, and the target knows that information, the target can attempt a Will save to keep it secret. On a critical success, the target can give the lich faulty information instead.",
+              "links": [
+                {
+                  "alt": "Recalls Information",
+                  "aonid": 26,
+                  "game-obj": "Actions",
+                  "name": "Recalls Information",
+                  "type": "link"
+                }
+              ],
+              "name": "Pillage Mind",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divination",
+                    "aonid": 47,
+                    "game-obj": "Traits",
+                    "name": "divination",
+                    "type": "link"
+                  },
+                  "name": "divination",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "trigger": "The lich deals damage with their hand Strike",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The creature must attempt one final Fortitude save. On a failure, the lich siphons the soul from the dying creature, storing it in a black mote of energy that orbits the lich's skull. The creature can't be brought back from the dead while its soul is trapped in this way. Once per day, as a single action, the lich can consume a mote to heal a number of Hit Points equal to double the soul's level. This utterly destroys the soul, making the creature impossible to bring back to life without a *wish*, *miracle*, or similar magic. The lich can have a number of motes orbiting them equal to their Charisma modifier (to a minimum of one mote); if the lich gains an additional mote, the oldest one is released, its soul free to travel to the afterlife.",
+              "frequency": "Once per day",
+              "links": [
+                {
+                  "alt": "wish",
+                  "aonid": 377,
+                  "game-obj": "Spells",
+                  "name": "wish",
+                  "type": "link"
+                },
+                {
+                  "alt": "miracle",
+                  "aonid": 196,
+                  "game-obj": "Spells",
+                  "name": "miracle",
+                  "type": "link"
+                }
+              ],
+              "name": "Steal Soul",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "evil",
+                    "aonid": 64,
+                    "game-obj": "Traits",
+                    "name": "evil",
+                    "type": "link"
+                  },
+                  "name": "evil",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "trigger": "A creature dies within 30 feet of the lich",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "evil",
+                  "formula": "2d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "evil",
+                  "formula": "1d4",
+                  "persistent": true,
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "evil",
+                  "aonid": 64,
+                  "game-obj": "Traits",
+                  "name": "evil",
+                  "type": "link"
+                },
+                {
+                  "alt": "persistent evil damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent evil damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Unholy Touch",
+              "subtype": "ability",
+              "text": "The lich's touch is suffused with evil, dealing evil damage instead of negative. On a critical hit, the target also takes persistent evil damage equal to half the lich's level.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "animated object",
+              "aonid": 4,
+              "game-obj": "MonsterFamilies",
+              "name": "animated object",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 1",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            },
+            {
+              "alt": "familiar",
+              "aonid": 160,
+              "game-obj": "Rules",
+              "name": "familiar",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "metamagic",
+              "aonid": 107,
+              "game-obj": "Traits",
+              "name": "metamagic",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "divination",
+              "aonid": 47,
+              "game-obj": "Traits",
+              "name": "divination",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "Recalls Information",
+              "aonid": 26,
+              "game-obj": "Actions",
+              "name": "Recalls Information",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "evil",
+              "aonid": 64,
+              "game-obj": "Traits",
+              "name": "evil",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "wish",
+              "aonid": 377,
+              "game-obj": "Spells",
+              "name": "wish",
+              "type": "link"
+            },
+            {
+              "alt": "miracle",
+              "aonid": 196,
+              "game-obj": "Spells",
+              "name": "miracle",
+              "type": "link"
+            },
+            {
+              "alt": "evil",
+              "aonid": 64,
+              "game-obj": "Traits",
+              "name": "evil",
+              "type": "link"
+            },
+            {
+              "alt": "persistent evil damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent evil damage",
+              "type": "link"
+            }
+          ],
+          "name": "Book of the Dead",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 220",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 220",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 220,
+              "type": "source"
+            }
+          ],
+          "text": "**Animate Cage** The lich has placed their soul cage inside an animated object that fights fiercely to defend itself, or at the very least to elude capture. If the lich's body is destroyed, the lich can control this animated object directly, although they can't cast any spells while inside the vessel. The lich's body is often restored inside this object, being ejected from the animated object after 1d10 days in the normal manner for a soul cage. The animated object is usually at least 4 levels lower than the lich, but it doesn't engage in combat unless directly threatened or if the lich is in control of it.  \n**Aura of Rot** (arcane, aura, necromancy) The lich is surrounded by pervasive, supernatural rot. Unattended food and drink within 30 feet of the lich immediately spoils. Anyone attempting to eat or drink within this area must succeed at a DC 5 flat check or become sickened 1 as the sustenance spoils before it can be ingested (ruining potions and other magical food and drink). Ordinary plants that remain within this aura for more than 1 minute wither and begin to die (depending on their size, this might take significantly longer).  \n**Familiar Soul** The lich has an undead familiar (using the familiar rules, except it's undead instead of an animal). Instead of a traditional soul cage, this lich stores their soul in the body of their undead familiar. While doing so makes it significantly more vulnerable, the moment the lich's body is destroyed, it can take over the body of the familiar. After 1 hour, the lich can use this body to cast spells, assuming it has an appendage capable of making somatic components. After 1d10 days, the lich's body reforms as normal.  \n**Mask Death** [#] (arcane, transmutation) The lich changes their appearance to look as they did in life. This effect lasts indefinitely, but if the lich takes damage, their rotten flesh beneath becomes visible until this ability is used again.  \n**Metamagic Alteration** (concentrate, metamagic) If the lich's next action is to Cast a Spell, they can alter it in one of two ways. \n* Increase the range of that spell by 30 feet (giving it a range of 30 feet if it's a touch spell).\n* Alternatively, the lich can change the area of the spell if the spell has an area and doesn't have a duration. If the spell is a burst with a radius of at least 10 feet, increase the radius by 5 feet. If it is a line or a cone that has an area of 15 feet or smaller, add 10 feet to the area.\n**Pillage Mind** [@] (arcane, divination, mental) **Trigger** The lich deals damage with their hand Strike; **Effect** The lich pulls a memory or thought from the target's mind. The lich Recalls Information with a skill of their choice, using the target's bonus with the skill instead of their own. If there's a very specific piece of information the lich hopes to uncover, and the target knows that information, the target can attempt a Will save to keep it secret. On a critical success, the target can give the lich faulty information instead.  \n**Steal Soul** [@] (arcane, evil, necromancy) **Trigger** A creature dies within 30 feet of the lich; **Effect** The creature must attempt one final Fortitude save. On a failure, the lich siphons the soul from the dying creature, storing it in a black mote of energy that orbits the lich's skull. The creature can't be brought back from the dead while its soul is trapped in this way. Once per day, as a single action, the lich can consume a mote to heal a number of Hit Points equal to double the soul's level. This utterly destroys the soul, making the creature impossible to bring back to life without a *wish*, *miracle*, or similar magic. The lich can have a number of motes orbiting them equal to their Charisma modifier (to a minimum of one mote); if the lich gains an additional mote, the oldest one is released, its soul free to travel to the afterlife.  \n**Unholy Touch** The lich's touch is suffused with evil, dealing evil damage instead of negative. On a critical hit, the target also takes persistent evil damage equal to half the lich's level.",
           "type": "section"
         },
         {

--- a/monster_families/bestiary/nymph.json
+++ b/monster_families/bestiary/nymph.json
@@ -69,469 +69,140 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "Nymph queens can transform between their original form, which looks much like a typical nymph of their kind, and any Small or Medium humanoid form, typically choosing a more humanoid-looking version of their natural form.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "frequency": "once per turn",
-                "name": "Focus Beauty",
-                "subtype": "ability",
-                "text": "The nymph queen focuses her beauty upon a target within her aura. The creature must attempt a Will save. On a failure, it is affected as if by the nymph queen\u2019s nymph\u2019s beauty aura; if it was already affected by the aura, it suffers a greater effect described in the nymph queen\u2019s entry. A nymph queen can Focus Beauty on a given creature only once per turn.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Inspiration",
-                "subtype": "ability",
-                "text": "A nymph queen can inspire a single intelligent creature by giving that creature a token of her favor, typically a lock of her hair. As long as the creature carries her token and remains in good standing with the nymph queen, the creature gains a +1 status bonus to all Crafting checks, Performance checks, and Will saves.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Nymph\u2019s Beauty",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "Creatures that start their turn in the aura must succeed at a Will save or suffer an effect described in the nymph queen\u2019s entry.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Tied to the Land",
-                "subtype": "ability",
-                "text": "A nymph queen is intrinsically tied to a specific region, such as a forest for a dryad queen. As long as the queen is healthy, the environment is exceptionally resilient, allowing the nymph queen to automatically attempt to counteract spells and rituals such as blight that would harm the environment, using her Spell DC with a counteract level equal to the highest-level druid spell she can cast. When the nymph queen becomes physically or psychologically unhealthy, however, her warded region eventually becomes twisted or unhealthy as well. In that case, restoring the nymph queen swiftly heals the entire region.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Nymph Queen Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -541,7 +212,6 @@
         ],
         "name": "Nymph Queen Abilities",
         "subtype": "monster_family",
-        "text": "A nymph queen is 6 to 10 levels higher than an ordinary nymph of the same type, with enhanced numerical statistics and improved Strikes to match. A nymph queen\u2019s ward is a significant region, and she strengthens and vivifies this territory with her presence. Nymph queens are not dependent on their wards and lose the corresponding ability (such as a dryad\u2019s tree dependent ability); instead, they gain the tied to the land ability, as described below. A nymph queen also gains the nymph\u2019s beauty aura and the Focus Beauty action, which have varying effects based on the queen\u2019s original type. She gains the Inspiration ability, allowing her to bestow a gift of inspiration on those who catch her fancy, and the Change Shape ability to change her form. Finally, she gains primal prepared spells as a druid of her level.",
         "type": "stat_block_section"
       }
     ],
@@ -567,6 +237,707 @@
         }
       ],
       "text": "Nymph queens are powerful nymphs that rule over entire regions of untouched wilderness, not just single trees or ponds. Every variety of nymph can have a queen. Naiad queens are among the most prominent, and more often interact with nearby mortals. Thus, some scholars refer to naiad queens as simply \u201cnymphs.\u201d",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "Nymph queens can transform between their original form, which looks much like a typical nymph of their kind, and any Small or Medium humanoid form, typically choosing a more humanoid-looking version of their natural form.",
+          "traits": [
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "frequency": "once per turn",
+          "name": "Focus Beauty",
+          "subtype": "ability",
+          "text": "The nymph queen focuses her beauty upon a target within her aura. The creature must attempt a Will save. On a failure, it is affected as if by the nymph queen\u2019s nymph\u2019s beauty aura; if it was already affected by the aura, it suffers a greater effect described in the nymph queen\u2019s entry. A nymph queen can Focus Beauty on a given creature only once per turn.",
+          "traits": [
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              "name": "enchantment",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Inspiration",
+          "subtype": "ability",
+          "text": "A nymph queen can inspire a single intelligent creature by giving that creature a token of her favor, typically a lock of her hair. As long as the creature carries her token and remains in good standing with the nymph queen, the creature gains a +1 status bonus to all Crafting checks, Performance checks, and Will saves.",
+          "traits": [
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              "name": "enchantment",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Nymph\u2019s Beauty",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "Creatures that start their turn in the aura must succeed at a Will save or suffer an effect described in the nymph queen\u2019s entry.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              "name": "enchantment",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Tied to the Land",
+          "subtype": "ability",
+          "text": "A nymph queen is intrinsically tied to a specific region, such as a forest for a dryad queen. As long as the queen is healthy, the environment is exceptionally resilient, allowing the nymph queen to automatically attempt to counteract spells and rituals such as blight that would harm the environment, using her Spell DC with a counteract level equal to the highest-level druid spell she can cast. When the nymph queen becomes physically or psychologically unhealthy, however, her warded region eventually becomes twisted or unhealthy as well. In that case, restoring the nymph queen swiftly heals the entire region.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 134,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "enchantment",
+          "aonid": 61,
+          "game-obj": "Traits",
+          "name": "enchantment",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 134,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 163,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "enchantment",
+          "aonid": 61,
+          "game-obj": "Traits",
+          "name": "enchantment",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 134,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 206,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "enchantment",
+          "aonid": 61,
+          "game-obj": "Traits",
+          "name": "enchantment",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 134,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 163,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        }
+      ],
+      "name": "Nymph Queen Abilities",
+      "sections": [
+        {
+          "name": "Inspirations for Art",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 246",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 246",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 246,
+              "type": "source"
+            }
+          ],
+          "text": "Nymphs are living manifestations of beauty and grace, and as such they are often the subjects of art\u2014sculpture and paintings in particular. Promising a nymph to immortalize them in a work of art can be an excellent way to secure that nymph\u2019s favor, but one should take care to ensure that the nymph admires and is proud of the artistic effort\u2019s final result, lest the nymph be insulted and lash out with her powerful magic.",
+          "type": "section"
+        },
+        {
+          "name": "Nymph Locations",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 246",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 246",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 246,
+              "type": "source"
+            }
+          ],
+          "text": "Nymphs tend to be closely associated with specific areas of natural splendor and beauty\u2014woodlands for dryads, rivers for naiads. Areas where nymphs dwell always look more pristine, breathtaking, and scenic than they would otherwise.",
+          "type": "section"
+        },
+        {
+          "name": "Nymph Queens",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 246",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 246",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 246,
+              "type": "source"
+            }
+          ],
+          "text": "The abilities shared by all nymph queens, including the abilities Change Shape, Focus Beauty, and Inspiration, are described in the Nymph creature family page. Hora queens are more likely to use these abilities freely during the season in which they flourish",
+          "type": "section"
+        },
+        {
+          "name": "Nymph Treasures",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 246",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 246",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 246,
+              "type": "source"
+            }
+          ],
+          "text": "Nymphs sometimes carry magical trinkets or wear enchanted clothing or jewelry, but the greatest treasure a nymph queen can share is often her inspiration to those seeking a muse.",
+          "type": "section"
+        },
+        {
+          "name": "Other Nymphs",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 246",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 246",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 246,
+              "type": "source"
+            }
+          ],
+          "text": "Naiads and dryads are the most well-known nymphs, but others exist as well. Hesperides, for example, are wards of the sunset and golden light and can be encountered dwelling on coastal cliffsides or remote islands. Lampads, on the other hand, are dark, moody nymphs found in wondrous, crystal-lined caverns deep underground.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary pg. 246",
+            "aonid": 2,
+            "game-obj": "Sources",
+            "name": "Bestiary pg. 246",
+            "type": "link"
+          },
+          "name": "Bestiary",
+          "page": 246,
+          "type": "source"
+        }
+      ],
+      "text": "A nymph queen is 6 to 10 levels higher than an ordinary nymph of the same type, with enhanced numerical statistics and improved Strikes to match. A nymph queen\u2019s ward is a significant region, and she strengthens and vivifies this territory with her presence. Nymph queens are not dependent on their wards and lose the corresponding ability (such as a dryad\u2019s tree dependent ability); instead, they gain the tied to the land ability, as described below. A nymph queen also gains the nymph\u2019s beauty aura and the Focus Beauty action, which have varying effects based on the queen\u2019s original type. She gains the Inspiration ability, allowing her to bestow a gift of inspiration on those who catch her fancy, and the Change Shape ability to change her form. Finally, she gains primal prepared spells as a druid of her level.  \n  \n**Change Shape** [#] (polymorph, primal, transmutation) Nymph queens can transform between their original form, which looks much like a typical nymph of their kind, and any Small or Medium humanoid form, typically choosing a more humanoid-looking version of their natural form.  \n**Focus Beauty** [#] (emotion, enchantment, mental, primal, visual) The nymph queen focuses her beauty upon a target within her aura. The creature must attempt a Will save. On a failure, it is affected as if by the nymph queen\u2019s nymph\u2019s beauty aura; if it was already affected by the aura, it suffers a greater effect described in the nymph queen\u2019s entry. A nymph queen can Focus Beauty on a given creature only once per turn.  \n**Inspiration** [###] (emotion, enchantment, mental, primal) A nymph queen can inspire a single intelligent creature by giving that creature a token of her favor, typically a lock of her hair. As long as the creature carries her token and remains in good standing with the nymph queen, the creature gains a +1 status bonus to all Crafting checks, Performance checks, and Will saves.  \n If a nymph queen grants her Inspiration to a bard and the nymph queen is that bard\u2019s muse, the bard gains an additional benefit depending on their muse theme: for lore muse, the bard also gains a +1 status bonus to all Lore checks; for maestro muse, the status bonus to Performance checks increases to +2 for the purpose of determining the effects of compositions; for polymath muse, the bard gains a +4 status bonus to untrained skill checks; and for all other muses, the Will save bonus increases to +2 against fey.  \n**Nymph\u2019s Beauty** (aura, emotion, enchantment, mental, primal, visual) 30 feet. Creatures that start their turn in the aura must succeed at a Will save or suffer an effect described in the nymph queen\u2019s entry.  \n**Tied to the Land** A nymph queen is intrinsically tied to a specific region, such as a forest for a dryad queen. As long as the queen is healthy, the environment is exceptionally resilient, allowing the nymph queen to automatically attempt to counteract spells and rituals such as blight that would harm the environment, using her Spell DC with a counteract level equal to the highest-level druid spell she can cast. When the nymph queen becomes physically or psychologically unhealthy, however, her warded region eventually becomes twisted or unhealthy as well. In that case, restoring the nymph queen swiftly heals the entire region.",
       "type": "section"
     }
   ],

--- a/monster_families/bestiary/shadow.json
+++ b/monster_families/bestiary/shadow.json
@@ -30,77 +30,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The shadow teleports from its space to a clear space it can see that is in dim light or darkness within 60 feet. A shadow using this ability is slowed 1 for 1 round after arriving at its destination.",
-                "links": [
-                  {
-                    "alt": "dim light",
-                    "aonid": 408,
-                    "game-obj": "Rules",
-                    "name": "dim light",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "darkness",
-                    "aonid": 409,
-                    "game-obj": "Rules",
-                    "name": "darkness",
-                    "type": "link"
-                  }
-                ],
-                "name": "Shadow Hop",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "requirement": "The shadow is in an area of dim light",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "magical",
-                      "aonid": 103,
-                      "game-obj": "Traits",
-                      "name": "magical",
-                      "type": "link"
-                    },
-                    "name": "magical",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "teleportation",
-                      "aonid": 156,
-                      "game-obj": "Traits",
-                      "name": "teleportation",
-                      "type": "link"
-                    },
-                    "name": "teleportation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shadow Variants')].sections[?(@.name=='Darting Shadows Some shadows have taken their ability to hide in shadows to a greater level, shifting from one shadow to another with supernatural ease. Darting shadows gain the following ability.')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "magical",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "teleportation",
+                "aonid": 156,
+                "game-obj": "Traits",
+                "name": "teleportation",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -115,43 +80,28 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "undead",
-                    "aonid": 160,
-                    "game-obj": "Traits",
-                    "name": "undead",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "possession",
-                    "aonid": 225,
-                    "game-obj": "Spells",
-                    "name": "possession",
-                    "type": "link"
-                  }
-                ],
-                "name": "Inhabit",
-                "subtype": "ability",
-                "text": "The shadow attempts to possess an adjacent undead corporeal creature. This has the same effect as the *possession* spell, except the shadow doesn't have a physical body, so it's unaffected by the spell's restriction.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shadow Variants')].sections[?(@.name=='Possessing Shadows')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "undead",
+                "aonid": 160,
+                "game-obj": "Traits",
+                "name": "undead",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 225,
+                "game-obj": "Spells",
+                "name": "possession",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -161,32 +111,16 @@
         ],
         "name": "Possessing Shadows",
         "subtype": "monster_family",
-        "text": "Some greater shadows develop the coveted ability to possess a body. Only greater shadows can become possessing shadows, and they can't use Slink in Shadows or Steal Shadow while using Inhabit.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Shadow Touch",
-                "subtype": "ability",
-                "text": "The shadow Interacts with a simple physical object, such as picking up a book or opening a door (it can't manipulate a complicated object, like a lock). It can't carry more than a single physical object of up to 2 Bulk. It must use Shadow Touch to keep its hold on the item each turn, or it drops the item at the end of its turn.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shadow Variants')].sections[?(@.name=='Shadow Thief')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -197,7 +131,6 @@
         ],
         "name": "Shadow Thief",
         "subtype": "monster_family",
-        "text": "Some shadows gain the ability to handle objects. A shadow thief can't use Slink in Shadows or Steal Shadow while using Shadow Touch.",
         "type": "stat_block_section"
       }
     ],
@@ -209,6 +142,217 @@
     {
       "name": "Shadow Variants",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The shadow teleports from its space to a clear space it can see that is in dim light or darkness within 60 feet. A shadow using this ability is slowed 1 for 1 round after arriving at its destination.",
+              "links": [
+                {
+                  "alt": "dim light",
+                  "aonid": 408,
+                  "game-obj": "Rules",
+                  "name": "dim light",
+                  "type": "link"
+                },
+                {
+                  "alt": "darkness",
+                  "aonid": 409,
+                  "game-obj": "Rules",
+                  "name": "darkness",
+                  "type": "link"
+                }
+              ],
+              "name": "Shadow Hop",
+              "range": {
+                "range": 60,
+                "subtype": "range",
+                "text": "within 60 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "requirement": "The shadow is in an area of dim light",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  "name": "magical",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "teleportation",
+                    "aonid": 156,
+                    "game-obj": "Traits",
+                    "name": "teleportation",
+                    "type": "link"
+                  },
+                  "name": "teleportation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "magical",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            },
+            {
+              "alt": "teleportation",
+              "aonid": 156,
+              "game-obj": "Traits",
+              "name": "teleportation",
+              "type": "link"
+            },
+            {
+              "alt": "dim light",
+              "aonid": 408,
+              "game-obj": "Rules",
+              "name": "dim light",
+              "type": "link"
+            },
+            {
+              "alt": "darkness",
+              "aonid": 409,
+              "game-obj": "Rules",
+              "name": "darkness",
+              "type": "link"
+            }
+          ],
+          "name": "Darting Shadows Some shadows have taken their ability to hide in shadows to a greater level, shifting from one shadow to another with supernatural ease. Darting shadows gain the following ability.",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #183: Field of Maidens pg. 73",
+                "href": "https://paizo.com/products/btq02c11",
+                "name": "Pathfinder #183: Field of Maidens pg. 73",
+                "type": "link"
+              },
+              "name": "Pathfinder #183: Field of Maidens",
+              "page": 73,
+              "type": "source"
+            }
+          ],
+          "text": "**Shadow Hop** [##] (magical, teleportation) **Requirements** The shadow is in an area of dim light; **Effect** The shadow teleports from its space to a clear space it can see that is in dim light or darkness within 60 feet. A shadow using this ability is slowed 1 for 1 round after arriving at its destination.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "undead",
+                  "aonid": 160,
+                  "game-obj": "Traits",
+                  "name": "undead",
+                  "type": "link"
+                },
+                {
+                  "alt": "possession",
+                  "aonid": 225,
+                  "game-obj": "Spells",
+                  "name": "possession",
+                  "type": "link"
+                }
+              ],
+              "name": "Inhabit",
+              "subtype": "ability",
+              "text": "The shadow attempts to possess an adjacent undead corporeal creature. This has the same effect as the *possession* spell, except the shadow doesn't have a physical body, so it's unaffected by the spell's restriction.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 160,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "possession",
+              "aonid": 225,
+              "game-obj": "Spells",
+              "name": "possession",
+              "type": "link"
+            }
+          ],
+          "name": "Possessing Shadows",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #183: Field of Maidens pg. 73",
+                "href": "https://paizo.com/products/btq02c11",
+                "name": "Pathfinder #183: Field of Maidens pg. 73",
+                "type": "link"
+              },
+              "name": "Pathfinder #183: Field of Maidens",
+              "page": 73,
+              "type": "source"
+            }
+          ],
+          "text": "Some greater shadows develop the coveted ability to possess a body. Only greater shadows can become possessing shadows, and they can't use Slink in Shadows or Steal Shadow while using Inhabit.  \n  \n**Inhabit** [##] The shadow attempts to possess an adjacent undead corporeal creature. This has the same effect as the *possession* spell, except the shadow doesn't have a physical body, so it's unaffected by the spell's restriction.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Shadow Touch",
+              "subtype": "ability",
+              "text": "The shadow Interacts with a simple physical object, such as picking up a book or opening a door (it can't manipulate a complicated object, like a lock). It can't carry more than a single physical object of up to 2 Bulk. It must use Shadow Touch to keep its hold on the item each turn, or it drops the item at the end of its turn.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Shadow Thief",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #183: Field of Maidens pg. 73",
+                "href": "https://paizo.com/products/btq02c11",
+                "name": "Pathfinder #183: Field of Maidens pg. 73",
+                "type": "link"
+              },
+              "name": "Pathfinder #183: Field of Maidens",
+              "page": 73,
+              "type": "source"
+            }
+          ],
+          "text": "Some shadows gain the ability to handle objects. A shadow thief can't use Slink in Shadows or Steal Shadow while using Shadow Touch.  \n  \n**Shadow Touch** [##] The shadow Interacts with a simple physical object, such as picking up a book or opening a door (it can't manipulate a complicated object, like a lock). It can't carry more than a single physical object of up to 2 Bulk. It must use Shadow Touch to keep its hold on the item each turn, or it drops the item at the end of its turn.",
+          "type": "section"
+        },
         {
           "name": "Shadow Locations",
           "sources": [

--- a/monster_families/bestiary/sinspawn.json
+++ b/monster_families/bestiary/sinspawn.json
@@ -30,59 +30,28 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d10+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 192,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "versatile S",
-                    "aonid": 200,
-                    "game-obj": "Traits",
-                    "name": "versatile S",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "halberd +10 (reach 10 feet, versatile S),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Sinful Bite",
-                "subtype": "ability",
-                "text": "Creatures that critically fail their saves against an envyspawn\u2019s sinful bite are enfeebled 2 for 1 minute.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='ENVYSPAWN')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "reach 10 feet",
+                "aonid": 192,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "versatile S",
+                "aonid": 200,
+                "game-obj": "Traits",
+                "name": "versatile S",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -92,65 +61,33 @@
         ],
         "name": "ENVYSPAWN",
         "subtype": "monster_family",
-        "text": "An envyspawn has Deception +7 and typically carries a halberd. They tend to be shorter and thinner than other sinspawn.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d10+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "deadly d10",
-                    "aonid": 174,
-                    "game-obj": "Traits",
-                    "name": "deadly d10",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "trip",
-                    "aonid": 196,
-                    "game-obj": "Traits",
-                    "name": "trip",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "scythe +10 (deadly d10, trip),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Sinful Bite",
-                "subtype": "ability",
-                "text": "Creatures that critically fail their saves against a gluttonyspawn\u2019s sinful bite are drained 1.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='GLUTTONYSPAWN')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "deadly d10",
+                "aonid": 174,
+                "game-obj": "Traits",
+                "name": "deadly d10",
+                "type": "link"
+              },
+              {
+                "alt": "trip",
+                "aonid": 196,
+                "game-obj": "Traits",
+                "name": "trip",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -160,72 +97,40 @@
         ],
         "name": "GLUTTONYSPAWN",
         "subtype": "monster_family",
-        "text": "A gluttonyspawn has Survival +10 and usually carries a scythe. They are obese, but hardy and strong.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d8+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "deadly d8",
-                    "aonid": 174,
-                    "game-obj": "Traits",
-                    "name": "deadly d8",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "forceful",
-                    "aonid": 180,
-                    "game-obj": "Traits",
-                    "name": "forceful",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 192,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "glaive +10 (deadly d8, forceful, reach 10 feet),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Sinful Bite",
-                "subtype": "ability",
-                "text": "Creatures that critically fail their saves against a greedspawn\u2019s sinful bite are clumsy 2 for 1 minute.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='GREEDSPAWN')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "deadly d8",
+                "aonid": 174,
+                "game-obj": "Traits",
+                "name": "deadly d8",
+                "type": "link"
+              },
+              {
+                "alt": "forceful",
+                "aonid": 180,
+                "game-obj": "Traits",
+                "name": "forceful",
+                "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 192,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -235,65 +140,33 @@
         ],
         "name": "GREEDSPAWN",
         "subtype": "monster_family",
-        "text": "A greedspawn has Thievery +9 and typically wields a glaive. They are the tallest of sinspawn, often 7 feet in height, and with gold-tinged veins.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d10+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 192,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "trip",
-                    "aonid": 196,
-                    "game-obj": "Traits",
-                    "name": "trip",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "guisarme +10 (reach 10 feet, trip),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Sinful Bite",
-                "subtype": "ability",
-                "text": "Creatures that critically fail their saves against a lustspawn\u2019s sinful bite are stupefied 2 for 1 minute.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='LUSTSPAWN')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "reach 10 feet",
+                "aonid": 192,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "trip",
+                "aonid": 196,
+                "game-obj": "Traits",
+                "name": "trip",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -303,58 +176,26 @@
         ],
         "name": "LUSTSPAWN",
         "subtype": "monster_family",
-        "text": "A lustspawn has Diplomacy +7 and usually carries a guisarme. They have attractive bodies, but hideous faces.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d12+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "shove",
-                    "aonid": 193,
-                    "game-obj": "Traits",
-                    "name": "shove",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "maul +10 (shove),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Sinful Bite",
-                "subtype": "ability",
-                "text": "Creatures that critically fail their saves against a pridespawn\u2019s sinful bite are clumsy 1 and enfeebled 1 for 1 minute.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='PRIDESPAWN')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "shove",
+                "aonid": 193,
+                "game-obj": "Traits",
+                "name": "shove",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -364,58 +205,26 @@
         ],
         "name": "PRIDESPAWN",
         "subtype": "monster_family",
-        "text": "A pridespawn has Intimidation +7 and often wields a maul. They are nearly skeletal in their gauntness, and often seek out fine clothes or jewelry to wear, taking strange pleasure in appearing elegant and regal.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d8+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 192,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "longspear +10 (reach 10 feet),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Sinful Bite",
-                "subtype": "ability",
-                "text": "Creatures that critically fail their saves against a slothspawn\u2019s sinful bite take a \u201310-foot status penalty to their Speeds for 1 minute.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='SLOTHSPAWN')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "reach 10 feet",
+                "aonid": 192,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -425,65 +234,33 @@
         ],
         "name": "SLOTHSPAWN",
         "subtype": "monster_family",
-        "text": "A slothspawn has Society +6 and usually carries a longspear. Thick rolls of excess skin drape the slothspawn\u2019s hunched frame.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d10+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "disarm",
-                    "aonid": 175,
-                    "game-obj": "Traits",
-                    "name": "disarm",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 192,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "ranseur + 10 (disarm, reach 10 feet),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Sinful Bite",
-                "subtype": "ability",
-                "text": "Creatures that critically fail their saves against a wrathspawn\u2019s sinful bite are drained 1 as well as enfeebled 1 for 1 minute.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='WRATHSPAWN')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disarm",
+                "aonid": 175,
+                "game-obj": "Traits",
+                "name": "disarm",
+                "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 192,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -493,7 +270,6 @@
         ],
         "name": "WRATHSPAWN",
         "subtype": "monster_family",
-        "text": "The most commonly encountered of the sinspawn, a wrathspawn has Athletics +12 and typically wields a ranseur. These sinspawn are the bulkiest looking of their kind.",
         "type": "stat_block_section"
       }
     ],
@@ -504,6 +280,568 @@
   "sections": [
     {
       "name": "Sinspawn Sins",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "1d10+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 192,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "versatile S",
+                  "aonid": 200,
+                  "game-obj": "Traits",
+                  "name": "versatile S",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "halberd +10 (reach 10 feet, versatile S),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Sinful Bite",
+              "subtype": "ability",
+              "text": "Creatures that critically fail their saves against an envyspawn\u2019s sinful bite are enfeebled 2 for 1 minute.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "reach 10 feet",
+              "aonid": 192,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "versatile S",
+              "aonid": 200,
+              "game-obj": "Traits",
+              "name": "versatile S",
+              "type": "link"
+            }
+          ],
+          "name": "ENVYSPAWN",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 296",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "An envyspawn has Deception +7 and typically carries a halberd. They tend to be shorter and thinner than other sinspawn.  \n**Melee** [#] halberd +10 (reach 10 feet, versatile S), **Damage** 1d10+4 piercing  \n**Sinful Bite** Creatures that critically fail their saves against an envyspawn\u2019s sinful bite are enfeebled 2 for 1 minute.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "slashing",
+                  "formula": "1d10+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "deadly d10",
+                  "aonid": 174,
+                  "game-obj": "Traits",
+                  "name": "deadly d10",
+                  "type": "link"
+                },
+                {
+                  "alt": "trip",
+                  "aonid": 196,
+                  "game-obj": "Traits",
+                  "name": "trip",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "scythe +10 (deadly d10, trip),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Sinful Bite",
+              "subtype": "ability",
+              "text": "Creatures that critically fail their saves against a gluttonyspawn\u2019s sinful bite are drained 1.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "deadly d10",
+              "aonid": 174,
+              "game-obj": "Traits",
+              "name": "deadly d10",
+              "type": "link"
+            },
+            {
+              "alt": "trip",
+              "aonid": 196,
+              "game-obj": "Traits",
+              "name": "trip",
+              "type": "link"
+            }
+          ],
+          "name": "GLUTTONYSPAWN",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 296",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "A gluttonyspawn has Survival +10 and usually carries a scythe. They are obese, but hardy and strong.  \n**Melee** [#] scythe +10 (deadly d10, trip), **Damage** 1d10+4 slashing  \n**Sinful Bite** Creatures that critically fail their saves against a gluttonyspawn\u2019s sinful bite are drained 1.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "slashing",
+                  "formula": "1d8+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "deadly d8",
+                  "aonid": 174,
+                  "game-obj": "Traits",
+                  "name": "deadly d8",
+                  "type": "link"
+                },
+                {
+                  "alt": "forceful",
+                  "aonid": 180,
+                  "game-obj": "Traits",
+                  "name": "forceful",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 192,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "glaive +10 (deadly d8, forceful, reach 10 feet),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Sinful Bite",
+              "subtype": "ability",
+              "text": "Creatures that critically fail their saves against a greedspawn\u2019s sinful bite are clumsy 2 for 1 minute.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "deadly d8",
+              "aonid": 174,
+              "game-obj": "Traits",
+              "name": "deadly d8",
+              "type": "link"
+            },
+            {
+              "alt": "forceful",
+              "aonid": 180,
+              "game-obj": "Traits",
+              "name": "forceful",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 192,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            }
+          ],
+          "name": "GREEDSPAWN",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 296",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "A greedspawn has Thievery +9 and typically wields a glaive. They are the tallest of sinspawn, often 7 feet in height, and with gold-tinged veins.  \n**Melee** [#] glaive +10 (deadly d8, forceful, reach 10 feet), **Damage** 1d8+4 slashing  \n**Sinful Bite** Creatures that critically fail their saves against a greedspawn\u2019s sinful bite are clumsy 2 for 1 minute.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "slashing",
+                  "formula": "1d10+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 192,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "trip",
+                  "aonid": 196,
+                  "game-obj": "Traits",
+                  "name": "trip",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "guisarme +10 (reach 10 feet, trip),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Sinful Bite",
+              "subtype": "ability",
+              "text": "Creatures that critically fail their saves against a lustspawn\u2019s sinful bite are stupefied 2 for 1 minute.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "reach 10 feet",
+              "aonid": 192,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "trip",
+              "aonid": 196,
+              "game-obj": "Traits",
+              "name": "trip",
+              "type": "link"
+            }
+          ],
+          "name": "LUSTSPAWN",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 296",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "A lustspawn has Diplomacy +7 and usually carries a guisarme. They have attractive bodies, but hideous faces.  \n**Melee** [#] guisarme +10 (reach 10 feet, trip), **Damage** 1d10+4 slashing  \n**Sinful Bite** Creatures that critically fail their saves against a lustspawn\u2019s sinful bite are stupefied 2 for 1 minute.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "bludgeoning",
+                  "formula": "1d12+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "shove",
+                  "aonid": 193,
+                  "game-obj": "Traits",
+                  "name": "shove",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "maul +10 (shove),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Sinful Bite",
+              "subtype": "ability",
+              "text": "Creatures that critically fail their saves against a pridespawn\u2019s sinful bite are clumsy 1 and enfeebled 1 for 1 minute.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "shove",
+              "aonid": 193,
+              "game-obj": "Traits",
+              "name": "shove",
+              "type": "link"
+            }
+          ],
+          "name": "PRIDESPAWN",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 296",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "A pridespawn has Intimidation +7 and often wields a maul. They are nearly skeletal in their gauntness, and often seek out fine clothes or jewelry to wear, taking strange pleasure in appearing elegant and regal.  \n**Melee** [#] maul +10 (shove), **Damage** 1d12+4 bludgeoning  \n**Sinful Bite** Creatures that critically fail their saves against a pridespawn\u2019s sinful bite are clumsy 1 and enfeebled 1 for 1 minute.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "1d8+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 192,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "longspear +10 (reach 10 feet),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Sinful Bite",
+              "subtype": "ability",
+              "text": "Creatures that critically fail their saves against a slothspawn\u2019s sinful bite take a \u201310-foot status penalty to their Speeds for 1 minute.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "reach 10 feet",
+              "aonid": 192,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            }
+          ],
+          "name": "SLOTHSPAWN",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 296",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "A slothspawn has Society +6 and usually carries a longspear. Thick rolls of excess skin drape the slothspawn\u2019s hunched frame.  \n**Melee** [#] longspear +10 (reach 10 feet), **Damage** 1d8+4 piercing  \n**Sinful Bite** Creatures that critically fail their saves against a slothspawn\u2019s sinful bite take a \u201310-foot status penalty to their Speeds for 1 minute.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "1d10+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "disarm",
+                  "aonid": 175,
+                  "game-obj": "Traits",
+                  "name": "disarm",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 192,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "ranseur + 10 (disarm, reach 10 feet),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Sinful Bite",
+              "subtype": "ability",
+              "text": "Creatures that critically fail their saves against a wrathspawn\u2019s sinful bite are drained 1 as well as enfeebled 1 for 1 minute.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "disarm",
+              "aonid": 175,
+              "game-obj": "Traits",
+              "name": "disarm",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 192,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            }
+          ],
+          "name": "WRATHSPAWN",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 296",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "The most commonly encountered of the sinspawn, a wrathspawn has Athletics +12 and typically wields a ranseur. These sinspawn are the bulkiest looking of their kind.  \n**Melee** [#] ranseur + 10 (disarm, reach 10 feet), **Damage** 1d10+4 piercing  \n**Sinful Bite** Creatures that critically fail their saves against a wrathspawn\u2019s sinful bite are drained 1 as well as enfeebled 1 for 1 minute.",
+          "type": "section"
+        }
+      ],
       "sources": [
         {
           "link": {

--- a/monster_families/bestiary/skeleton.json
+++ b/monster_families/bestiary/skeleton.json
@@ -30,172 +30,84 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fast healing",
-                    "aonid": 15,
-                    "game-obj": "MonsterAbilities",
-                    "name": "fast healing",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bloody",
-                "subtype": "ability",
-                "text": "The skeleton is covered in dripping blood and gains fast healing equal to its level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The skeleton collapses into a pile of bones and the attack deals only normal damage. The skeleton can reform in a standing position as an action, but until it does, it is immobilized and flat-footed.",
-                "links": [
-                  {
-                    "alt": "immobilized",
-                    "aonid": 24,
-                    "game-obj": "Conditions",
-                    "name": "immobilized",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "flat-footed",
-                    "aonid": 16,
-                    "game-obj": "Conditions",
-                    "name": "flat-footed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Collapse",
-                "subtype": "ability",
-                "trigger": "The skeleton is critically hit.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Explosive Death",
-                "subtype": "ability",
-                "text": "When the skeleton is destroyed, its bones shatter and explode as the necromantic energy holding it together is released. Adjacent creatures take 1d6 slashing damage per 2 levels (minimum 1d6) with a basic Reflex save.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Demoralize",
-                    "aonid": 53,
-                    "game-obj": "Actions",
-                    "name": "Demoralize",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "blind",
-                    "aonid": 1,
-                    "game-obj": "Conditions",
-                    "name": "blind",
-                    "type": "link"
-                  }
-                ],
-                "name": "Screaming Skull",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "range of 20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The skeleton removes its skull and throws it, making a jaws attack with a range of 20 feet. It then attempts to Demoralize each foe within 10 feet of the target. The head bounces, rolls, or even flies back, returning to the skeleton at the start of its next turn. The skeleton is blind until then.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 16,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Skeleton Abilities')].sections[?(@.name=='Bestiary')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fast healing",
+                "aonid": 15,
+                "game-obj": "MonsterAbilities",
+                "name": "fast healing",
+                "type": "link"
+              },
+              {
+                "alt": "immobilized",
+                "aonid": 24,
+                "game-obj": "Conditions",
+                "name": "immobilized",
+                "type": "link"
+              },
+              {
+                "alt": "flat-footed",
+                "aonid": 16,
+                "game-obj": "Conditions",
+                "name": "flat-footed",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 16,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "Demoralize",
+                "aonid": 53,
+                "game-obj": "Actions",
+                "name": "Demoralize",
+                "type": "link"
+              },
+              {
+                "alt": "blind",
+                "aonid": 1,
+                "game-obj": "Conditions",
+                "name": "blind",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -210,102 +122,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fire",
-                    "aonid": 72,
-                    "game-obj": "Traits",
-                    "name": "fire",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "cold",
-                    "aonid": 27,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent fire damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent fire damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blaze",
-                "subtype": "ability",
-                "text": "The skeleton is wreathed with fire, which doesn't consume its bones or gear. The skeleton gains immunity to fire and weakness 5 to cold, loses its resistance to cold, and its Strikes deal additional persistent fire damage equal to half the skeleton's level (minimum 1 damage).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Bone Missile",
-                "subtype": "ability",
-                "text": "The skeleton yanks a rib from its ribcage to use as an arrow or javelin. The skeleton loses HP equal to its level (minimum 1), then makes a ranged Strike. This uses the attack bonus of whichever of the skeleton's other Strikes has the highest attack bonus and deals piercing damage equal to that Strike's damage plus the skeleton's level (minimum 1).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 5,
-                    "subtype": "area",
-                    "text": "5-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "poison",
-                    "formula": "1d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "persistent poison damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent poison damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bone Powder",
-                "subtype": "ability",
-                "text": "**Source** When the skeleton takes physical damage from a critical hit, one of its bones is pulverized into a fine powder. All creatures in a 5-foot emanation that breathe take 1d6 persistent poison damage (plus an additional 1d6 for every 6 levels the skeleton has).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Skeleton of Roses",
-                "subtype": "ability",
-                "text": "Thick briars have grown through the skeleton's bones, covering it in red roses with inch-long thorns. The skeleton's unarmed melee Strikes deal additional piercing damage equal to 1/3 the skeleton's level (minimum 1 damage). At the end of each of its turns, if the skeleton has caused piercing damage with its thorns, it regains HP equal to its level (minimum 1). Each time the skeleton regains HP in this way, another rose blossoms.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Skeleton Abilities')].sections[?(@.name=='Bestiary 3')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fire",
+                "aonid": 72,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 27,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "persistent fire damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent fire damage",
+                "type": "link"
+              },
+              {
+                "alt": "persistent poison damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent poison damage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -320,231 +172,133 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "aquatic",
-                    "aonid": 168,
-                    "game-obj": "Traits",
-                    "name": "aquatic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "aquatic ambush",
-                    "aonid": 2,
-                    "game-obj": "MonsterAbilities",
-                    "name": "aquatic ambush",
-                    "type": "link"
-                  }
-                ],
-                "name": "Aquatic Bones",
-                "subtype": "ability",
-                "text": "The skeleton has bones from aquatic creatures, allowing it to swim using a simple tail, paddles, or similar appendage. The skeleton has a swim Speed of 20 feet and gains the aquatic trait and the aquatic ambush ability.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "effect": "The skeleton transforms into a cyclone of bones, taking up the same space, but twice as tall. It then Strides up to double its Speed. It can move through spaces occupied by other creatures, and this movement doesn't trigger reactions. Creatures the bone storm moves through take 1d6 slashing damage for every 2 levels of the skeleton, with a basic Reflex save against the hard DC for the creature's level. A level 1 or lower skeleton only moves; it doesn't deal damage. A creature attempts this save only once even if the bone storm moved through its space multiple times. At the end of the movement, the skeleton reforms.",
-                "frequency": "once per day",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "hard DC for the creature's level",
-                    "aonid": 554,
-                    "game-obj": "Rules",
-                    "name": "hard DC for the creature's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bone Storm",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Crumbling Bones",
-                "subtype": "ability",
-                "text": "The skeleton is made from crumbling bones that drift in clouds of dust. The skeleton has a fly Speed of 20 but it must end its turn within no more than 5 feet off the ground, or it falls, taking damage as normal. In addition, the skeleton can move through any space that's large enough for its skull to fit through.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "cold",
-                    "aonid": 27,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fire",
-                    "aonid": 72,
-                    "game-obj": "Traits",
-                    "name": "fire",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "standard DC for its level",
-                    "aonid": 554,
-                    "game-obj": "Rules",
-                    "name": "standard DC for its level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Frozen",
-                "subtype": "ability",
-                "text": "The skeleton's bones are covered in a thin layer of ice. The skeleton gains immunity to cold and weakness 5 to fire and loses resistance to fire. The skeleton is surrounded by an aura of cold that deals cold damage equal to half the skeleton's level to all adjacent creatures at the start of the skeleton's turn (basic Reflex save with a standard DC for its level).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The skeleton erupts from the ground, Stands, and makes a melee Strike. The target is flat-footed against this Strike. If the Strike hits, the target is frightened 1 (or frightened 2 on a critical hit).",
-                "links": [
-                  {
-                    "alt": "undetected",
-                    "aonid": 39,
-                    "game-obj": "Conditions",
-                    "name": "undetected",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "flat-footed",
-                    "aonid": 16,
-                    "game-obj": "Conditions",
-                    "name": "flat-footed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened 1",
-                    "aonid": 19,
-                    "game-obj": "Conditions",
-                    "name": "frightened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grave Eruption",
-                "requirement": "The skeleton is undetected and buried in dirt, gravel, or other loose material",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "acid",
-                    "aonid": 3,
-                    "game-obj": "Traits",
-                    "name": "acid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Lacquered",
-                "subtype": "ability",
-                "text": "During the process to create the skeleton, it was covered with several layers of an alchemical lacquer, giving its bones a golden hue and granting added protection. The skeleton gains acid resistance 5 and a +2 status bonus to saves against effects that age or erode the target.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Nimble Dodge",
-                    "aonid": 550,
-                    "game-obj": "Feats",
-                    "name": "Nimble Dodge",
-                    "type": "link"
-                  }
-                ],
-                "name": "Nimble",
-                "subtype": "ability",
-                "text": "The skeleton is particularly fast and nimble. Its land Speed increases by 10 feet and it has a climb Speed of 20 feet. In addition, it gains the Nimble Dodge reaction.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "standard DC of the skeleton's level",
-                    "aonid": 554,
-                    "game-obj": "Rules",
-                    "name": "standard DC of the skeleton's level",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "slowed 1",
-                    "aonid": 35,
-                    "game-obj": "Conditions",
-                    "name": "slowed 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  }
-                ],
-                "name": "Rotten",
-                "subtype": "ability",
-                "text": "The bones of this skeleton are black and rotten, having spent years in polluted water or some other foul substance. The skeleton loses its resistance to piercing and slashing damage and is surrounded by a horrific stench in a 10-foot aura. A creature entering or starting its turn in the aura must succeed at a Fortitude save against the standard DC of the skeleton's level or become sickened 1 (plus slowed 1 for as long as it remains sickened on a critical failure). While within the aura, affected creatures take a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Skeleton Abilities')].sections[?(@.name=='Book of the Dead')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "aquatic",
+                "aonid": 168,
+                "game-obj": "Traits",
+                "name": "aquatic",
+                "type": "link"
+              },
+              {
+                "alt": "aquatic ambush",
+                "aonid": 2,
+                "game-obj": "MonsterAbilities",
+                "name": "aquatic ambush",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "hard DC for the creature's level",
+                "aonid": 554,
+                "game-obj": "Rules",
+                "name": "hard DC for the creature's level",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 27,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 72,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "standard DC for its level",
+                "aonid": 554,
+                "game-obj": "Rules",
+                "name": "standard DC for its level",
+                "type": "link"
+              },
+              {
+                "alt": "undetected",
+                "aonid": 39,
+                "game-obj": "Conditions",
+                "name": "undetected",
+                "type": "link"
+              },
+              {
+                "alt": "flat-footed",
+                "aonid": 16,
+                "game-obj": "Conditions",
+                "name": "flat-footed",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 1",
+                "aonid": 19,
+                "game-obj": "Conditions",
+                "name": "frightened 1",
+                "type": "link"
+              },
+              {
+                "alt": "acid",
+                "aonid": 3,
+                "game-obj": "Traits",
+                "name": "acid",
+                "type": "link"
+              },
+              {
+                "alt": "Nimble Dodge",
+                "aonid": 550,
+                "game-obj": "Feats",
+                "name": "Nimble Dodge",
+                "type": "link"
+              },
+              {
+                "alt": "standard DC of the skeleton's level",
+                "aonid": 554,
+                "game-obj": "Rules",
+                "name": "standard DC of the skeleton's level",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "slowed 1",
+                "aonid": 35,
+                "game-obj": "Conditions",
+                "name": "slowed 1",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -565,6 +319,755 @@
     {
       "name": "Skeleton Abilities",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "fast healing",
+                  "aonid": 15,
+                  "game-obj": "MonsterAbilities",
+                  "name": "fast healing",
+                  "type": "link"
+                }
+              ],
+              "name": "Bloody",
+              "subtype": "ability",
+              "text": "The skeleton is covered in dripping blood and gains fast healing equal to its level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The skeleton collapses into a pile of bones and the attack deals only normal damage. The skeleton can reform in a standing position as an action, but until it does, it is immobilized and flat-footed.",
+              "links": [
+                {
+                  "alt": "immobilized",
+                  "aonid": 24,
+                  "game-obj": "Conditions",
+                  "name": "immobilized",
+                  "type": "link"
+                },
+                {
+                  "alt": "flat-footed",
+                  "aonid": 16,
+                  "game-obj": "Conditions",
+                  "name": "flat-footed",
+                  "type": "link"
+                }
+              ],
+              "name": "Collapse",
+              "subtype": "ability",
+              "trigger": "The skeleton is critically hit.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "slashing",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Explosive Death",
+              "subtype": "ability",
+              "text": "When the skeleton is destroyed, its bones shatter and explode as the necromantic energy holding it together is released. Adjacent creatures take 1d6 slashing damage per 2 levels (minimum 1d6) with a basic Reflex save.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "Demoralize",
+                  "aonid": 53,
+                  "game-obj": "Actions",
+                  "name": "Demoralize",
+                  "type": "link"
+                },
+                {
+                  "alt": "blind",
+                  "aonid": 1,
+                  "game-obj": "Conditions",
+                  "name": "blind",
+                  "type": "link"
+                }
+              ],
+              "name": "Screaming Skull",
+              "range": {
+                "range": 20,
+                "subtype": "range",
+                "text": "range of 20 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The skeleton removes its skull and throws it, making a jaws attack with a range of 20 feet. It then attempts to Demoralize each foe within 10 feet of the target. The head bounces, rolls, or even flies back, returning to the skeleton at the start of its next turn. The skeleton is blind until then.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "auditory",
+                    "aonid": 16,
+                    "game-obj": "Traits",
+                    "name": "auditory",
+                    "type": "link"
+                  },
+                  "name": "auditory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 60,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fear",
+                    "aonid": 68,
+                    "game-obj": "Traits",
+                    "name": "fear",
+                    "type": "link"
+                  },
+                  "name": "fear",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "fast healing",
+              "aonid": 15,
+              "game-obj": "MonsterAbilities",
+              "name": "fast healing",
+              "type": "link"
+            },
+            {
+              "alt": "immobilized",
+              "aonid": 24,
+              "game-obj": "Conditions",
+              "name": "immobilized",
+              "type": "link"
+            },
+            {
+              "alt": "flat-footed",
+              "aonid": 16,
+              "game-obj": "Conditions",
+              "name": "flat-footed",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "auditory",
+              "aonid": 16,
+              "game-obj": "Traits",
+              "name": "auditory",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 60,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 68,
+              "game-obj": "Traits",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "Demoralize",
+              "aonid": 53,
+              "game-obj": "Actions",
+              "name": "Demoralize",
+              "type": "link"
+            },
+            {
+              "alt": "blind",
+              "aonid": 1,
+              "game-obj": "Conditions",
+              "name": "blind",
+              "type": "link"
+            }
+          ],
+          "name": "Bestiary",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 298",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 298",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 298,
+              "type": "source"
+            }
+          ],
+          "text": "**Bloody** The skeleton is covered in dripping blood and gains fast healing equal to its level.   \n  \n**Collapse** [@] **Trigger** The skeleton is critically hit. **Effect** The skeleton collapses into a pile of bones and the attack deals only normal damage. The skeleton can reform in a standing position as an action, but until it does, it is immobilized and flat-footed.  \n  \n**Explosive Death** When the skeleton is destroyed, its bones shatter and explode as the necromantic energy holding it together is released. Adjacent creatures take 1d6 slashing damage per 2 levels (minimum 1d6) with a basic Reflex save.  \n  \n**Screaming Skull** [##] (auditory, emotion, fear, mental) The skeleton removes its skull and throws it, making a jaws attack with a range of 20 feet. It then attempts to Demoralize each foe within 10 feet of the target. The head bounces, rolls, or even flies back, returning to the skeleton at the start of its next turn. The skeleton is blind until then.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "fire",
+                  "aonid": 72,
+                  "game-obj": "Traits",
+                  "name": "fire",
+                  "type": "link"
+                },
+                {
+                  "alt": "cold",
+                  "aonid": 27,
+                  "game-obj": "Traits",
+                  "name": "cold",
+                  "type": "link"
+                },
+                {
+                  "alt": "persistent fire damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent fire damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Blaze",
+              "subtype": "ability",
+              "text": "The skeleton is wreathed with fire, which doesn't consume its bones or gear. The skeleton gains immunity to fire and weakness 5 to cold, loses its resistance to cold, and its Strikes deal additional persistent fire damage equal to half the skeleton's level (minimum 1 damage).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Bone Missile",
+              "subtype": "ability",
+              "text": "The skeleton yanks a rib from its ribcage to use as an arrow or javelin. The skeleton loses HP equal to its level (minimum 1), then makes a ranged Strike. This uses the attack bonus of whichever of the skeleton's other Strikes has the highest attack bonus and deals piercing damage equal to that Strike's damage plus the skeleton's level (minimum 1).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "area": [
+                {
+                  "shape": "emanation",
+                  "size": 5,
+                  "subtype": "area",
+                  "text": "5-foot emanation",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "damage_type": "poison",
+                  "formula": "1d6",
+                  "persistent": true,
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "persistent poison damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent poison damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Bone Powder",
+              "subtype": "ability",
+              "text": "**Source** When the skeleton takes physical damage from a critical hit, one of its bones is pulverized into a fine powder. All creatures in a 5-foot emanation that breathe take 1d6 persistent poison damage (plus an additional 1d6 for every 6 levels the skeleton has).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Skeleton of Roses",
+              "subtype": "ability",
+              "text": "Thick briars have grown through the skeleton's bones, covering it in red roses with inch-long thorns. The skeleton's unarmed melee Strikes deal additional piercing damage equal to 1/3 the skeleton's level (minimum 1 damage). At the end of each of its turns, if the skeleton has caused piercing damage with its thorns, it regains HP equal to its level (minimum 1). Each time the skeleton regains HP in this way, another rose blossoms.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "fire",
+              "aonid": 72,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 27,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "persistent fire damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent fire damage",
+              "type": "link"
+            },
+            {
+              "alt": "persistent poison damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent poison damage",
+              "type": "link"
+            }
+          ],
+          "name": "Bestiary 3",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 298",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 298",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 298,
+              "type": "source"
+            }
+          ],
+          "text": "**Blaze** The skeleton is wreathed with fire, which doesn't consume its bones or gear. The skeleton gains immunity to fire and weakness 5 to cold, loses its resistance to cold, and its Strikes deal additional persistent fire damage equal to half the skeleton's level (minimum 1 damage).  \n  \n**Bone Missile** [##] The skeleton yanks a rib from its ribcage to use as an arrow or javelin. The skeleton loses HP equal to its level (minimum 1), then makes a ranged Strike. This uses the attack bonus of whichever of the skeleton's other Strikes has the highest attack bonus and deals piercing damage equal to that Strike's damage plus the skeleton's level (minimum 1).  \n  \n**Bone Powder** **Source** When the skeleton takes physical damage from a critical hit, one of its bones is pulverized into a fine powder. All creatures in a 5-foot emanation that breathe take 1d6 persistent poison damage (plus an additional 1d6 for every 6 levels the skeleton has).   \n  \n**Skeleton of Roses** Thick briars have grown through the skeleton's bones, covering it in red roses with inch-long thorns. The skeleton's unarmed melee Strikes deal additional piercing damage equal to 1/3 the skeleton's level (minimum 1 damage). At the end of each of its turns, if the skeleton has caused piercing damage with its thorns, it regains HP equal to its level (minimum 1). Each time the skeleton regains HP in this way, another rose blossoms.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "aquatic",
+                  "aonid": 168,
+                  "game-obj": "Traits",
+                  "name": "aquatic",
+                  "type": "link"
+                },
+                {
+                  "alt": "aquatic ambush",
+                  "aonid": 2,
+                  "game-obj": "MonsterAbilities",
+                  "name": "aquatic ambush",
+                  "type": "link"
+                }
+              ],
+              "name": "Aquatic Bones",
+              "subtype": "ability",
+              "text": "The skeleton has bones from aquatic creatures, allowing it to swim using a simple tail, paddles, or similar appendage. The skeleton has a swim Speed of 20 feet and gains the aquatic trait and the aquatic ambush ability.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Three Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "slashing",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "effect": "The skeleton transforms into a cyclone of bones, taking up the same space, but twice as tall. It then Strides up to double its Speed. It can move through spaces occupied by other creatures, and this movement doesn't trigger reactions. Creatures the bone storm moves through take 1d6 slashing damage for every 2 levels of the skeleton, with a basic Reflex save against the hard DC for the creature's level. A level 1 or lower skeleton only moves; it doesn't deal damage. A creature attempts this save only once even if the bone storm moved through its space multiple times. At the end of the movement, the skeleton reforms.",
+              "frequency": "once per day",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                },
+                {
+                  "alt": "hard DC for the creature's level",
+                  "aonid": 554,
+                  "game-obj": "Rules",
+                  "name": "hard DC for the creature's level",
+                  "type": "link"
+                }
+              ],
+              "name": "Bone Storm",
+              "subtype": "ability",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Crumbling Bones",
+              "subtype": "ability",
+              "text": "The skeleton is made from crumbling bones that drift in clouds of dust. The skeleton has a fly Speed of 20 but it must end its turn within no more than 5 feet off the ground, or it falls, taking damage as normal. In addition, the skeleton can move through any space that's large enough for its skull to fit through.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "cold",
+                  "aonid": 27,
+                  "game-obj": "Traits",
+                  "name": "cold",
+                  "type": "link"
+                },
+                {
+                  "alt": "fire",
+                  "aonid": 72,
+                  "game-obj": "Traits",
+                  "name": "fire",
+                  "type": "link"
+                },
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                },
+                {
+                  "alt": "standard DC for its level",
+                  "aonid": 554,
+                  "game-obj": "Rules",
+                  "name": "standard DC for its level",
+                  "type": "link"
+                }
+              ],
+              "name": "Frozen",
+              "subtype": "ability",
+              "text": "The skeleton's bones are covered in a thin layer of ice. The skeleton gains immunity to cold and weakness 5 to fire and loses resistance to fire. The skeleton is surrounded by an aura of cold that deals cold damage equal to half the skeleton's level to all adjacent creatures at the start of the skeleton's turn (basic Reflex save with a standard DC for its level).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The skeleton erupts from the ground, Stands, and makes a melee Strike. The target is flat-footed against this Strike. If the Strike hits, the target is frightened 1 (or frightened 2 on a critical hit).",
+              "links": [
+                {
+                  "alt": "undetected",
+                  "aonid": 39,
+                  "game-obj": "Conditions",
+                  "name": "undetected",
+                  "type": "link"
+                },
+                {
+                  "alt": "flat-footed",
+                  "aonid": 16,
+                  "game-obj": "Conditions",
+                  "name": "flat-footed",
+                  "type": "link"
+                },
+                {
+                  "alt": "frightened 1",
+                  "aonid": 19,
+                  "game-obj": "Conditions",
+                  "name": "frightened 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Grave Eruption",
+              "requirement": "The skeleton is undetected and buried in dirt, gravel, or other loose material",
+              "subtype": "ability",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "acid",
+                  "aonid": 3,
+                  "game-obj": "Traits",
+                  "name": "acid",
+                  "type": "link"
+                }
+              ],
+              "name": "Lacquered",
+              "subtype": "ability",
+              "text": "During the process to create the skeleton, it was covered with several layers of an alchemical lacquer, giving its bones a golden hue and granting added protection. The skeleton gains acid resistance 5 and a +2 status bonus to saves against effects that age or erode the target.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Nimble Dodge",
+                  "aonid": 550,
+                  "game-obj": "Feats",
+                  "name": "Nimble Dodge",
+                  "type": "link"
+                }
+              ],
+              "name": "Nimble",
+              "subtype": "ability",
+              "text": "The skeleton is particularly fast and nimble. Its land Speed increases by 10 feet and it has a climb Speed of 20 feet. In addition, it gains the Nimble Dodge reaction.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "standard DC of the skeleton's level",
+                  "aonid": 554,
+                  "game-obj": "Rules",
+                  "name": "standard DC of the skeleton's level",
+                  "type": "link"
+                },
+                {
+                  "alt": "sickened 1",
+                  "aonid": 34,
+                  "game-obj": "Conditions",
+                  "name": "sickened 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "slowed 1",
+                  "aonid": 35,
+                  "game-obj": "Conditions",
+                  "name": "slowed 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                }
+              ],
+              "name": "Rotten",
+              "subtype": "ability",
+              "text": "The bones of this skeleton are black and rotten, having spent years in polluted water or some other foul substance. The skeleton loses its resistance to piercing and slashing damage and is surrounded by a horrific stench in a 10-foot aura. A creature entering or starting its turn in the aura must succeed at a Fortitude save against the standard DC of the skeleton's level or become sickened 1 (plus slowed 1 for as long as it remains sickened on a critical failure). While within the aura, affected creatures take a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "aquatic",
+              "aonid": 168,
+              "game-obj": "Traits",
+              "name": "aquatic",
+              "type": "link"
+            },
+            {
+              "alt": "aquatic ambush",
+              "aonid": 2,
+              "game-obj": "MonsterAbilities",
+              "name": "aquatic ambush",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "hard DC for the creature's level",
+              "aonid": 554,
+              "game-obj": "Rules",
+              "name": "hard DC for the creature's level",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 27,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "fire",
+              "aonid": 72,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "standard DC for its level",
+              "aonid": 554,
+              "game-obj": "Rules",
+              "name": "standard DC for its level",
+              "type": "link"
+            },
+            {
+              "alt": "undetected",
+              "aonid": 39,
+              "game-obj": "Conditions",
+              "name": "undetected",
+              "type": "link"
+            },
+            {
+              "alt": "flat-footed",
+              "aonid": 16,
+              "game-obj": "Conditions",
+              "name": "flat-footed",
+              "type": "link"
+            },
+            {
+              "alt": "frightened 1",
+              "aonid": 19,
+              "game-obj": "Conditions",
+              "name": "frightened 1",
+              "type": "link"
+            },
+            {
+              "alt": "acid",
+              "aonid": 3,
+              "game-obj": "Traits",
+              "name": "acid",
+              "type": "link"
+            },
+            {
+              "alt": "Nimble Dodge",
+              "aonid": 550,
+              "game-obj": "Feats",
+              "name": "Nimble Dodge",
+              "type": "link"
+            },
+            {
+              "alt": "standard DC of the skeleton's level",
+              "aonid": 554,
+              "game-obj": "Rules",
+              "name": "standard DC of the skeleton's level",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 1",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            },
+            {
+              "alt": "slowed 1",
+              "aonid": 35,
+              "game-obj": "Conditions",
+              "name": "slowed 1",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            }
+          ],
+          "name": "Book of the Dead",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 298",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 298",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 298,
+              "type": "source"
+            }
+          ],
+          "text": "**Aquatic Bones** The skeleton has bones from aquatic creatures, allowing it to swim using a simple tail, paddles, or similar appendage. The skeleton has a swim Speed of 20 feet and gains the aquatic trait and the aquatic ambush ability.  \n  \n**Bone Storm** [###] **Frequency** once per day; **Effect** The skeleton transforms into a cyclone of bones, taking up the same space, but twice as tall. It then Strides up to double its Speed. It can move through spaces occupied by other creatures, and this movement doesn't trigger reactions. Creatures the bone storm moves through take 1d6 slashing damage for every 2 levels of the skeleton, with a basic Reflex save against the hard DC for the creature's level. A level 1 or lower skeleton only moves; it doesn't deal damage. A creature attempts this save only once even if the bone storm moved through its space multiple times. At the end of the movement, the skeleton reforms.  \n  \n**Crumbling Bones** The skeleton is made from crumbling bones that drift in clouds of dust. The skeleton has a fly Speed of 20 but it must end its turn within no more than 5 feet off the ground, or it falls, taking damage as normal. In addition, the skeleton can move through any space that's large enough for its skull to fit through.  \n  \n**Frozen** The skeleton's bones are covered in a thin layer of ice. The skeleton gains immunity to cold and weakness 5 to fire and loses resistance to fire. The skeleton is surrounded by an aura of cold that deals cold damage equal to half the skeleton's level to all adjacent creatures at the start of the skeleton's turn (basic Reflex save with a standard DC for its level).  \n  \n**Grave Eruption** [##] **Requirements** The skeleton is undetected and buried in dirt, gravel, or other loose material; **Effect** The skeleton erupts from the ground, Stands, and makes a melee Strike. The target is flat-footed against this Strike. If the Strike hits, the target is frightened 1 (or frightened 2 on a critical hit).  \n  \n**Lacquered** During the process to create the skeleton, it was covered with several layers of an alchemical lacquer, giving its bones a golden hue and granting added protection. The skeleton gains acid resistance 5 and a +2 status bonus to saves against effects that age or erode the target.  \n  \n**Nimble** The skeleton is particularly fast and nimble. Its land Speed increases by 10 feet and it has a climb Speed of 20 feet. In addition, it gains the Nimble Dodge reaction.  \n  \n**Rotten** The bones of this skeleton are black and rotten, having spent years in polluted water or some other foul substance. The skeleton loses its resistance to piercing and slashing damage and is surrounded by a horrific stench in a 10-foot aura. A creature entering or starting its turn in the aura must succeed at a Fortitude save against the standard DC of the skeleton's level or become sickened 1 (plus slowed 1 for as long as it remains sickened on a critical failure). While within the aura, affected creatures take a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute.  \n This stench remains for 1 hour after the rotten skeleton has been destroyed unless the bones are burned, or the rot is washed away with at least 1 gallon of water.",
+          "type": "section"
+        },
         {
           "name": "Creating Skeletons",
           "sources": [

--- a/monster_families/bestiary/vampire.json
+++ b/monster_families/bestiary/vampire.json
@@ -366,366 +366,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyze",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyze",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 145,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyze, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Coffin Restoration",
-                "subtype": "ability",
-                "text": "Unlike other undead, a vampire isn't destroyed at 0 HP. Instead, it falls unconscious. If its body rests in its coffin for 1 hour, the vampire gains 1 HP, after which its fast healing begins to function normally.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "negative",
-                      "aonid": 118,
-                      "game-obj": "Traits",
-                      "name": "negative",
-                      "type": "link"
-                    },
-                    "name": "negative",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Vampire Weaknesses",
-                "subtype": "ability",
-                "text": "All vampires possess the following weaknesses.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Climb Speed",
-                "subtype": "ability",
-                "text": "Vampires gain a climb Speed equal to their land Speed.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the creature had hands, its fingernails thicken and grow, granting it an unarmed claw Strike that deals slashing damage and has the agile trait. If the monster had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The vampire sinks its fangs into that creature to drink its blood. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the vampire regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire but increases the victim's drain value by 1. A vampire can also consume blood that's been emptied into a vessel for sustenance, but it gains no HP from doing so. A victim's drained condition decreases by 1 per week. A blood transfusion, which requires a DC 20 Medicine check and sufficient blood or a blood donor, reduces the drain by 1 after 10 minutes.",
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 20,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 33,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Medicine",
-                    "aonid": 9,
-                    "game-obj": "Skills",
-                    "name": "Medicine",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Blood",
-                "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vampire's reach.",
-                "saving_throw": [
-                  {
-                    "dc": 20,
-                    "subtype": "save_dc",
-                    "text": "DC 20",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grab",
-                "subtype": "ability",
-                "text": "The creature's claw attacks (or equivalent unarmed attacks) gain Grab.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 45,
-                  "edition": "remastered",
-                  "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
-                  "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "grabbed",
-                      "aonid": 20,
-                      "game-obj": "Conditions",
-                      "name": "grabbed",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "restrained",
-                      "aonid": 33,
-                      "game-obj": "Conditions",
-                      "name": "restrained",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Grapple",
-                      "aonid": 35,
-                      "game-obj": "Actions",
-                      "name": "Grapple",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Grab",
-                  "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Rage of Elements pg. 232",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "Rage of Elements pg. 232",
-                        "type": "link"
-                      },
-                      "name": "Rage of Elements",
-                      "page": 232,
-                      "type": "source"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Vampire')].sections[?(@.name=='Basic Vampire Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -743,6 +388,153 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyze",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyze",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 145,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "negative",
+                "aonid": 118,
+                "game-obj": "Traits",
+                "name": "negative",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "Medicine",
+                "aonid": 9,
+                "game-obj": "Skills",
+                "name": "Medicine",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -752,579 +544,208 @@
         ],
         "name": "Basic Vampire Abilities",
         "subtype": "monster_family",
-        "text": "All vampires gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vampire's theme.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "magical",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "The vampire resists all physical damage except magical silver.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Create Spawn",
-                "subtype": "ability",
-                "text": "If a creature dies after being reduced to 0 HP by Drink Blood, the vampire can turn this victim into a vampire by donating some of its own blood to the victim and burying the victim in earth for 3 nights. If the new vampire is lower level than its creator, it is under the creator's control. If a vampire controls too many spawn at once (as determined by the GM), strong-willed spawn can free themselves by succeeding at a Will saving throw against the vampire's Will DC.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "downtime",
-                      "aonid": 49,
-                      "game-obj": "Traits",
-                      "name": "downtime",
-                      "type": "link"
-                    },
-                    "name": "downtime",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The vampire uses Turn to Mist. It can take move actions to move toward its coffin even though it's at 0 HP. While at 0 HP in this form, the vampire is unaffected by further damage. It automatically returns to its corporeal form, unconscious, if it reaches its coffin or after 2 hours, whichever comes first.",
-                "name": "Mist Escape",
-                "subtype": "ability",
-                "trigger": "The vampire is reduced to 0 HP.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "aerial form",
-                    "aonid": 4,
-                    "game-obj": "Spells",
-                    "name": "aerial form",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "animal form",
-                    "aonid": 10,
-                    "game-obj": "Spells",
-                    "name": "animal form",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The vampire transforms into one of its animal forms or back into its normal form. Most vampires can turn into a bat, but some can turn into a different creature, such as a rat or a wolf. Use the options in the *aerial form* and *animal form* spells as guidelines.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "rat swarms",
-                    "aonid": 347,
-                    "game-obj": "Monsters",
-                    "name": "rat swarms",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "bat swarms",
-                    "aonid": 45,
-                    "game-obj": "Monsters",
-                    "name": "bat swarms",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "wolves",
-                    "aonid": 101,
-                    "game-obj": "MonsterFamilies",
-                    "name": "wolves",
-                    "type": "link"
-                  }
-                ],
-                "name": "Children of the Night",
-                "range": {
-                  "range": 100,
-                  "subtype": "range",
-                  "text": "within 100 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The vampire's presence brings forth creatures of the night to do the master's bidding. These typically include rat swarms, bat swarms, and wolves, but can include other creatures. The vampire can give telepathic orders to these creatures as long as they are within 100 feet, but they can't communicate back.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 87,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "visual",
-                    "aonid": 163,
-                    "game-obj": "Traits",
-                    "name": "visual",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dominate",
-                "subtype": "ability",
-                "text": "The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Drink Blood",
-                "subtype": "ability",
-                "text": "As a typical vampire, but the victim is drained 2 instead of 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "gaseous form",
-                    "aonid": 129,
-                    "game-obj": "Spells",
-                    "name": "gaseous form",
-                    "type": "link"
-                  }
-                ],
-                "name": "Turn to Mist",
-                "subtype": "ability",
-                "text": "The vampire turns into a cloud of vapor, as the *gaseous form* spell, or back to its normal form. The vampire loses fast healing while in gaseous form. The vampire can remain in this form indefinitely.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Vampire')].sections[?(@.name=='True Vampire Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "magical",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "downtime",
+                "aonid": 49,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "aerial form",
+                "aonid": 4,
+                "game-obj": "Spells",
+                "name": "aerial form",
+                "type": "link"
+              },
+              {
+                "alt": "animal form",
+                "aonid": 10,
+                "game-obj": "Spells",
+                "name": "animal form",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "rat swarms",
+                "aonid": 347,
+                "game-obj": "Monsters",
+                "name": "rat swarms",
+                "type": "link"
+              },
+              {
+                "alt": "bat swarms",
+                "aonid": 45,
+                "game-obj": "Monsters",
+                "name": "bat swarms",
+                "type": "link"
+              },
+              {
+                "alt": "wolves",
+                "aonid": 101,
+                "game-obj": "MonsterFamilies",
+                "name": "wolves",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 87,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "gaseous form",
+                "aonid": 129,
+                "game-obj": "Spells",
+                "name": "gaseous form",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1334,7 +755,6 @@
         ],
         "name": "True Vampire Abilities",
         "subtype": "monster_family",
-        "text": "Powerful vampires that can create and control vampires from their victims gain additional vampire abilities, as detailed below. A creature below level 5 is not a significant enough creature to become a true vampire\u2014you should instead simply make such a creature into a regular vampire spawn, or rebuild the creature so that it's at least level 5 before becoming a true vampire.",
         "type": "stat_block_section"
       }
     ],
@@ -1346,6 +766,1314 @@
     {
       "name": "Creating a Vampire",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyze",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyze",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "sleep",
+                  "aonid": 145,
+                  "game-obj": "Traits",
+                  "name": "sleep",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyze, poison, sleep",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                }
+              ],
+              "name": "Coffin Restoration",
+              "subtype": "ability",
+              "text": "Unlike other undead, a vampire isn't destroyed at 0 HP. Instead, it falls unconscious. If its body rests in its coffin for 1 hour, the vampire gains 1 HP, after which its fast healing begins to function normally.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "negative",
+                    "aonid": 118,
+                    "game-obj": "Traits",
+                    "name": "negative",
+                    "type": "link"
+                  },
+                  "name": "negative",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Vampire Weaknesses",
+              "subtype": "ability",
+              "text": "All vampires possess the following weaknesses.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "name": "Climb Speed",
+              "subtype": "ability",
+              "text": "Vampires gain a climb Speed equal to their land Speed.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 170,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                }
+              ],
+              "name": "Claws",
+              "subtype": "ability",
+              "text": "If the creature had hands, its fingernails thicken and grow, granting it an unarmed claw Strike that deals slashing damage and has the agile trait. If the monster had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The vampire sinks its fangs into that creature to drink its blood. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the vampire regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire but increases the victim's drain value by 1. A vampire can also consume blood that's been emptied into a vessel for sustenance, but it gains no HP from doing so. A victim's drained condition decreases by 1 per week. A blood transfusion, which requires a DC 20 Medicine check and sufficient blood or a blood donor, reduces the drain by 1 after 10 minutes.",
+              "links": [
+                {
+                  "alt": "grabbed",
+                  "aonid": 20,
+                  "game-obj": "Conditions",
+                  "name": "grabbed",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "restrained",
+                  "aonid": 33,
+                  "game-obj": "Conditions",
+                  "name": "restrained",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                },
+                {
+                  "alt": "Athletics",
+                  "aonid": 3,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                },
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "Medicine",
+                  "aonid": 9,
+                  "game-obj": "Skills",
+                  "name": "Medicine",
+                  "type": "link"
+                }
+              ],
+              "name": "Drink Blood",
+              "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vampire's reach.",
+              "saving_throw": [
+                {
+                  "dc": 20,
+                  "subtype": "save_dc",
+                  "text": "DC 20",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Grab",
+                  "aonid": 18,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Grab",
+                  "type": "link"
+                }
+              ],
+              "name": "Grab",
+              "subtype": "ability",
+              "text": "The creature's claw attacks (or equivalent unarmed attacks) gain Grab.",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 45,
+                "edition": "remastered",
+                "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
+                "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "grabbed",
+                    "aonid": 20,
+                    "game-obj": "Conditions",
+                    "name": "grabbed",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "restrained",
+                    "aonid": 33,
+                    "game-obj": "Conditions",
+                    "name": "restrained",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Grapple",
+                    "aonid": 35,
+                    "game-obj": "Actions",
+                    "name": "Grapple",
+                    "type": "link"
+                  }
+                ],
+                "name": "Grab",
+                "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 205,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Rage of Elements pg. 232",
+                      "aonid": 205,
+                      "game-obj": "Sources",
+                      "name": "Rage of Elements pg. 232",
+                      "type": "link"
+                    },
+                    "name": "Rage of Elements",
+                    "page": 232,
+                    "type": "source"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "human",
+              "aonid": 90,
+              "game-obj": "Traits",
+              "name": "human",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 91,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyze",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyze",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 145,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "negative",
+              "aonid": 118,
+              "game-obj": "Traits",
+              "name": "negative",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "grabbed",
+              "aonid": 20,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 33,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "Medicine",
+              "aonid": 9,
+              "game-obj": "Skills",
+              "name": "Medicine",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Basic Vampire Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 318",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 318",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 318,
+              "type": "source"
+            }
+          ],
+          "text": "All vampires gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vampire's theme.  \n  \n**Negative Healing**  \n  \n**Immunities** death effects, disease, paralyze, poison, sleep  \n  \n**Coffin Restoration** (divine, necromancy, negative) Unlike other undead, a vampire isn't destroyed at 0 HP. Instead, it falls unconscious. If its body rests in its coffin for 1 hour, the vampire gains 1 HP, after which its fast healing begins to function normally.  \n  \n**Vampire Weaknesses** All vampires possess the following weaknesses.**Climb Speed** Vampires gain a climb Speed equal to their land Speed. **Claws** If the creature had hands, its fingernails thicken and grow, granting it an unarmed claw Strike that deals slashing damage and has the agile trait. If the monster had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage. **Drink Blood** [#] (divine, necromancy); **Requirement** A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vampire's reach. **Effect** The vampire sinks its fangs into that creature to drink its blood. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the vampire regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire but increases the victim's drain value by 1. A vampire can also consume blood that's been emptied into a vessel for sustenance, but it gains no HP from doing so. A victim's drained condition decreases by 1 per week. A blood transfusion, which requires a DC 20 Medicine check and sufficient blood or a blood donor, reduces the drain by 1 after 10 minutes. **Grab** The creature's claw attacks (or equivalent unarmed attacks) gain Grab.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "magical",
+                  "aonid": 103,
+                  "game-obj": "Traits",
+                  "name": "magical",
+                  "type": "link"
+                }
+              ],
+              "name": "Resistances",
+              "subtype": "ability",
+              "text": "The vampire resists all physical damage except magical silver.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Create Spawn",
+              "subtype": "ability",
+              "text": "If a creature dies after being reduced to 0 HP by Drink Blood, the vampire can turn this victim into a vampire by donating some of its own blood to the victim and burying the victim in earth for 3 nights. If the new vampire is lower level than its creator, it is under the creator's control. If a vampire controls too many spawn at once (as determined by the GM), strong-willed spawn can free themselves by succeeding at a Will saving throw against the vampire's Will DC.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "downtime",
+                    "aonid": 49,
+                    "game-obj": "Traits",
+                    "name": "downtime",
+                    "type": "link"
+                  },
+                  "name": "downtime",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The vampire uses Turn to Mist. It can take move actions to move toward its coffin even though it's at 0 HP. While at 0 HP in this form, the vampire is unaffected by further damage. It automatically returns to its corporeal form, unconscious, if it reaches its coffin or after 2 hours, whichever comes first.",
+              "name": "Mist Escape",
+              "subtype": "ability",
+              "trigger": "The vampire is reduced to 0 HP.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "aerial form",
+                  "aonid": 4,
+                  "game-obj": "Spells",
+                  "name": "aerial form",
+                  "type": "link"
+                },
+                {
+                  "alt": "animal form",
+                  "aonid": 10,
+                  "game-obj": "Spells",
+                  "name": "animal form",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The vampire transforms into one of its animal forms or back into its normal form. Most vampires can turn into a bat, but some can turn into a different creature, such as a rat or a wolf. Use the options in the *aerial form* and *animal form* spells as guidelines.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "rat swarms",
+                  "aonid": 347,
+                  "game-obj": "Monsters",
+                  "name": "rat swarms",
+                  "type": "link"
+                },
+                {
+                  "alt": "bat swarms",
+                  "aonid": 45,
+                  "game-obj": "Monsters",
+                  "name": "bat swarms",
+                  "type": "link"
+                },
+                {
+                  "alt": "wolves",
+                  "aonid": 101,
+                  "game-obj": "MonsterFamilies",
+                  "name": "wolves",
+                  "type": "link"
+                }
+              ],
+              "name": "Children of the Night",
+              "range": {
+                "range": 100,
+                "subtype": "range",
+                "text": "within 100 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The vampire's presence brings forth creatures of the night to do the master's bidding. These typically include rat swarms, bat swarms, and wolves, but can include other creatures. The vampire can give telepathic orders to these creatures as long as they are within 100 feet, but they can't communicate back.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "dominate",
+                  "aonid": 87,
+                  "game-obj": "Spells",
+                  "name": "dominate",
+                  "type": "link"
+                },
+                {
+                  "alt": "visual",
+                  "aonid": 163,
+                  "game-obj": "Traits",
+                  "name": "visual",
+                  "type": "link"
+                }
+              ],
+              "name": "Dominate",
+              "subtype": "ability",
+              "text": "The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "visual",
+                    "aonid": 163,
+                    "game-obj": "Traits",
+                    "name": "visual",
+                    "type": "link"
+                  },
+                  "name": "visual",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Drink Blood",
+              "subtype": "ability",
+              "text": "As a typical vampire, but the victim is drained 2 instead of 1.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "gaseous form",
+                  "aonid": 129,
+                  "game-obj": "Spells",
+                  "name": "gaseous form",
+                  "type": "link"
+                }
+              ],
+              "name": "Turn to Mist",
+              "subtype": "ability",
+              "text": "The vampire turns into a cloud of vapor, as the *gaseous form* spell, or back to its normal form. The vampire loses fast healing while in gaseous form. The vampire can remain in this form indefinitely.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "magical",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "downtime",
+              "aonid": 49,
+              "game-obj": "Traits",
+              "name": "downtime",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "aerial form",
+              "aonid": 4,
+              "game-obj": "Spells",
+              "name": "aerial form",
+              "type": "link"
+            },
+            {
+              "alt": "animal form",
+              "aonid": 10,
+              "game-obj": "Spells",
+              "name": "animal form",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "rat swarms",
+              "aonid": 347,
+              "game-obj": "Monsters",
+              "name": "rat swarms",
+              "type": "link"
+            },
+            {
+              "alt": "bat swarms",
+              "aonid": 45,
+              "game-obj": "Monsters",
+              "name": "bat swarms",
+              "type": "link"
+            },
+            {
+              "alt": "wolves",
+              "aonid": 101,
+              "game-obj": "MonsterFamilies",
+              "name": "wolves",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "dominate",
+              "aonid": 87,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "gaseous form",
+              "aonid": 129,
+              "game-obj": "Spells",
+              "name": "gaseous form",
+              "type": "link"
+            }
+          ],
+          "name": "True Vampire Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 318",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 318",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 318,
+              "type": "source"
+            }
+          ],
+          "text": "Powerful vampires that can create and control vampires from their victims gain additional vampire abilities, as detailed below. A creature below level 5 is not a significant enough creature to become a true vampire\u2014you should instead simply make such a creature into a regular vampire spawn, or rebuild the creature so that it's at least level 5 before becoming a true vampire.  \n  \n**Resistances** The vampire resists all physical damage except magical silver.  \n  \n**Create Spawn** (divine, downtime, necromancy) If a creature dies after being reduced to 0 HP by Drink Blood, the vampire can turn this victim into a vampire by donating some of its own blood to the victim and burying the victim in earth for 3 nights. If the new vampire is lower level than its creator, it is under the creator's control. If a vampire controls too many spawn at once (as determined by the GM), strong-willed spawn can free themselves by succeeding at a Will saving throw against the vampire's Will DC.  \n  \n**Mist Escape** [-] **Trigger** The vampire is reduced to 0 HP. **Effect** The vampire uses Turn to Mist. It can take move actions to move toward its coffin even though it's at 0 HP. While at 0 HP in this form, the vampire is unaffected by further damage. It automatically returns to its corporeal form, unconscious, if it reaches its coffin or after 2 hours, whichever comes first.  \n  \n**Change Shape** [#] (concentrate, divine, polymorph, transmutation) The vampire transforms into one of its animal forms or back into its normal form. Most vampires can turn into a bat, but some can turn into a different creature, such as a rat or a wolf. Use the options in the *aerial form* and *animal form* spells as guidelines.**Children of the Night** (divine, enchantment, mental) The vampire's presence brings forth creatures of the night to do the master's bidding. These typically include rat swarms, bat swarms, and wolves, but can include other creatures. The vampire can give telepathic orders to these creatures as long as they are within 100 feet, but they can't communicate back.  \n  \n**Dominate** [##] (divine, enchantment, incapacitation, mental, visual) The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.  \n  \n**Drink Blood** As a typical vampire, but the victim is drained 2 instead of 1.  \n  \n**Turn to Mist** [#] (concentrate, divine, transmutation) The vampire turns into a cloud of vapor, as the *gaseous form* spell, or back to its normal form. The vampire loses fast healing while in gaseous form. The vampire can remain in this form indefinitely.",
+          "type": "section"
+        },
         {
           "name": "Building Vampires",
           "sources": [

--- a/monster_families/bestiary/werecreature.json
+++ b/monster_families/bestiary/werecreature.json
@@ -235,395 +235,98 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Senses",
-                "subtype": "ability",
-                "text": "The werecreature gains all the senses of the animal.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Animal Empathy",
-                "subtype": "ability",
-                "text": "A werecreature can communicate with animals of the same general kind.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divination",
-                      "aonid": 47,
-                      "game-obj": "Traits",
-                      "name": "divination",
-                      "type": "link"
-                    },
-                    "name": "divination",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "The werecreature gains a claw Strike (an agile unarmed attack that deals slashing damage). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Jaws",
-                "subtype": "ability",
-                "text": "The creature gains a jaws Strike (an unarmed attack that deals piercing damage) that inflicts its curse of the werecreature. If it had any non-agile attacks, the damage dealt by its jaws should be roughly the same as the damage dealt by those attacks. If it had only agile attacks, its jaws should deal one-third more damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The werecreature changes into its humanoid, hybrid, or animal shape. Each shape has a specific, persistent appearance. A true werecreature's natural form is its hybrid shape. In humanoid shape, the werecreature uses its original humanoid size, loses its jaws and claws Strikes, and gains a melee fist Strike that deals bludgeoning damage equal to the slashing damage dealt by its claw. In animal shape, its Speed and size change to that of the animal, it gains any special Strike effects of the animal that it didn't already have (such as Grab), and it loses its weapon Strikes.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Curse of the Werecreature",
-                "subtype": "ability",
-                "text": "This curse affects only humanoids. Saving Throw Fortitude DC is the standard DC for the werecreature's new level \u2013 1. On each full moon, the cursed creature must succeed at another Fortitude save or turn into the same kind of werecreature until dawn. The creature is under the GM's control and goes on a rampage for half the night before falling unconscious until dawn.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 38,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Moon Frenzy",
-                "subtype": "ability",
-                "text": "When a full moon appears in the night sky, the werecreature must enter hybrid form, can't Change Shape thereafter, becomes one size larger, increases its reach by 5 feet, and increases the damage of its jaws Strike (or a similar Strike) by 2. When the moon sets or the sun rises, the werecreature returns to humanoid form and is fatigued for 2d4 hours.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Werecreatures')].sections[?(@.name=='Werecreature Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -633,7 +336,6 @@
         ],
         "name": "Werecreature Abilities",
         "subtype": "monster_family",
-        "text": "All werecreatures gain the following abilities, some of which match an ability of the animal the werecreature transforms into. You might also need to adjust some abilities that conflict with the theme of the werecreature (such as abilities with a conflicting alignment trait).",
         "type": "stat_block_section"
       }
     ],
@@ -664,6 +366,494 @@
     {
       "name": "Creating Werecreatures",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Senses",
+              "subtype": "ability",
+              "text": "The werecreature gains all the senses of the animal.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "name": "Animal Empathy",
+              "subtype": "ability",
+              "text": "A werecreature can communicate with animals of the same general kind.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divination",
+                    "aonid": 47,
+                    "game-obj": "Traits",
+                    "name": "divination",
+                    "type": "link"
+                  },
+                  "name": "divination",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Claws",
+              "subtype": "ability",
+              "text": "The werecreature gains a claw Strike (an agile unarmed attack that deals slashing damage). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Jaws",
+              "subtype": "ability",
+              "text": "The creature gains a jaws Strike (an unarmed attack that deals piercing damage) that inflicts its curse of the werecreature. If it had any non-agile attacks, the damage dealt by its jaws should be roughly the same as the damage dealt by those attacks. If it had only agile attacks, its jaws should deal one-third more damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The werecreature changes into its humanoid, hybrid, or animal shape. Each shape has a specific, persistent appearance. A true werecreature's natural form is its hybrid shape. In humanoid shape, the werecreature uses its original humanoid size, loses its jaws and claws Strikes, and gains a melee fist Strike that deals bludgeoning damage equal to the slashing damage dealt by its claw. In animal shape, its Speed and size change to that of the animal, it gains any special Strike effects of the animal that it didn't already have (such as Grab), and it loses its weapon Strikes.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Curse of the Werecreature",
+              "subtype": "ability",
+              "text": "This curse affects only humanoids. Saving Throw Fortitude DC is the standard DC for the werecreature's new level \u2013 1. On each full moon, the cursed creature must succeed at another Fortitude save or turn into the same kind of werecreature until dawn. The creature is under the GM's control and goes on a rampage for half the night before falling unconscious until dawn.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "curse",
+                    "aonid": 38,
+                    "game-obj": "Traits",
+                    "name": "curse",
+                    "type": "link"
+                  },
+                  "name": "curse",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Moon Frenzy",
+              "subtype": "ability",
+              "text": "When a full moon appears in the night sky, the werecreature must enter hybrid form, can't Change Shape thereafter, becomes one size larger, increases its reach by 5 feet, and increases the damage of its jaws Strike (or a similar Strike) by 2. When the moon sets or the sun rises, the werecreature returns to humanoid form and is fatigued for 2d4 hours.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divination",
+              "aonid": 47,
+              "game-obj": "Traits",
+              "name": "divination",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "curse",
+              "aonid": 38,
+              "game-obj": "Traits",
+              "name": "curse",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            }
+          ],
+          "name": "Werecreature Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 328",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 328",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 328,
+              "type": "source"
+            }
+          ],
+          "text": "All werecreatures gain the following abilities, some of which match an ability of the animal the werecreature transforms into. You might also need to adjust some abilities that conflict with the theme of the werecreature (such as abilities with a conflicting alignment trait).  \n**Senses** The werecreature gains all the senses of the animal.  \n**Animal Empathy** (divination, primal) A werecreature can communicate with animals of the same general kind.  \n**Claws** The werecreature gains a claw Strike (an agile unarmed attack that deals slashing damage). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.  \n**Jaws** The creature gains a jaws Strike (an unarmed attack that deals piercing damage) that inflicts its curse of the werecreature. If it had any non-agile attacks, the damage dealt by its jaws should be roughly the same as the damage dealt by those attacks. If it had only agile attacks, its jaws should deal one-third more damage.  \n**Change Shape** [#] (concentrate, polymorph, primal, transmutation) The werecreature changes into its humanoid, hybrid, or animal shape. Each shape has a specific, persistent appearance. A true werecreature's natural form is its hybrid shape. In humanoid shape, the werecreature uses its original humanoid size, loses its jaws and claws Strikes, and gains a melee fist Strike that deals bludgeoning damage equal to the slashing damage dealt by its claw. In animal shape, its Speed and size change to that of the animal, it gains any special Strike effects of the animal that it didn't already have (such as Grab), and it loses its weapon Strikes.  \n**Curse of the Werecreature** (curse, necromancy, primal) This curse affects only humanoids. Saving Throw Fortitude DC is the standard DC for the werecreature's new level \u2013 1. On each full moon, the cursed creature must succeed at another Fortitude save or turn into the same kind of werecreature until dawn. The creature is under the GM's control and goes on a rampage for half the night before falling unconscious until dawn.  \n**Moon Frenzy** (polymorph, primal, transmutation) When a full moon appears in the night sky, the werecreature must enter hybrid form, can't Change Shape thereafter, becomes one size larger, increases its reach by 5 feet, and increases the damage of its jaws Strike (or a similar Strike) by 2. When the moon sets or the sun rises, the werecreature returns to humanoid form and is fatigued for 2d4 hours.",
+          "type": "section"
+        },
         {
           "name": "Building Werecreatures",
           "sources": [

--- a/monster_families/bestiary/zombie.json
+++ b/monster_families/bestiary/zombie.json
@@ -30,176 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Disgusting Pustules",
-                "subtype": "ability",
-                "text": "The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. In either case, adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Feast",
-                "subtype": "ability",
-                "text": "If the zombie is adjacent to a helpless or unconscious creature, or a deceased creature that died in the past hour, the zombie can feast upon its flesh to heal itself. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, flst, or claw damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 104,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Plague-Ridden",
-                "subtype": "ability",
-                "text": "The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Rotting Aura",
-                "range": {
-                  "range": 10,
-                  "subtype": "range",
-                  "text": "within 10 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 damage as its wounds fester. This damage increases by 1d6 for every 6 levels the zombie has. Creatures that take a critical hit from the zombie also take this damage immediately.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Unkillable",
-                "subtype": "ability",
-                "text": "This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Zombie Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -210,6 +45,62 @@
                 "game-obj": "Rules",
                 "name": "Spell DC and Spell Attack Bonus",
                 "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 104,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -219,131 +110,75 @@
         ],
         "name": "Zombie Abilities",
         "subtype": "monster_family",
-        "text": "You can modify zombies with the following zombie abilities. Most zombies have one of these abilities; If you give a zombie more, you might want to increase its level and adjust its statistics. The DCs use the zombie's level from the Spell DC and Spell Attack Bonus table.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "prone",
-                    "aonid": 31,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "flat-footed",
-                    "aonid": 16,
-                    "game-obj": "Conditions",
-                    "name": "flat-footed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Trip",
-                    "aonid": 40,
-                    "game-obj": "Actions",
-                    "name": "Trip",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Crawls",
-                    "aonid": 76,
-                    "game-obj": "Actions",
-                    "name": "Crawls",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ankle Biter",
-                "subtype": "ability",
-                "text": "This zombie fights just as well on the ground as it does standing. While prone, the zombie isn't flat-footed, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "name": "Persistent Limbs",
-                "subtype": "ability",
-                "text": "The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Putrid Stench",
-                "range": {
-                  "range": 15,
-                  "subtype": "range",
-                  "text": "15 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The zombie's rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies' putrid stenches for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "olfactory",
-                      "aonid": 246,
-                      "game-obj": "Traits",
-                      "name": "olfactory",
-                      "type": "link"
-                    },
-                    "name": "olfactory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Unholy Speed",
-                "subtype": "ability",
-                "text": "The zombie gains a +10 status bonus to all its Speeds",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Additional Monster Abilities')].sections[?(@.name=='Bestiary 3')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "prone",
+                "aonid": 31,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "flat-footed",
+                "aonid": 16,
+                "game-obj": "Conditions",
+                "name": "flat-footed",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "Trip",
+                "aonid": 40,
+                "game-obj": "Actions",
+                "name": "Trip",
+                "type": "link"
+              },
+              {
+                "alt": "Crawls",
+                "aonid": 76,
+                "game-obj": "Actions",
+                "name": "Crawls",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "olfactory",
+                "aonid": 246,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -353,120 +188,61 @@
         ],
         "name": "Bestiary 3",
         "subtype": "monster_family",
-        "text": "You can modify zombies with the following zombie abilities, in addition to those found on page 340 of the *Bestiary*. Most zombies have one of these abilities; if you give a zombie more, you might want to increase its level and adjust its statistics.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "swarm",
-                    "aonid": 239,
-                    "game-obj": "Traits",
-                    "name": "swarm",
-                    "type": "link"
-                  }
-                ],
-                "name": "Infested",
-                "subtype": "ability",
-                "text": "The zombie's flesh is infested with swarming vermin. When the zombie is hit with a critical hit or destroyed, the swarm is set free. Its initiative is immediately after the zombie's. If the swarm is 4 or more levels lower than the zombie, it isn't worth XP (and doesn't add its XP to the encounter budget).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "acid",
-                    "formula": "1d12",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "acid",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "acid",
-                    "formula": "1d4",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "persistent acid damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent acid damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Spitting Zombie",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "range of 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The zombie spits acid as a ranged Strike with a range of 30 feet. This uses the highest attack bonus among the zombie's Strikes and deals 1d12 acid damage per 3 levels of the zombie (or 1d6 acid damage below level 3). On a critical hit, the target also takes 1d4 persistent acid damage per 3 levels of the zombie. Once used, the zombie must spend 1 action to cough up enough acid to use this ability again.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Grapples",
-                    "aonid": 35,
-                    "game-obj": "Actions",
-                    "name": "Grapples",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "grabbed",
-                    "aonid": 20,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 33,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Tearing Grapple",
-                "subtype": "ability",
-                "text": "The zombies work in groups to rip foes to pieces. Whenever a zombie with this ability successfully Grapples a foe that's already grabbed or restrained by another zombie with this ability, they violently struggle over the poor victim, dealing fist damage (or a similar Strike's damage if the zombie doesn't have a fist Strike). If the grapple is a critical success, the target takes double damage and ceases being grabbed or restrained by any other creatures. If the zombie has the Grab ability, using Grab deals half its fist Strike damage to the target.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Additional Monster Abilities')].sections[?(@.name=='Book of the Dead')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "swarm",
+                "aonid": 239,
+                "game-obj": "Traits",
+                "name": "swarm",
+                "type": "link"
+              },
+              {
+                "alt": "persistent acid damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent acid damage",
+                "type": "link"
+              },
+              {
+                "alt": "Grapples",
+                "aonid": 35,
+                "game-obj": "Actions",
+                "name": "Grapples",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -485,8 +261,612 @@
   "schema_version": 1.0,
   "sections": [
     {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Disgusting Pustules",
+          "subtype": "ability",
+          "text": "The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. In either case, adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save.",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Feast",
+          "subtype": "ability",
+          "text": "If the zombie is adjacent to a helpless or unconscious creature, or a deceased creature that died in the past hour, the zombie can feast upon its flesh to heal itself. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, flst, or claw damage.",
+          "traits": [
+            {
+              "link": {
+                "alt": "manipulate",
+                "aonid": 104,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              "name": "manipulate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Plague-Ridden",
+          "subtype": "ability",
+          "text": "The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie.",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Rotting Aura",
+          "range": {
+            "range": 10,
+            "subtype": "range",
+            "text": "within 10 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 damage as its wounds fester. This damage increases by 1d6 for every 6 levels the zombie has. Creatures that take a critical hit from the zombie also take this damage immediately.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Unkillable",
+          "subtype": "ability",
+          "text": "This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Spell DC and Spell Attack Bonus",
+          "aonid": 1020,
+          "game-obj": "Rules",
+          "name": "Spell DC and Spell Attack Bonus",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 104,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 206,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        }
+      ],
+      "name": "Zombie Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary pg. 340",
+            "aonid": 2,
+            "game-obj": "Sources",
+            "name": "Bestiary pg. 340",
+            "type": "link"
+          },
+          "name": "Bestiary",
+          "page": 340,
+          "type": "source"
+        }
+      ],
+      "text": "You can modify zombies with the following zombie abilities. Most zombies have one of these abilities; If you give a zombie more, you might want to increase its level and adjust its statistics. The DCs use the zombie's level from the Spell DC and Spell Attack Bonus table.  \n**Disgusting Pustules** (disease, necromancy) The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. In either case, adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save.  \n**Feast** [##] (manipulate) If the zombie is adjacent to a helpless or unconscious creature, or a deceased creature that died in the past hour, the zombie can feast upon its flesh to heal itself. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, flst, or claw damage.  \n**Plague-Ridden** (disease, necromancy) The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie.  \n**Rotting Aura** (aura, disease, necromancy) The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 damage as its wounds fester. This damage increases by 1d6 for every 6 levels the zombie has. Creatures that take a critical hit from the zombie also take this damage immediately.  \n**Unkillable** This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
+      "type": "section"
+    },
+    {
       "name": "Additional Monster Abilities",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "prone",
+                  "aonid": 31,
+                  "game-obj": "Conditions",
+                  "name": "prone",
+                  "type": "link"
+                },
+                {
+                  "alt": "flat-footed",
+                  "aonid": 16,
+                  "game-obj": "Conditions",
+                  "name": "flat-footed",
+                  "type": "link"
+                },
+                {
+                  "alt": "Athletics",
+                  "aonid": 3,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                },
+                {
+                  "alt": "Trip",
+                  "aonid": 40,
+                  "game-obj": "Actions",
+                  "name": "Trip",
+                  "type": "link"
+                },
+                {
+                  "alt": "Crawls",
+                  "aonid": 76,
+                  "game-obj": "Actions",
+                  "name": "Crawls",
+                  "type": "link"
+                }
+              ],
+              "name": "Ankle Biter",
+              "subtype": "ability",
+              "text": "This zombie fights just as well on the ground as it does standing. While prone, the zombie isn't flat-footed, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "name": "Persistent Limbs",
+              "subtype": "ability",
+              "text": "The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "sickened 1",
+                  "aonid": 34,
+                  "game-obj": "Conditions",
+                  "name": "sickened 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Putrid Stench",
+              "range": {
+                "range": 15,
+                "subtype": "range",
+                "text": "15 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The zombie's rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies' putrid stenches for 1 minute.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "olfactory",
+                    "aonid": 246,
+                    "game-obj": "Traits",
+                    "name": "olfactory",
+                    "type": "link"
+                  },
+                  "name": "olfactory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Unholy Speed",
+              "subtype": "ability",
+              "text": "The zombie gains a +10 status bonus to all its Speeds",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "prone",
+              "aonid": 31,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            },
+            {
+              "alt": "flat-footed",
+              "aonid": 16,
+              "game-obj": "Conditions",
+              "name": "flat-footed",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "Trip",
+              "aonid": 40,
+              "game-obj": "Actions",
+              "name": "Trip",
+              "type": "link"
+            },
+            {
+              "alt": "Crawls",
+              "aonid": 76,
+              "game-obj": "Actions",
+              "name": "Crawls",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "olfactory",
+              "aonid": 246,
+              "game-obj": "Traits",
+              "name": "olfactory",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 1",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Bestiary 3",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 340",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 340",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 340,
+              "type": "source"
+            }
+          ],
+          "text": "You can modify zombies with the following zombie abilities, in addition to those found on page 340 of the *Bestiary*. Most zombies have one of these abilities; if you give a zombie more, you might want to increase its level and adjust its statistics.   \n  \n**Ankle Biter** This zombie fights just as well on the ground as it does standing. While prone, the zombie isn't flat-footed, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.   \n  \n**Persistent Limbs** The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.   \n  \n**Putrid Stench** (aura, olfactory) 15 feet. The zombie's rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies' putrid stenches for 1 minute.   \n  \n**Unholy Speed** The zombie gains a +10 status bonus to all its Speeds",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "swarm",
+                  "aonid": 239,
+                  "game-obj": "Traits",
+                  "name": "swarm",
+                  "type": "link"
+                }
+              ],
+              "name": "Infested",
+              "subtype": "ability",
+              "text": "The zombie's flesh is infested with swarming vermin. When the zombie is hit with a critical hit or destroyed, the swarm is set free. Its initiative is immediately after the zombie's. If the swarm is 4 or more levels lower than the zombie, it isn't worth XP (and doesn't add its XP to the encounter budget).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "acid",
+                  "formula": "1d12",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "acid",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "acid",
+                  "formula": "1d4",
+                  "persistent": true,
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "persistent acid damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent acid damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Spitting Zombie",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "range of 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The zombie spits acid as a ranged Strike with a range of 30 feet. This uses the highest attack bonus among the zombie's Strikes and deals 1d12 acid damage per 3 levels of the zombie (or 1d6 acid damage below level 3). On a critical hit, the target also takes 1d4 persistent acid damage per 3 levels of the zombie. Once used, the zombie must spend 1 action to cough up enough acid to use this ability again.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Grapples",
+                  "aonid": 35,
+                  "game-obj": "Actions",
+                  "name": "Grapples",
+                  "type": "link"
+                },
+                {
+                  "alt": "grabbed",
+                  "aonid": 20,
+                  "game-obj": "Conditions",
+                  "name": "grabbed",
+                  "type": "link"
+                },
+                {
+                  "alt": "restrained",
+                  "aonid": 33,
+                  "game-obj": "Conditions",
+                  "name": "restrained",
+                  "type": "link"
+                },
+                {
+                  "alt": "Grab",
+                  "aonid": 18,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Grab",
+                  "type": "link"
+                }
+              ],
+              "name": "Tearing Grapple",
+              "subtype": "ability",
+              "text": "The zombies work in groups to rip foes to pieces. Whenever a zombie with this ability successfully Grapples a foe that's already grabbed or restrained by another zombie with this ability, they violently struggle over the poor victim, dealing fist damage (or a similar Strike's damage if the zombie doesn't have a fist Strike). If the grapple is a critical success, the target takes double damage and ceases being grabbed or restrained by any other creatures. If the zombie has the Grab ability, using Grab deals half its fist Strike damage to the target.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "swarm",
+              "aonid": 239,
+              "game-obj": "Traits",
+              "name": "swarm",
+              "type": "link"
+            },
+            {
+              "alt": "persistent acid damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent acid damage",
+              "type": "link"
+            },
+            {
+              "alt": "Grapples",
+              "aonid": 35,
+              "game-obj": "Actions",
+              "name": "Grapples",
+              "type": "link"
+            },
+            {
+              "alt": "grabbed",
+              "aonid": 20,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 33,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Book of the Dead",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary pg. 340",
+                "aonid": 2,
+                "game-obj": "Sources",
+                "name": "Bestiary pg. 340",
+                "type": "link"
+              },
+              "name": "Bestiary",
+              "page": 340,
+              "type": "source"
+            }
+          ],
+          "text": "**Infested** The zombie's flesh is infested with swarming vermin. When the zombie is hit with a critical hit or destroyed, the swarm is set free. Its initiative is immediately after the zombie's. If the swarm is 4 or more levels lower than the zombie, it isn't worth XP (and doesn't add its XP to the encounter budget).  \n  \n**Spitting Zombie** The zombie spits acid as a ranged Strike with a range of 30 feet. This uses the highest attack bonus among the zombie's Strikes and deals 1d12 acid damage per 3 levels of the zombie (or 1d6 acid damage below level 3). On a critical hit, the target also takes 1d4 persistent acid damage per 3 levels of the zombie. Once used, the zombie must spend 1 action to cough up enough acid to use this ability again.  \n  \n**Tearing Grapple** The zombies work in groups to rip foes to pieces. Whenever a zombie with this ability successfully Grapples a foe that's already grabbed or restrained by another zombie with this ability, they violently struggle over the poor victim, dealing fist damage (or a similar Strike's damage if the zombie doesn't have a fist Strike). If the grapple is a critical success, the target takes double damage and ceases being grabbed or restrained by any other creatures. If the zombie has the Grab ability, using Grab deals half its fist Strike damage to the target.",
+          "type": "section"
+        },
         {
           "name": "Creating Zombies",
           "sources": [

--- a/monster_families/bestiary_2/dragon_brine.json
+++ b/monster_families/bestiary_2/dragon_brine.json
@@ -31,265 +31,111 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 147,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "lightning bolt",
-                            "aonid": 172,
-                            "game-obj": "Spells",
-                            "name": "lightning bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "lightning bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 289,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "animal messenger",
-                            "aonid": 11,
-                            "game-obj": "Spells",
-                            "name": "animal messenger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "animal messenger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 153,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water breathing",
-                            "aonid": 370,
-                            "game-obj": "Spells",
-                            "name": "water breathing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water breathing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create water",
-                            "aonid": 53,
-                            "game-obj": "Spells",
-                            "name": "create water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 140,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "negate aroma",
-                            "aonid": 206,
-                            "game-obj": "Spells",
-                            "name": "negate aroma",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "negate aroma",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 286,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 307,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "haste",
+                "aonid": 147,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "lightning bolt",
+                "aonid": 172,
+                "game-obj": "Spells",
+                "name": "lightning bolt",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 289,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "animal messenger",
+                "aonid": 11,
+                "game-obj": "Spells",
+                "name": "animal messenger",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 153,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "water breathing",
+                "aonid": 370,
+                "game-obj": "Spells",
+                "name": "water breathing",
+                "type": "link"
+              },
+              {
+                "alt": "create water",
+                "aonid": 53,
+                "game-obj": "Spells",
+                "name": "create water",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 140,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "negate aroma",
+                "aonid": 206,
+                "game-obj": "Spells",
+                "name": "negate aroma",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 286,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 307,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -305,215 +151,90 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as young brine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cone of cold",
-                            "aonid": 47,
-                            "game-obj": "Spells",
-                            "name": "cone of cold",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cone of cold",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "control water",
-                            "aonid": 51,
-                            "game-obj": "Spells",
-                            "name": "control water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "control water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mariner's curse",
-                            "aonid": 184,
-                            "game-obj": "Spells",
-                            "name": "mariner's curse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mariner's curse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "freedom of movement",
-                            "aonid": 128,
-                            "game-obj": "Spells",
-                            "name": "freedom of movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "freedom of movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucinatory terrain",
-                            "aonid": 145,
-                            "game-obj": "Spells",
-                            "name": "hallucinatory terrain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucinatory terrain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "solid fog",
-                            "aonid": 290,
-                            "game-obj": "Spells",
-                            "name": "solid fog",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "solid fog",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 286,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 307,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cone of cold",
+                "aonid": 47,
+                "game-obj": "Spells",
+                "name": "cone of cold",
+                "type": "link"
+              },
+              {
+                "alt": "control water",
+                "aonid": 51,
+                "game-obj": "Spells",
+                "name": "control water",
+                "type": "link"
+              },
+              {
+                "alt": "mariner's curse",
+                "aonid": 184,
+                "game-obj": "Spells",
+                "name": "mariner's curse",
+                "type": "link"
+              },
+              {
+                "alt": "freedom of movement",
+                "aonid": 128,
+                "game-obj": "Spells",
+                "name": "freedom of movement",
+                "type": "link"
+              },
+              {
+                "alt": "hallucinatory terrain",
+                "aonid": 145,
+                "game-obj": "Spells",
+                "name": "hallucinatory terrain",
+                "type": "link"
+              },
+              {
+                "alt": "solid fog",
+                "aonid": 290,
+                "game-obj": "Spells",
+                "name": "solid fog",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 286,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 307,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -529,253 +250,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as adult brine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 78,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "horrid wilting",
-                            "aonid": 152,
-                            "game-obj": "Spells",
-                            "name": "horrid wilting",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "horrid wilting",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 100,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "plane shift",
-                            "aonid": 222,
-                            "game-obj": "Spells",
-                            "name": "plane shift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "plane shift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 248,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "baleful polymorph",
-                            "aonid": 17,
-                            "game-obj": "Spells",
-                            "name": "baleful polymorph",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "baleful polymorph",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 289,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 286,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 307,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 78,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "horrid wilting",
+                "aonid": 152,
+                "game-obj": "Spells",
+                "name": "horrid wilting",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 100,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "plane shift",
+                "aonid": 222,
+                "game-obj": "Spells",
+                "name": "plane shift",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 248,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "baleful polymorph",
+                "aonid": 17,
+                "game-obj": "Spells",
+                "name": "baleful polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 289,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 286,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 307,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -817,6 +389,1105 @@
         }
       ],
       "text": "Brine dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "haste",
+          "aonid": 147,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "lightning bolt",
+          "aonid": 172,
+          "game-obj": "Spells",
+          "name": "lightning bolt",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 289,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "animal messenger",
+          "aonid": 11,
+          "game-obj": "Spells",
+          "name": "animal messenger",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 153,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "water breathing",
+          "aonid": 370,
+          "game-obj": "Spells",
+          "name": "water breathing",
+          "type": "link"
+        },
+        {
+          "alt": "create water",
+          "aonid": 53,
+          "game-obj": "Spells",
+          "name": "create water",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 140,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "negate aroma",
+          "aonid": 206,
+          "game-obj": "Spells",
+          "name": "negate aroma",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 286,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 307,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Young",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 86",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 86",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 86,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 147,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "lightning bolt",
+                      "aonid": 172,
+                      "game-obj": "Spells",
+                      "name": "lightning bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "lightning bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 289,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "animal messenger",
+                      "aonid": 11,
+                      "game-obj": "Spells",
+                      "name": "animal messenger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "animal messenger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 153,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water breathing",
+                      "aonid": 370,
+                      "game-obj": "Spells",
+                      "name": "water breathing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water breathing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create water",
+                      "aonid": 53,
+                      "game-obj": "Spells",
+                      "name": "create water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 140,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "negate aroma",
+                      "aonid": 206,
+                      "game-obj": "Spells",
+                      "name": "negate aroma",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "negate aroma",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 286,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 307,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 26, attack +20; **3rd** *haste*, *lightning bolt*, *slow*; **2nd** *animal messenger*, *humanoid form*, *water breathing*; **1st** *create water*, *grease*, *negate aroma*; **Cantrips (3rd)** *acid splash*, *detect magic*, *prestidigitation*, *sigil*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cone of cold",
+          "aonid": 47,
+          "game-obj": "Spells",
+          "name": "cone of cold",
+          "type": "link"
+        },
+        {
+          "alt": "control water",
+          "aonid": 51,
+          "game-obj": "Spells",
+          "name": "control water",
+          "type": "link"
+        },
+        {
+          "alt": "mariner's curse",
+          "aonid": 184,
+          "game-obj": "Spells",
+          "name": "mariner's curse",
+          "type": "link"
+        },
+        {
+          "alt": "freedom of movement",
+          "aonid": 128,
+          "game-obj": "Spells",
+          "name": "freedom of movement",
+          "type": "link"
+        },
+        {
+          "alt": "hallucinatory terrain",
+          "aonid": 145,
+          "game-obj": "Spells",
+          "name": "hallucinatory terrain",
+          "type": "link"
+        },
+        {
+          "alt": "solid fog",
+          "aonid": 290,
+          "game-obj": "Spells",
+          "name": "solid fog",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 286,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 307,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Adult",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 86",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 86",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 86,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as young brine dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cone of cold",
+                      "aonid": 47,
+                      "game-obj": "Spells",
+                      "name": "cone of cold",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cone of cold",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "control water",
+                      "aonid": 51,
+                      "game-obj": "Spells",
+                      "name": "control water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "control water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mariner's curse",
+                      "aonid": 184,
+                      "game-obj": "Spells",
+                      "name": "mariner's curse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mariner's curse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "freedom of movement",
+                      "aonid": 128,
+                      "game-obj": "Spells",
+                      "name": "freedom of movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "freedom of movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucinatory terrain",
+                      "aonid": 145,
+                      "game-obj": "Spells",
+                      "name": "hallucinatory terrain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucinatory terrain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "solid fog",
+                      "aonid": 290,
+                      "game-obj": "Spells",
+                      "name": "solid fog",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "solid fog",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 286,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 307,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 33, attack +26; as young brine dragon, plus **5th** *cone of cold*, *control water*, *mariner's curse*; **4th** *freedom of movement*, *hallucinatory terrain*, *solid fog*; **Cantrips (5th)** *acid splash*, *detect magic*, *prestidigitation*, *sigil*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 78,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "horrid wilting",
+          "aonid": 152,
+          "game-obj": "Spells",
+          "name": "horrid wilting",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 100,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "plane shift",
+          "aonid": 222,
+          "game-obj": "Spells",
+          "name": "plane shift",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 248,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "baleful polymorph",
+          "aonid": 17,
+          "game-obj": "Spells",
+          "name": "baleful polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 289,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 286,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 307,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient",
+      "sections": [
+        {
+          "name": "Rezlarabren",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 86",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 86",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 86,
+              "type": "source"
+            }
+          ],
+          "text": "A series of underwater caverns on Thoska Isle in the Ironbound Archipelago serves as Rezlarabren's lair. There she rules a tribe of ulat-kini who labor as miners. Her relationship with the Linnorm Kings is complex, and whether she views them as allies or enemies depends on her mood.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 86",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 86",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 86,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as adult brine dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 78,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "horrid wilting",
+                      "aonid": 152,
+                      "game-obj": "Spells",
+                      "name": "horrid wilting",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "horrid wilting",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 100,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "plane shift",
+                      "aonid": 222,
+                      "game-obj": "Spells",
+                      "name": "plane shift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "plane shift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 248,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "baleful polymorph",
+                      "aonid": 17,
+                      "game-obj": "Spells",
+                      "name": "baleful polymorph",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "baleful polymorph",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 289,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 286,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 307,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 38, attack +33; as adult brine dragon, plus **8th** *dispel magic*, *horrid wilting*; **7th** *energy aegis*, *plane shift*, *regenerate*; **6th** *baleful polymorph*, *slow*, *true seeing*; **Cantrips (8th)** *acid splash*, *detect magic*, *prestidigitation*, *sigil*, *stabilize*",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_2/dragon_cloud.json
+++ b/monster_families/bestiary_2/dragon_cloud.json
@@ -31,318 +31,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 23,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "freedom of movement",
-                            "aonid": 128,
-                            "game-obj": "Spells",
-                            "name": "freedom of movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "freedom of movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucinatory terrain",
-                            "aonid": 145,
-                            "game-obj": "Spells",
-                            "name": "hallucinatory terrain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucinatory terrain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "speak with plants",
-                            "aonid": 294,
-                            "game-obj": "Spells",
-                            "name": "speak with plants",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "speak with plants",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 94,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 147,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stinking cloud",
-                            "aonid": 309,
-                            "game-obj": "Spells",
-                            "name": "stinking cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stinking cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "animal messenger",
-                            "aonid": 11,
-                            "game-obj": "Spells",
-                            "name": "animal messenger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "animal messenger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "faerie fire",
-                            "aonid": 107,
-                            "game-obj": "Spells",
-                            "name": "faerie fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "faerie fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "speak with animals",
-                            "aonid": 293,
-                            "game-obj": "Spells",
-                            "name": "speak with animals",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "speak with animals",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "feather fall",
-                            "aonid": 111,
-                            "game-obj": "Spells",
-                            "name": "feather fall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "feather fall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "negate aroma",
-                            "aonid": 206,
-                            "game-obj": "Spells",
-                            "name": "negate aroma",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "negate aroma",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shocking grasp",
-                            "aonid": 283,
-                            "game-obj": "Spells",
-                            "name": "shocking grasp",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shocking grasp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dancing lights",
-                            "aonid": 58,
-                            "game-obj": "Spells",
-                            "name": "dancing lights",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dancing lights",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 97,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "freedom of movement",
+                "aonid": 128,
+                "game-obj": "Spells",
+                "name": "freedom of movement",
+                "type": "link"
+              },
+              {
+                "alt": "hallucinatory terrain",
+                "aonid": 145,
+                "game-obj": "Spells",
+                "name": "hallucinatory terrain",
+                "type": "link"
+              },
+              {
+                "alt": "speak with plants",
+                "aonid": 294,
+                "game-obj": "Spells",
+                "name": "speak with plants",
+                "type": "link"
+              },
+              {
+                "alt": "earthbind",
+                "aonid": 94,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 147,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "stinking cloud",
+                "aonid": 309,
+                "game-obj": "Spells",
+                "name": "stinking cloud",
+                "type": "link"
+              },
+              {
+                "alt": "animal messenger",
+                "aonid": 11,
+                "game-obj": "Spells",
+                "name": "animal messenger",
+                "type": "link"
+              },
+              {
+                "alt": "faerie fire",
+                "aonid": 107,
+                "game-obj": "Spells",
+                "name": "faerie fire",
+                "type": "link"
+              },
+              {
+                "alt": "speak with animals",
+                "aonid": 293,
+                "game-obj": "Spells",
+                "name": "speak with animals",
+                "type": "link"
+              },
+              {
+                "alt": "feather fall",
+                "aonid": 111,
+                "game-obj": "Spells",
+                "name": "feather fall",
+                "type": "link"
+              },
+              {
+                "alt": "negate aroma",
+                "aonid": 206,
+                "game-obj": "Spells",
+                "name": "negate aroma",
+                "type": "link"
+              },
+              {
+                "alt": "shocking grasp",
+                "aonid": 283,
+                "game-obj": "Spells",
+                "name": "shocking grasp",
+                "type": "link"
+              },
+              {
+                "alt": "dancing lights",
+                "aonid": 58,
+                "game-obj": "Spells",
+                "name": "dancing lights",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 97,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -358,215 +172,90 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as young cloud dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 29,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heal",
-                            "aonid": 148,
-                            "game-obj": "Spells",
-                            "name": "heal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 289,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 19,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "death ward",
-                            "aonid": 64,
-                            "game-obj": "Spells",
-                            "name": "death ward",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "death ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "passwall",
-                            "aonid": 216,
-                            "game-obj": "Spells",
-                            "name": "passwall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "passwall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dancing lights",
-                            "aonid": 58,
-                            "game-obj": "Spells",
-                            "name": "dancing lights",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dancing lights",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 97,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "heal",
+                "aonid": 148,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 289,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 19,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "death ward",
+                "aonid": 64,
+                "game-obj": "Spells",
+                "name": "death ward",
+                "type": "link"
+              },
+              {
+                "alt": "passwall",
+                "aonid": 216,
+                "game-obj": "Spells",
+                "name": "passwall",
+                "type": "link"
+              },
+              {
+                "alt": "dancing lights",
+                "aonid": 58,
+                "game-obj": "Spells",
+                "name": "dancing lights",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 97,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -582,253 +271,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as adult cloud dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heal",
-                            "aonid": 148,
-                            "game-obj": "Spells",
-                            "name": "heal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "storm of vengeance",
-                            "aonid": 313,
-                            "game-obj": "Spells",
-                            "name": "storm of vengeance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "storm of vengeance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 78,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 201,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "punishing winds",
-                            "aonid": 240,
-                            "game-obj": "Spells",
-                            "name": "punishing winds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "punishing winds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 100,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "plane shift",
-                            "aonid": 222,
-                            "game-obj": "Spells",
-                            "name": "plane shift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "plane shift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered pack",
-                            "aonid": 350,
-                            "game-obj": "Spells",
-                            "name": "unfettered pack",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered pack",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dancing lights",
-                            "aonid": 58,
-                            "game-obj": "Spells",
-                            "name": "dancing lights",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dancing lights",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 97,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "heal",
+                "aonid": 148,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
+              },
+              {
+                "alt": "storm of vengeance",
+                "aonid": 313,
+                "game-obj": "Spells",
+                "name": "storm of vengeance",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 78,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "moment of renewal",
+                "aonid": 201,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "punishing winds",
+                "aonid": 240,
+                "game-obj": "Spells",
+                "name": "punishing winds",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 100,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "plane shift",
+                "aonid": 222,
+                "game-obj": "Spells",
+                "name": "plane shift",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered pack",
+                "aonid": 350,
+                "game-obj": "Spells",
+                "name": "unfettered pack",
+                "type": "link"
+              },
+              {
+                "alt": "dancing lights",
+                "aonid": 58,
+                "game-obj": "Spells",
+                "name": "dancing lights",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 97,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -870,6 +410,1179 @@
         }
       ],
       "text": "Cloud dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "freedom of movement",
+          "aonid": 128,
+          "game-obj": "Spells",
+          "name": "freedom of movement",
+          "type": "link"
+        },
+        {
+          "alt": "hallucinatory terrain",
+          "aonid": 145,
+          "game-obj": "Spells",
+          "name": "hallucinatory terrain",
+          "type": "link"
+        },
+        {
+          "alt": "speak with plants",
+          "aonid": 294,
+          "game-obj": "Spells",
+          "name": "speak with plants",
+          "type": "link"
+        },
+        {
+          "alt": "earthbind",
+          "aonid": 94,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 147,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "stinking cloud",
+          "aonid": 309,
+          "game-obj": "Spells",
+          "name": "stinking cloud",
+          "type": "link"
+        },
+        {
+          "alt": "animal messenger",
+          "aonid": 11,
+          "game-obj": "Spells",
+          "name": "animal messenger",
+          "type": "link"
+        },
+        {
+          "alt": "faerie fire",
+          "aonid": 107,
+          "game-obj": "Spells",
+          "name": "faerie fire",
+          "type": "link"
+        },
+        {
+          "alt": "speak with animals",
+          "aonid": 293,
+          "game-obj": "Spells",
+          "name": "speak with animals",
+          "type": "link"
+        },
+        {
+          "alt": "feather fall",
+          "aonid": 111,
+          "game-obj": "Spells",
+          "name": "feather fall",
+          "type": "link"
+        },
+        {
+          "alt": "negate aroma",
+          "aonid": 206,
+          "game-obj": "Spells",
+          "name": "negate aroma",
+          "type": "link"
+        },
+        {
+          "alt": "shocking grasp",
+          "aonid": 283,
+          "game-obj": "Spells",
+          "name": "shocking grasp",
+          "type": "link"
+        },
+        {
+          "alt": "dancing lights",
+          "aonid": 58,
+          "game-obj": "Spells",
+          "name": "dancing lights",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 97,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        }
+      ],
+      "name": "Young",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 88",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 88",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 88,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 23,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "freedom of movement",
+                      "aonid": 128,
+                      "game-obj": "Spells",
+                      "name": "freedom of movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "freedom of movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucinatory terrain",
+                      "aonid": 145,
+                      "game-obj": "Spells",
+                      "name": "hallucinatory terrain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucinatory terrain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "speak with plants",
+                      "aonid": 294,
+                      "game-obj": "Spells",
+                      "name": "speak with plants",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "speak with plants",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 94,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 147,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stinking cloud",
+                      "aonid": 309,
+                      "game-obj": "Spells",
+                      "name": "stinking cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stinking cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "animal messenger",
+                      "aonid": 11,
+                      "game-obj": "Spells",
+                      "name": "animal messenger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "animal messenger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "faerie fire",
+                      "aonid": 107,
+                      "game-obj": "Spells",
+                      "name": "faerie fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "faerie fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "speak with animals",
+                      "aonid": 293,
+                      "game-obj": "Spells",
+                      "name": "speak with animals",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "speak with animals",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "feather fall",
+                      "aonid": 111,
+                      "game-obj": "Spells",
+                      "name": "feather fall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "feather fall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "negate aroma",
+                      "aonid": 206,
+                      "game-obj": "Spells",
+                      "name": "negate aroma",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "negate aroma",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shocking grasp",
+                      "aonid": 283,
+                      "game-obj": "Spells",
+                      "name": "shocking grasp",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shocking grasp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dancing lights",
+                      "aonid": 58,
+                      "game-obj": "Spells",
+                      "name": "dancing lights",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dancing lights",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 97,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 29, attack +23; **4th** *freedom of movement*, *hallucinatory terrain*, *speak with plants*; **3rd** *earthbind*, *haste*, *stinking cloud*; **2nd** *animal messenger*, *faerie fire*, *speak with animals*; **1st** *feather fall*, *negate aroma*, *shocking grasp*; **Cantrips (4th)** *dancing lights*, *detect magic*, *electric arc*, *prestidigitation*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "heal",
+          "aonid": 148,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 289,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 19,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "death ward",
+          "aonid": 64,
+          "game-obj": "Spells",
+          "name": "death ward",
+          "type": "link"
+        },
+        {
+          "alt": "passwall",
+          "aonid": 216,
+          "game-obj": "Spells",
+          "name": "passwall",
+          "type": "link"
+        },
+        {
+          "alt": "dancing lights",
+          "aonid": 58,
+          "game-obj": "Spells",
+          "name": "dancing lights",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 97,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        }
+      ],
+      "name": "Adult",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 88",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 88",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 88,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as young cloud dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 29,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heal",
+                      "aonid": 148,
+                      "game-obj": "Spells",
+                      "name": "heal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 289,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 19,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "death ward",
+                      "aonid": 64,
+                      "game-obj": "Spells",
+                      "name": "death ward",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "death ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "passwall",
+                      "aonid": 216,
+                      "game-obj": "Spells",
+                      "name": "passwall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "passwall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dancing lights",
+                      "aonid": 58,
+                      "game-obj": "Spells",
+                      "name": "dancing lights",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dancing lights",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 97,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 34, attack +29; as young cloud dragon, plus **6th** *heal*, *slow*, *true seeing*; **5th** *banishment*, *death ward*, *passwall*; **Cantrips (6th)** *dancing lights*, *detect magic*, *electric arc*, *prestidigitation*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "heal",
+          "aonid": 148,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        },
+        {
+          "alt": "storm of vengeance",
+          "aonid": 313,
+          "game-obj": "Spells",
+          "name": "storm of vengeance",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 78,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "moment of renewal",
+          "aonid": 201,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "punishing winds",
+          "aonid": 240,
+          "game-obj": "Spells",
+          "name": "punishing winds",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 100,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "plane shift",
+          "aonid": 222,
+          "game-obj": "Spells",
+          "name": "plane shift",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered pack",
+          "aonid": 350,
+          "game-obj": "Spells",
+          "name": "unfettered pack",
+          "type": "link"
+        },
+        {
+          "alt": "dancing lights",
+          "aonid": 58,
+          "game-obj": "Spells",
+          "name": "dancing lights",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 97,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient",
+      "sections": [
+        {
+          "name": "Zanembis",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 88",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 88",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "While most cloud dragons prefer solitude and avoid confrontations, Zanembis is an excellent example of how failed dragonslaying attempts can create problems. Previously content to dwell atop Angel Peak in the Mindspin Mountains, this cloud dragon has grown vengeful and violent in the wake of unexpected and unjustified attacks on his lair.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 88",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 88",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 88,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as adult cloud dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heal",
+                      "aonid": 148,
+                      "game-obj": "Spells",
+                      "name": "heal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "storm of vengeance",
+                      "aonid": 313,
+                      "game-obj": "Spells",
+                      "name": "storm of vengeance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "storm of vengeance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 78,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 201,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "punishing winds",
+                      "aonid": 240,
+                      "game-obj": "Spells",
+                      "name": "punishing winds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "punishing winds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 100,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "plane shift",
+                      "aonid": 222,
+                      "game-obj": "Spells",
+                      "name": "plane shift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "plane shift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered pack",
+                      "aonid": 350,
+                      "game-obj": "Spells",
+                      "name": "unfettered pack",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered pack",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dancing lights",
+                      "aonid": 58,
+                      "game-obj": "Spells",
+                      "name": "dancing lights",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dancing lights",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 97,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +36; as adult cloud dragon, plus **9th** *heal*, *storm of vengeance*; **8th** *dispel magic*, *moment of renewal*, *punishing winds*; **7th** *energy aegis*, *plane shift*, *unfettered pack*; **Cantrips (9th)** *dancing lights*, *detect magic*, *electric arc*, *prestidigitation*, *read aura*",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_2/dragon_crystal.json
+++ b/monster_families/bestiary_2/dragon_crystal.json
@@ -31,250 +31,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 25,
-                  "subtype": "save_dc",
-                  "text": "DC 25",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 94,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "meld into stone",
-                            "aonid": 188,
-                            "game-obj": "Spells",
-                            "name": "meld into stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "meld into stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "faerie fire",
-                            "aonid": 107,
-                            "game-obj": "Spells",
-                            "name": "faerie fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "faerie fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "glitterdust",
-                            "aonid": 136,
-                            "game-obj": "Spells",
-                            "name": "glitterdust",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "glitterdust",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shatter",
-                            "aonid": 279,
-                            "game-obj": "Spells",
-                            "name": "shatter",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shatter",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 140,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mending",
-                            "aonid": 189,
-                            "game-obj": "Spells",
-                            "name": "mending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pass without trace",
-                            "aonid": 215,
-                            "game-obj": "Spells",
-                            "name": "pass without trace",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pass without trace",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 171,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 334,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "earthbind",
+                "aonid": 94,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "meld into stone",
+                "aonid": 188,
+                "game-obj": "Spells",
+                "name": "meld into stone",
+                "type": "link"
+              },
+              {
+                "alt": "faerie fire",
+                "aonid": 107,
+                "game-obj": "Spells",
+                "name": "faerie fire",
+                "type": "link"
+              },
+              {
+                "alt": "glitterdust",
+                "aonid": 136,
+                "game-obj": "Spells",
+                "name": "glitterdust",
+                "type": "link"
+              },
+              {
+                "alt": "shatter",
+                "aonid": 279,
+                "game-obj": "Spells",
+                "name": "shatter",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 140,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "mending",
+                "aonid": 189,
+                "game-obj": "Spells",
+                "name": "mending",
+                "type": "link"
+              },
+              {
+                "alt": "pass without trace",
+                "aonid": 215,
+                "game-obj": "Spells",
+                "name": "pass without trace",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 171,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 334,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -290,223 +144,90 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as young crystal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cloak of colors",
-                            "aonid": 41,
-                            "game-obj": "Spells",
-                            "name": "cloak of colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cloak of colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of stone",
-                            "aonid": 365,
-                            "game-obj": "Spells",
-                            "name": "wall of stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucinatory terrain",
-                            "aonid": 145,
-                            "game-obj": "Spells",
-                            "name": "hallucinatory terrain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucinatory terrain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shape stone",
-                            "aonid": 276,
-                            "game-obj": "Spells",
-                            "name": "shape stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shape stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stoneskin",
-                            "aonid": 312,
-                            "game-obj": "Spells",
-                            "name": "stoneskin",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stoneskin",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 147,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dancing lights",
-                            "aonid": 58,
-                            "game-obj": "Spells",
-                            "name": "dancing lights",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dancing lights",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 171,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 334,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cloak of colors",
+                "aonid": 41,
+                "game-obj": "Spells",
+                "name": "cloak of colors",
+                "type": "link"
+              },
+              {
+                "alt": "wall of stone",
+                "aonid": 365,
+                "game-obj": "Spells",
+                "name": "wall of stone",
+                "type": "link"
+              },
+              {
+                "alt": "hallucinatory terrain",
+                "aonid": 145,
+                "game-obj": "Spells",
+                "name": "hallucinatory terrain",
+                "type": "link"
+              },
+              {
+                "alt": "shape stone",
+                "aonid": 276,
+                "game-obj": "Spells",
+                "name": "shape stone",
+                "type": "link"
+              },
+              {
+                "alt": "stoneskin",
+                "aonid": 312,
+                "game-obj": "Spells",
+                "name": "stoneskin",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 147,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "dancing lights",
+                "aonid": 58,
+                "game-obj": "Spells",
+                "name": "dancing lights",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 171,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 334,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -522,238 +243,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as adult crystal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 37,
-                  "subtype": "save_dc",
-                  "text": "DC 37",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 100,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spell turning",
-                            "aonid": 297,
-                            "game-obj": "Spells",
-                            "name": "spell turning",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spell turning",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "volcanic eruption",
-                            "aonid": 360,
-                            "game-obj": "Spells",
-                            "name": "volcanic eruption",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "volcanic eruption",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "flesh to stone",
-                            "aonid": 123,
-                            "game-obj": "Spells",
-                            "name": "flesh to stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "flesh to stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stone tell",
-                            "aonid": 310,
-                            "game-obj": "Spells",
-                            "name": "stone tell",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stone tell",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chromatic wall",
-                            "aonid": 37,
-                            "game-obj": "Spells",
-                            "name": "chromatic wall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chromatic wall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dancing lights",
-                            "aonid": 58,
-                            "game-obj": "Spells",
-                            "name": "dancing lights",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dancing lights",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 171,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 334,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "energy aegis",
+                "aonid": 100,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "spell turning",
+                "aonid": 297,
+                "game-obj": "Spells",
+                "name": "spell turning",
+                "type": "link"
+              },
+              {
+                "alt": "volcanic eruption",
+                "aonid": 360,
+                "game-obj": "Spells",
+                "name": "volcanic eruption",
+                "type": "link"
+              },
+              {
+                "alt": "flesh to stone",
+                "aonid": 123,
+                "game-obj": "Spells",
+                "name": "flesh to stone",
+                "type": "link"
+              },
+              {
+                "alt": "stone tell",
+                "aonid": 310,
+                "game-obj": "Spells",
+                "name": "stone tell",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "chromatic wall",
+                "aonid": 37,
+                "game-obj": "Spells",
+                "name": "chromatic wall",
+                "type": "link"
+              },
+              {
+                "alt": "dancing lights",
+                "aonid": 58,
+                "game-obj": "Spells",
+                "name": "dancing lights",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 171,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 334,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -795,6 +375,1069 @@
         }
       ],
       "text": "Crystal dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "earthbind",
+          "aonid": 94,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "meld into stone",
+          "aonid": 188,
+          "game-obj": "Spells",
+          "name": "meld into stone",
+          "type": "link"
+        },
+        {
+          "alt": "faerie fire",
+          "aonid": 107,
+          "game-obj": "Spells",
+          "name": "faerie fire",
+          "type": "link"
+        },
+        {
+          "alt": "glitterdust",
+          "aonid": 136,
+          "game-obj": "Spells",
+          "name": "glitterdust",
+          "type": "link"
+        },
+        {
+          "alt": "shatter",
+          "aonid": 279,
+          "game-obj": "Spells",
+          "name": "shatter",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 140,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "mending",
+          "aonid": 189,
+          "game-obj": "Spells",
+          "name": "mending",
+          "type": "link"
+        },
+        {
+          "alt": "pass without trace",
+          "aonid": 215,
+          "game-obj": "Spells",
+          "name": "pass without trace",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 171,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 334,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Young",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 91",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 91",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 91,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 25,
+            "subtype": "save_dc",
+            "text": "DC 25",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 94,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "meld into stone",
+                      "aonid": 188,
+                      "game-obj": "Spells",
+                      "name": "meld into stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "meld into stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "faerie fire",
+                      "aonid": 107,
+                      "game-obj": "Spells",
+                      "name": "faerie fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "faerie fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "glitterdust",
+                      "aonid": 136,
+                      "game-obj": "Spells",
+                      "name": "glitterdust",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "glitterdust",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shatter",
+                      "aonid": 279,
+                      "game-obj": "Spells",
+                      "name": "shatter",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shatter",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 140,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mending",
+                      "aonid": 189,
+                      "game-obj": "Spells",
+                      "name": "mending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pass without trace",
+                      "aonid": 215,
+                      "game-obj": "Spells",
+                      "name": "pass without trace",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pass without trace",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 171,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 334,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 25, attack +18; **3rd** *earthbind*, *meld into stone*; **2nd** *faerie fire*, *glitterdust*, *shatter*; **1st** *grease*, *mending*, *pass without trace*; **Cantrips (3rd)** *acid splash*, *detect magic*, *light*, *prestidigitation*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cloak of colors",
+          "aonid": 41,
+          "game-obj": "Spells",
+          "name": "cloak of colors",
+          "type": "link"
+        },
+        {
+          "alt": "wall of stone",
+          "aonid": 365,
+          "game-obj": "Spells",
+          "name": "wall of stone",
+          "type": "link"
+        },
+        {
+          "alt": "hallucinatory terrain",
+          "aonid": 145,
+          "game-obj": "Spells",
+          "name": "hallucinatory terrain",
+          "type": "link"
+        },
+        {
+          "alt": "shape stone",
+          "aonid": 276,
+          "game-obj": "Spells",
+          "name": "shape stone",
+          "type": "link"
+        },
+        {
+          "alt": "stoneskin",
+          "aonid": 312,
+          "game-obj": "Spells",
+          "name": "stoneskin",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 147,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "dancing lights",
+          "aonid": 58,
+          "game-obj": "Spells",
+          "name": "dancing lights",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 171,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 334,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Adult",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 91",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 91",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 91,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as young crystal dragon"
+          ],
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cloak of colors",
+                      "aonid": 41,
+                      "game-obj": "Spells",
+                      "name": "cloak of colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cloak of colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of stone",
+                      "aonid": 365,
+                      "game-obj": "Spells",
+                      "name": "wall of stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucinatory terrain",
+                      "aonid": 145,
+                      "game-obj": "Spells",
+                      "name": "hallucinatory terrain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucinatory terrain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shape stone",
+                      "aonid": 276,
+                      "game-obj": "Spells",
+                      "name": "shape stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shape stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stoneskin",
+                      "aonid": 312,
+                      "game-obj": "Spells",
+                      "name": "stoneskin",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stoneskin",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 147,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dancing lights",
+                      "aonid": 58,
+                      "game-obj": "Spells",
+                      "name": "dancing lights",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dancing lights",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 171,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 334,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 30, attack +24; as young crystal dragon, plus **5th** *cloak of colors*, *wall of stone*; **4th** *hallucinatory terrain*, *shape stone*, *stoneskin*; **3rd** *haste*; **Cantrips (5th)** *dancing lights*, *detect magic*, *light*, *prestidigitation*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "energy aegis",
+          "aonid": 100,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "spell turning",
+          "aonid": 297,
+          "game-obj": "Spells",
+          "name": "spell turning",
+          "type": "link"
+        },
+        {
+          "alt": "volcanic eruption",
+          "aonid": 360,
+          "game-obj": "Spells",
+          "name": "volcanic eruption",
+          "type": "link"
+        },
+        {
+          "alt": "flesh to stone",
+          "aonid": 123,
+          "game-obj": "Spells",
+          "name": "flesh to stone",
+          "type": "link"
+        },
+        {
+          "alt": "stone tell",
+          "aonid": 310,
+          "game-obj": "Spells",
+          "name": "stone tell",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "chromatic wall",
+          "aonid": 37,
+          "game-obj": "Spells",
+          "name": "chromatic wall",
+          "type": "link"
+        },
+        {
+          "alt": "dancing lights",
+          "aonid": 58,
+          "game-obj": "Spells",
+          "name": "dancing lights",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 171,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 334,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient",
+      "sections": [
+        {
+          "name": "Shardizhad",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 91",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 91",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 91,
+              "type": "source"
+            }
+          ],
+          "text": "Still a relatively young crystal dragon, Shardizhad has already made a name for herself in the city of Wati in Osirion. She has taken on a somewhat unusual role as a shopkeeper in that city's necropolis, where she's eager to trade magic items she's collected for more gems and valuable stones.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 91",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 91",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 91,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as adult crystal dragon"
+          ],
+          "saving_throw": {
+            "dc": 37,
+            "subtype": "save_dc",
+            "text": "DC 37",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 100,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spell turning",
+                      "aonid": 297,
+                      "game-obj": "Spells",
+                      "name": "spell turning",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spell turning",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "volcanic eruption",
+                      "aonid": 360,
+                      "game-obj": "Spells",
+                      "name": "volcanic eruption",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "volcanic eruption",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "flesh to stone",
+                      "aonid": 123,
+                      "game-obj": "Spells",
+                      "name": "flesh to stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "flesh to stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stone tell",
+                      "aonid": 310,
+                      "game-obj": "Spells",
+                      "name": "stone tell",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stone tell",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chromatic wall",
+                      "aonid": 37,
+                      "game-obj": "Spells",
+                      "name": "chromatic wall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chromatic wall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dancing lights",
+                      "aonid": 58,
+                      "game-obj": "Spells",
+                      "name": "dancing lights",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dancing lights",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 171,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 334,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 37, attack +32; as adult crystal dragon, plus **7th** *energy aegis*, *spell turning*, *volcanic eruption*; **6th** *flesh to stone*, *stone tell*, *true seeing*; **5th** *chromatic wall*; **Cantrips (7th)** *dancing lights*, *detect magic*, *light*, *prestidigitation*, *telekinetic projectile*",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_2/dragon_magma.json
+++ b/monster_families/bestiary_2/dragon_magma.json
@@ -31,303 +31,125 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stoneskin",
-                            "aonid": 312,
-                            "game-obj": "Spells",
-                            "name": "stoneskin",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stoneskin",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of fire",
-                            "aonid": 362,
-                            "game-obj": "Spells",
-                            "name": "wall of fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 147,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 289,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stinking cloud",
-                            "aonid": 309,
-                            "game-obj": "Spells",
-                            "name": "stinking cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stinking cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "glitterdust",
-                            "aonid": 136,
-                            "game-obj": "Spells",
-                            "name": "glitterdust",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "glitterdust",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "obscuring mist",
-                            "aonid": 210,
-                            "game-obj": "Spells",
-                            "name": "obscuring mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "obscuring mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "restore senses",
-                            "aonid": 259,
-                            "game-obj": "Spells",
-                            "name": "restore senses",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "restore senses",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "air bubble",
-                            "aonid": 5,
-                            "game-obj": "Spells",
-                            "name": "air bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "air bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 140,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pass without trace",
-                            "aonid": 215,
-                            "game-obj": "Spells",
-                            "name": "pass without trace",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pass without trace",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "produce flame",
-                            "aonid": 236,
-                            "game-obj": "Spells",
-                            "name": "produce flame",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "produce flame",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tanglefoot",
-                            "aonid": 330,
-                            "game-obj": "Spells",
-                            "name": "tanglefoot",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tanglefoot",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "stoneskin",
+                "aonid": 312,
+                "game-obj": "Spells",
+                "name": "stoneskin",
+                "type": "link"
+              },
+              {
+                "alt": "wall of fire",
+                "aonid": 362,
+                "game-obj": "Spells",
+                "name": "wall of fire",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 147,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 289,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "stinking cloud",
+                "aonid": 309,
+                "game-obj": "Spells",
+                "name": "stinking cloud",
+                "type": "link"
+              },
+              {
+                "alt": "glitterdust",
+                "aonid": 136,
+                "game-obj": "Spells",
+                "name": "glitterdust",
+                "type": "link"
+              },
+              {
+                "alt": "obscuring mist",
+                "aonid": 210,
+                "game-obj": "Spells",
+                "name": "obscuring mist",
+                "type": "link"
+              },
+              {
+                "alt": "restore senses",
+                "aonid": 259,
+                "game-obj": "Spells",
+                "name": "restore senses",
+                "type": "link"
+              },
+              {
+                "alt": "air bubble",
+                "aonid": 5,
+                "game-obj": "Spells",
+                "name": "air bubble",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 140,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "pass without trace",
+                "aonid": 215,
+                "game-obj": "Spells",
+                "name": "pass without trace",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "produce flame",
+                "aonid": 236,
+                "game-obj": "Spells",
+                "name": "produce flame",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tanglefoot",
+                "aonid": 330,
+                "game-obj": "Spells",
+                "name": "tanglefoot",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -343,223 +165,90 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as young magma dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fire seeds",
-                            "aonid": 117,
-                            "game-obj": "Spells",
-                            "name": "fire seeds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fire seeds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cloudkill",
-                            "aonid": 42,
-                            "game-obj": "Spells",
-                            "name": "cloudkill",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cloudkill",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "elemental form",
-                            "aonid": 98,
-                            "game-obj": "Spells",
-                            "name": "elemental form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "elemental form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "flame strike",
-                            "aonid": 120,
-                            "game-obj": "Spells",
-                            "name": "flame strike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "flame strike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucinatory terrain",
-                            "aonid": 145,
-                            "game-obj": "Spells",
-                            "name": "hallucinatory terrain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucinatory terrain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "produce flame",
-                            "aonid": 236,
-                            "game-obj": "Spells",
-                            "name": "produce flame",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "produce flame",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tanglefoot",
-                            "aonid": 330,
-                            "game-obj": "Spells",
-                            "name": "tanglefoot",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tanglefoot",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fire seeds",
+                "aonid": 117,
+                "game-obj": "Spells",
+                "name": "fire seeds",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "cloudkill",
+                "aonid": 42,
+                "game-obj": "Spells",
+                "name": "cloudkill",
+                "type": "link"
+              },
+              {
+                "alt": "elemental form",
+                "aonid": 98,
+                "game-obj": "Spells",
+                "name": "elemental form",
+                "type": "link"
+              },
+              {
+                "alt": "flame strike",
+                "aonid": 120,
+                "game-obj": "Spells",
+                "name": "flame strike",
+                "type": "link"
+              },
+              {
+                "alt": "hallucinatory terrain",
+                "aonid": 145,
+                "game-obj": "Spells",
+                "name": "hallucinatory terrain",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "produce flame",
+                "aonid": 236,
+                "game-obj": "Spells",
+                "name": "produce flame",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tanglefoot",
+                "aonid": 330,
+                "game-obj": "Spells",
+                "name": "tanglefoot",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -575,238 +264,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as adult magma dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthquake",
-                            "aonid": 95,
-                            "game-obj": "Spells",
-                            "name": "earthquake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthquake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "horrid wilting",
-                            "aonid": 152,
-                            "game-obj": "Spells",
-                            "name": "horrid wilting",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "horrid wilting",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "power word stun",
-                            "aonid": 228,
-                            "game-obj": "Spells",
-                            "name": "power word stun",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "power word stun",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fiery body",
-                            "aonid": 115,
-                            "game-obj": "Spells",
-                            "name": "fiery body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fiery body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "plane shift",
-                            "aonid": 222,
-                            "game-obj": "Spells",
-                            "name": "plane shift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "plane shift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "volcanic eruption",
-                            "aonid": 360,
-                            "game-obj": "Spells",
-                            "name": "volcanic eruption",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "volcanic eruption",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "flesh to stone",
-                            "aonid": 123,
-                            "game-obj": "Spells",
-                            "name": "flesh to stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "flesh to stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "produce flame",
-                            "aonid": 236,
-                            "game-obj": "Spells",
-                            "name": "produce flame",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "produce flame",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tanglefoot",
-                            "aonid": 330,
-                            "game-obj": "Spells",
-                            "name": "tanglefoot",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tanglefoot",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "earthquake",
+                "aonid": 95,
+                "game-obj": "Spells",
+                "name": "earthquake",
+                "type": "link"
+              },
+              {
+                "alt": "horrid wilting",
+                "aonid": 152,
+                "game-obj": "Spells",
+                "name": "horrid wilting",
+                "type": "link"
+              },
+              {
+                "alt": "power word stun",
+                "aonid": 228,
+                "game-obj": "Spells",
+                "name": "power word stun",
+                "type": "link"
+              },
+              {
+                "alt": "fiery body",
+                "aonid": 115,
+                "game-obj": "Spells",
+                "name": "fiery body",
+                "type": "link"
+              },
+              {
+                "alt": "plane shift",
+                "aonid": 222,
+                "game-obj": "Spells",
+                "name": "plane shift",
+                "type": "link"
+              },
+              {
+                "alt": "volcanic eruption",
+                "aonid": 360,
+                "game-obj": "Spells",
+                "name": "volcanic eruption",
+                "type": "link"
+              },
+              {
+                "alt": "flesh to stone",
+                "aonid": 123,
+                "game-obj": "Spells",
+                "name": "flesh to stone",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "produce flame",
+                "aonid": 236,
+                "game-obj": "Spells",
+                "name": "produce flame",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tanglefoot",
+                "aonid": 330,
+                "game-obj": "Spells",
+                "name": "tanglefoot",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -848,6 +396,1143 @@
         }
       ],
       "text": "Magma dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "stoneskin",
+          "aonid": 312,
+          "game-obj": "Spells",
+          "name": "stoneskin",
+          "type": "link"
+        },
+        {
+          "alt": "wall of fire",
+          "aonid": 362,
+          "game-obj": "Spells",
+          "name": "wall of fire",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 147,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 289,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "stinking cloud",
+          "aonid": 309,
+          "game-obj": "Spells",
+          "name": "stinking cloud",
+          "type": "link"
+        },
+        {
+          "alt": "glitterdust",
+          "aonid": 136,
+          "game-obj": "Spells",
+          "name": "glitterdust",
+          "type": "link"
+        },
+        {
+          "alt": "obscuring mist",
+          "aonid": 210,
+          "game-obj": "Spells",
+          "name": "obscuring mist",
+          "type": "link"
+        },
+        {
+          "alt": "restore senses",
+          "aonid": 259,
+          "game-obj": "Spells",
+          "name": "restore senses",
+          "type": "link"
+        },
+        {
+          "alt": "air bubble",
+          "aonid": 5,
+          "game-obj": "Spells",
+          "name": "air bubble",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 140,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "pass without trace",
+          "aonid": 215,
+          "game-obj": "Spells",
+          "name": "pass without trace",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "produce flame",
+          "aonid": 236,
+          "game-obj": "Spells",
+          "name": "produce flame",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tanglefoot",
+          "aonid": 330,
+          "game-obj": "Spells",
+          "name": "tanglefoot",
+          "type": "link"
+        }
+      ],
+      "name": "Young",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 93",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 93",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 93,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stoneskin",
+                      "aonid": 312,
+                      "game-obj": "Spells",
+                      "name": "stoneskin",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stoneskin",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of fire",
+                      "aonid": 362,
+                      "game-obj": "Spells",
+                      "name": "wall of fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 147,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 289,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stinking cloud",
+                      "aonid": 309,
+                      "game-obj": "Spells",
+                      "name": "stinking cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stinking cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "glitterdust",
+                      "aonid": 136,
+                      "game-obj": "Spells",
+                      "name": "glitterdust",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "glitterdust",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "obscuring mist",
+                      "aonid": 210,
+                      "game-obj": "Spells",
+                      "name": "obscuring mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "obscuring mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "restore senses",
+                      "aonid": 259,
+                      "game-obj": "Spells",
+                      "name": "restore senses",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "restore senses",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "air bubble",
+                      "aonid": 5,
+                      "game-obj": "Spells",
+                      "name": "air bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "air bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 140,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pass without trace",
+                      "aonid": 215,
+                      "game-obj": "Spells",
+                      "name": "pass without trace",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pass without trace",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "produce flame",
+                      "aonid": 236,
+                      "game-obj": "Spells",
+                      "name": "produce flame",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "produce flame",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tanglefoot",
+                      "aonid": 330,
+                      "game-obj": "Spells",
+                      "name": "tanglefoot",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tanglefoot",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 28, attack +20; **4th** *stoneskin*, *wall of fire*; **3rd** *haste*, *slow*, *stinking cloud*; **2nd** *glitterdust*, *obscuring mist*, *restore senses*; **1st** *air bubble*, *grease*, *pass without trace*; **Cantrips (4th)** *detect magic*, *prestidigitation*, *produce flame*, *read aura*, *tanglefoot*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fire seeds",
+          "aonid": 117,
+          "game-obj": "Spells",
+          "name": "fire seeds",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "cloudkill",
+          "aonid": 42,
+          "game-obj": "Spells",
+          "name": "cloudkill",
+          "type": "link"
+        },
+        {
+          "alt": "elemental form",
+          "aonid": 98,
+          "game-obj": "Spells",
+          "name": "elemental form",
+          "type": "link"
+        },
+        {
+          "alt": "flame strike",
+          "aonid": 120,
+          "game-obj": "Spells",
+          "name": "flame strike",
+          "type": "link"
+        },
+        {
+          "alt": "hallucinatory terrain",
+          "aonid": 145,
+          "game-obj": "Spells",
+          "name": "hallucinatory terrain",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "produce flame",
+          "aonid": 236,
+          "game-obj": "Spells",
+          "name": "produce flame",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tanglefoot",
+          "aonid": 330,
+          "game-obj": "Spells",
+          "name": "tanglefoot",
+          "type": "link"
+        }
+      ],
+      "name": "Adult",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 93",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 93",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 93,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as young magma dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fire seeds",
+                      "aonid": 117,
+                      "game-obj": "Spells",
+                      "name": "fire seeds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fire seeds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cloudkill",
+                      "aonid": 42,
+                      "game-obj": "Spells",
+                      "name": "cloudkill",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cloudkill",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "elemental form",
+                      "aonid": 98,
+                      "game-obj": "Spells",
+                      "name": "elemental form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "elemental form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "flame strike",
+                      "aonid": 120,
+                      "game-obj": "Spells",
+                      "name": "flame strike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "flame strike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucinatory terrain",
+                      "aonid": 145,
+                      "game-obj": "Spells",
+                      "name": "hallucinatory terrain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucinatory terrain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "produce flame",
+                      "aonid": 236,
+                      "game-obj": "Spells",
+                      "name": "produce flame",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "produce flame",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tanglefoot",
+                      "aonid": 330,
+                      "game-obj": "Spells",
+                      "name": "tanglefoot",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tanglefoot",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 33, attack +25; as young magma dragon, plus **6th** *fire seeds*, *true seeing*; **5th** *cloudkill*, *elemental form*, *flame strike*; **4th** *hallucinatory terrain*; **Cantrips (6th)** *detect magic*, *prestidigitation*, *produce flame*, *read aura*, *tanglefoot*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "earthquake",
+          "aonid": 95,
+          "game-obj": "Spells",
+          "name": "earthquake",
+          "type": "link"
+        },
+        {
+          "alt": "horrid wilting",
+          "aonid": 152,
+          "game-obj": "Spells",
+          "name": "horrid wilting",
+          "type": "link"
+        },
+        {
+          "alt": "power word stun",
+          "aonid": 228,
+          "game-obj": "Spells",
+          "name": "power word stun",
+          "type": "link"
+        },
+        {
+          "alt": "fiery body",
+          "aonid": 115,
+          "game-obj": "Spells",
+          "name": "fiery body",
+          "type": "link"
+        },
+        {
+          "alt": "plane shift",
+          "aonid": 222,
+          "game-obj": "Spells",
+          "name": "plane shift",
+          "type": "link"
+        },
+        {
+          "alt": "volcanic eruption",
+          "aonid": 360,
+          "game-obj": "Spells",
+          "name": "volcanic eruption",
+          "type": "link"
+        },
+        {
+          "alt": "flesh to stone",
+          "aonid": 123,
+          "game-obj": "Spells",
+          "name": "flesh to stone",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "produce flame",
+          "aonid": 236,
+          "game-obj": "Spells",
+          "name": "produce flame",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tanglefoot",
+          "aonid": 330,
+          "game-obj": "Spells",
+          "name": "tanglefoot",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient",
+      "sections": [
+        {
+          "name": "Moschabbatt",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 93",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 93",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 93,
+              "type": "source"
+            }
+          ],
+          "text": "The ancient magma dragon Moschabbatt dwells in a vast chamber hidden within Droskar's Crag, the largest volcano in the Inner Sea region. Rumor holds that the dragon counts at least one legendary dwarven artifact among the priceless treasures of his vast hoard.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 93",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 93",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 93,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as adult magma dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthquake",
+                      "aonid": 95,
+                      "game-obj": "Spells",
+                      "name": "earthquake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthquake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "horrid wilting",
+                      "aonid": 152,
+                      "game-obj": "Spells",
+                      "name": "horrid wilting",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "horrid wilting",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "power word stun",
+                      "aonid": 228,
+                      "game-obj": "Spells",
+                      "name": "power word stun",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "power word stun",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fiery body",
+                      "aonid": 115,
+                      "game-obj": "Spells",
+                      "name": "fiery body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fiery body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "plane shift",
+                      "aonid": 222,
+                      "game-obj": "Spells",
+                      "name": "plane shift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "plane shift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "volcanic eruption",
+                      "aonid": 360,
+                      "game-obj": "Spells",
+                      "name": "volcanic eruption",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "volcanic eruption",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "flesh to stone",
+                      "aonid": 123,
+                      "game-obj": "Spells",
+                      "name": "flesh to stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "flesh to stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "produce flame",
+                      "aonid": 236,
+                      "game-obj": "Spells",
+                      "name": "produce flame",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "produce flame",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tanglefoot",
+                      "aonid": 330,
+                      "game-obj": "Spells",
+                      "name": "tanglefoot",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tanglefoot",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 42, attack +34; as adult magma dragon, plus **8th** *earthquake*, *horrid wilting*, *power word stun*; **7th** *fiery body*, *plane shift*, *volcanic eruption*; **6th** *flesh to stone*; **Cantrips (8th)** *detect magic*, *prestidigitation*, *produce flame*, *read aura*, *tanglefoot*",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_2/dragon_umbral.json
+++ b/monster_families/bestiary_2/dragon_umbral.json
@@ -40,318 +40,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gaseous form",
-                            "aonid": 129,
-                            "game-obj": "Spells",
-                            "name": "gaseous form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gaseous form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucinatory terrain",
-                            "aonid": 145,
-                            "game-obj": "Spells",
-                            "name": "hallucinatory terrain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucinatory terrain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nightmare",
-                            "aonid": 208,
-                            "game-obj": "Spells",
-                            "name": "nightmare",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nightmare",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bind undead",
-                            "aonid": 22,
-                            "game-obj": "Spells",
-                            "name": "bind undead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bind undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blindness",
-                            "aonid": 26,
-                            "game-obj": "Spells",
-                            "name": "blindness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blindness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 289,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "death knell",
-                            "aonid": 63,
-                            "game-obj": "Spells",
-                            "name": "death knell",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "death knell",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gentle repose",
-                            "aonid": 131,
-                            "game-obj": "Spells",
-                            "name": "gentle repose",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gentle repose",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 153,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "charm",
-                            "aonid": 34,
-                            "game-obj": "Spells",
-                            "name": "charm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "charm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "item facade",
-                            "aonid": 166,
-                            "game-obj": "Spells",
-                            "name": "item facade",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "item facade",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ray of enfeeblement",
-                            "aonid": 244,
-                            "game-obj": "Spells",
-                            "name": "ray of enfeeblement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ray of enfeeblement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chill touch",
-                            "aonid": 35,
-                            "game-obj": "Spells",
-                            "name": "chill touch",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chill touch",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ghost sound",
-                            "aonid": 132,
-                            "game-obj": "Spells",
-                            "name": "ghost sound",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ghost sound",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ray of frost",
-                            "aonid": 245,
-                            "game-obj": "Spells",
-                            "name": "ray of frost",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ray of frost",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 286,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "gaseous form",
+                "aonid": 129,
+                "game-obj": "Spells",
+                "name": "gaseous form",
+                "type": "link"
+              },
+              {
+                "alt": "hallucinatory terrain",
+                "aonid": 145,
+                "game-obj": "Spells",
+                "name": "hallucinatory terrain",
+                "type": "link"
+              },
+              {
+                "alt": "nightmare",
+                "aonid": 208,
+                "game-obj": "Spells",
+                "name": "nightmare",
+                "type": "link"
+              },
+              {
+                "alt": "bind undead",
+                "aonid": 22,
+                "game-obj": "Spells",
+                "name": "bind undead",
+                "type": "link"
+              },
+              {
+                "alt": "blindness",
+                "aonid": 26,
+                "game-obj": "Spells",
+                "name": "blindness",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 289,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "death knell",
+                "aonid": 63,
+                "game-obj": "Spells",
+                "name": "death knell",
+                "type": "link"
+              },
+              {
+                "alt": "gentle repose",
+                "aonid": 131,
+                "game-obj": "Spells",
+                "name": "gentle repose",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 153,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "charm",
+                "aonid": 34,
+                "game-obj": "Spells",
+                "name": "charm",
+                "type": "link"
+              },
+              {
+                "alt": "item facade",
+                "aonid": 166,
+                "game-obj": "Spells",
+                "name": "item facade",
+                "type": "link"
+              },
+              {
+                "alt": "ray of enfeeblement",
+                "aonid": 244,
+                "game-obj": "Spells",
+                "name": "ray of enfeeblement",
+                "type": "link"
+              },
+              {
+                "alt": "chill touch",
+                "aonid": 35,
+                "game-obj": "Spells",
+                "name": "chill touch",
+                "type": "link"
+              },
+              {
+                "alt": "ghost sound",
+                "aonid": 132,
+                "game-obj": "Spells",
+                "name": "ghost sound",
+                "type": "link"
+              },
+              {
+                "alt": "ray of frost",
+                "aonid": 245,
+                "game-obj": "Spells",
+                "name": "ray of frost",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 286,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -367,215 +181,90 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as young umbral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 35,
-                  "subtype": "save_dc",
-                  "text": "DC 35",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dominate",
-                            "aonid": 87,
-                            "game-obj": "Spells",
-                            "name": "dominate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dominate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vampiric exsanguination",
-                            "aonid": 353,
-                            "game-obj": "Spells",
-                            "name": "vampiric exsanguination",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vampiric exsanguination",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "black tentacles",
-                            "aonid": 23,
-                            "game-obj": "Spells",
-                            "name": "black tentacles",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "black tentacles",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shadow blast",
-                            "aonid": 273,
-                            "game-obj": "Spells",
-                            "name": "shadow blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shadow blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shadow siphon",
-                            "aonid": 274,
-                            "game-obj": "Spells",
-                            "name": "shadow siphon",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shadow siphon",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chill touch",
-                            "aonid": 35,
-                            "game-obj": "Spells",
-                            "name": "chill touch",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chill touch",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ghost sound",
-                            "aonid": 132,
-                            "game-obj": "Spells",
-                            "name": "ghost sound",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ghost sound",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ray of frost",
-                            "aonid": 245,
-                            "game-obj": "Spells",
-                            "name": "ray of frost",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ray of frost",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 286,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dominate",
+                "aonid": 87,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric exsanguination",
+                "aonid": 353,
+                "game-obj": "Spells",
+                "name": "vampiric exsanguination",
+                "type": "link"
+              },
+              {
+                "alt": "black tentacles",
+                "aonid": 23,
+                "game-obj": "Spells",
+                "name": "black tentacles",
+                "type": "link"
+              },
+              {
+                "alt": "shadow blast",
+                "aonid": 273,
+                "game-obj": "Spells",
+                "name": "shadow blast",
+                "type": "link"
+              },
+              {
+                "alt": "shadow siphon",
+                "aonid": 274,
+                "game-obj": "Spells",
+                "name": "shadow siphon",
+                "type": "link"
+              },
+              {
+                "alt": "chill touch",
+                "aonid": 35,
+                "game-obj": "Spells",
+                "name": "chill touch",
+                "type": "link"
+              },
+              {
+                "alt": "ghost sound",
+                "aonid": 132,
+                "game-obj": "Spells",
+                "name": "ghost sound",
+                "type": "link"
+              },
+              {
+                "alt": "ray of frost",
+                "aonid": 245,
+                "game-obj": "Spells",
+                "name": "ray of frost",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 286,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -591,268 +280,111 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as adult umbral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disjunction",
-                            "aonid": 77,
-                            "game-obj": "Spells",
-                            "name": "disjunction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disjunction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 186,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "weird",
-                            "aonid": 375,
-                            "game-obj": "Spells",
-                            "name": "weird",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "weird",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 73,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "horrid wilting",
-                            "aonid": 152,
-                            "game-obj": "Spells",
-                            "name": "horrid wilting",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "horrid wilting",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "maze",
-                            "aonid": 187,
-                            "game-obj": "Spells",
-                            "name": "maze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "maze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "eclipse burst",
-                            "aonid": 96,
-                            "game-obj": "Spells",
-                            "name": "eclipse burst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "eclipse burst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 185,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "plane shift",
-                            "aonid": 222,
-                            "game-obj": "Spells",
-                            "name": "plane shift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "plane shift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chill touch",
-                            "aonid": 35,
-                            "game-obj": "Spells",
-                            "name": "chill touch",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chill touch",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ghost sound",
-                            "aonid": 132,
-                            "game-obj": "Spells",
-                            "name": "ghost sound",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ghost sound",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ray of frost",
-                            "aonid": 245,
-                            "game-obj": "Spells",
-                            "name": "ray of frost",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ray of frost",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 286,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disjunction",
+                "aonid": 77,
+                "game-obj": "Spells",
+                "name": "disjunction",
+                "type": "link"
+              },
+              {
+                "alt": "massacre",
+                "aonid": 186,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
+              },
+              {
+                "alt": "weird",
+                "aonid": 375,
+                "game-obj": "Spells",
+                "name": "weird",
+                "type": "link"
+              },
+              {
+                "alt": "disappearance",
+                "aonid": 73,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "horrid wilting",
+                "aonid": 152,
+                "game-obj": "Spells",
+                "name": "horrid wilting",
+                "type": "link"
+              },
+              {
+                "alt": "maze",
+                "aonid": 187,
+                "game-obj": "Spells",
+                "name": "maze",
+                "type": "link"
+              },
+              {
+                "alt": "eclipse burst",
+                "aonid": 96,
+                "game-obj": "Spells",
+                "name": "eclipse burst",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 185,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "plane shift",
+                "aonid": 222,
+                "game-obj": "Spells",
+                "name": "plane shift",
+                "type": "link"
+              },
+              {
+                "alt": "chill touch",
+                "aonid": 35,
+                "game-obj": "Spells",
+                "name": "chill touch",
+                "type": "link"
+              },
+              {
+                "alt": "ghost sound",
+                "aonid": 132,
+                "game-obj": "Spells",
+                "name": "ghost sound",
+                "type": "link"
+              },
+              {
+                "alt": "ray of frost",
+                "aonid": 245,
+                "game-obj": "Spells",
+                "name": "ray of frost",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 286,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -920,6 +452,1173 @@
         }
       ],
       "text": "Umbral dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "gaseous form",
+          "aonid": 129,
+          "game-obj": "Spells",
+          "name": "gaseous form",
+          "type": "link"
+        },
+        {
+          "alt": "hallucinatory terrain",
+          "aonid": 145,
+          "game-obj": "Spells",
+          "name": "hallucinatory terrain",
+          "type": "link"
+        },
+        {
+          "alt": "nightmare",
+          "aonid": 208,
+          "game-obj": "Spells",
+          "name": "nightmare",
+          "type": "link"
+        },
+        {
+          "alt": "bind undead",
+          "aonid": 22,
+          "game-obj": "Spells",
+          "name": "bind undead",
+          "type": "link"
+        },
+        {
+          "alt": "blindness",
+          "aonid": 26,
+          "game-obj": "Spells",
+          "name": "blindness",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 289,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "death knell",
+          "aonid": 63,
+          "game-obj": "Spells",
+          "name": "death knell",
+          "type": "link"
+        },
+        {
+          "alt": "gentle repose",
+          "aonid": 131,
+          "game-obj": "Spells",
+          "name": "gentle repose",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 153,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "charm",
+          "aonid": 34,
+          "game-obj": "Spells",
+          "name": "charm",
+          "type": "link"
+        },
+        {
+          "alt": "item facade",
+          "aonid": 166,
+          "game-obj": "Spells",
+          "name": "item facade",
+          "type": "link"
+        },
+        {
+          "alt": "ray of enfeeblement",
+          "aonid": 244,
+          "game-obj": "Spells",
+          "name": "ray of enfeeblement",
+          "type": "link"
+        },
+        {
+          "alt": "chill touch",
+          "aonid": 35,
+          "game-obj": "Spells",
+          "name": "chill touch",
+          "type": "link"
+        },
+        {
+          "alt": "ghost sound",
+          "aonid": 132,
+          "game-obj": "Spells",
+          "name": "ghost sound",
+          "type": "link"
+        },
+        {
+          "alt": "ray of frost",
+          "aonid": 245,
+          "game-obj": "Spells",
+          "name": "ray of frost",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 286,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Young",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 95",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 95",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 95,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gaseous form",
+                      "aonid": 129,
+                      "game-obj": "Spells",
+                      "name": "gaseous form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gaseous form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucinatory terrain",
+                      "aonid": 145,
+                      "game-obj": "Spells",
+                      "name": "hallucinatory terrain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucinatory terrain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nightmare",
+                      "aonid": 208,
+                      "game-obj": "Spells",
+                      "name": "nightmare",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nightmare",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bind undead",
+                      "aonid": 22,
+                      "game-obj": "Spells",
+                      "name": "bind undead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bind undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blindness",
+                      "aonid": 26,
+                      "game-obj": "Spells",
+                      "name": "blindness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blindness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 289,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "death knell",
+                      "aonid": 63,
+                      "game-obj": "Spells",
+                      "name": "death knell",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "death knell",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gentle repose",
+                      "aonid": 131,
+                      "game-obj": "Spells",
+                      "name": "gentle repose",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gentle repose",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 153,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "charm",
+                      "aonid": 34,
+                      "game-obj": "Spells",
+                      "name": "charm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "charm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "item facade",
+                      "aonid": 166,
+                      "game-obj": "Spells",
+                      "name": "item facade",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "item facade",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ray of enfeeblement",
+                      "aonid": 244,
+                      "game-obj": "Spells",
+                      "name": "ray of enfeeblement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ray of enfeeblement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chill touch",
+                      "aonid": 35,
+                      "game-obj": "Spells",
+                      "name": "chill touch",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chill touch",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ghost sound",
+                      "aonid": 132,
+                      "game-obj": "Spells",
+                      "name": "ghost sound",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ghost sound",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ray of frost",
+                      "aonid": 245,
+                      "game-obj": "Spells",
+                      "name": "ray of frost",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ray of frost",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 286,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 29, attack +24; **4th** *gaseous form*, *hallucinatory terrain*, *nightmare*; **3rd** *bind undead*, *blindness*, *slow*; **2nd** *death knell*, *gentle repose*, *humanoid form*; **1st** *charm*, *item facade*, *ray of enfeeblement*; **Cantrips (4th)** *chill touch*, *ghost sound*, *ray of frost*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dominate",
+          "aonid": 87,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "vampiric exsanguination",
+          "aonid": 353,
+          "game-obj": "Spells",
+          "name": "vampiric exsanguination",
+          "type": "link"
+        },
+        {
+          "alt": "black tentacles",
+          "aonid": 23,
+          "game-obj": "Spells",
+          "name": "black tentacles",
+          "type": "link"
+        },
+        {
+          "alt": "shadow blast",
+          "aonid": 273,
+          "game-obj": "Spells",
+          "name": "shadow blast",
+          "type": "link"
+        },
+        {
+          "alt": "shadow siphon",
+          "aonid": 274,
+          "game-obj": "Spells",
+          "name": "shadow siphon",
+          "type": "link"
+        },
+        {
+          "alt": "chill touch",
+          "aonid": 35,
+          "game-obj": "Spells",
+          "name": "chill touch",
+          "type": "link"
+        },
+        {
+          "alt": "ghost sound",
+          "aonid": 132,
+          "game-obj": "Spells",
+          "name": "ghost sound",
+          "type": "link"
+        },
+        {
+          "alt": "ray of frost",
+          "aonid": 245,
+          "game-obj": "Spells",
+          "name": "ray of frost",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 286,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Adult",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 95",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 95",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 95,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as young umbral dragon"
+          ],
+          "saving_throw": {
+            "dc": 35,
+            "subtype": "save_dc",
+            "text": "DC 35",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dominate",
+                      "aonid": 87,
+                      "game-obj": "Spells",
+                      "name": "dominate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dominate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vampiric exsanguination",
+                      "aonid": 353,
+                      "game-obj": "Spells",
+                      "name": "vampiric exsanguination",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vampiric exsanguination",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "black tentacles",
+                      "aonid": 23,
+                      "game-obj": "Spells",
+                      "name": "black tentacles",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "black tentacles",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shadow blast",
+                      "aonid": 273,
+                      "game-obj": "Spells",
+                      "name": "shadow blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shadow blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shadow siphon",
+                      "aonid": 274,
+                      "game-obj": "Spells",
+                      "name": "shadow siphon",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shadow siphon",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chill touch",
+                      "aonid": 35,
+                      "game-obj": "Spells",
+                      "name": "chill touch",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chill touch",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ghost sound",
+                      "aonid": 132,
+                      "game-obj": "Spells",
+                      "name": "ghost sound",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ghost sound",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ray of frost",
+                      "aonid": 245,
+                      "game-obj": "Spells",
+                      "name": "ray of frost",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ray of frost",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 286,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 35, attack +30; as young umbral dragon, plus **6th** *dominate*, *true seeing*, *vampiric exsanguination*; **5th** *black tentacles*, *shadow blast*, *shadow siphon*; **Cantrips (6th)** *chill touch*, *ghost sound*, *ray of frost*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "disjunction",
+          "aonid": 77,
+          "game-obj": "Spells",
+          "name": "disjunction",
+          "type": "link"
+        },
+        {
+          "alt": "massacre",
+          "aonid": 186,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        },
+        {
+          "alt": "weird",
+          "aonid": 375,
+          "game-obj": "Spells",
+          "name": "weird",
+          "type": "link"
+        },
+        {
+          "alt": "disappearance",
+          "aonid": 73,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "horrid wilting",
+          "aonid": 152,
+          "game-obj": "Spells",
+          "name": "horrid wilting",
+          "type": "link"
+        },
+        {
+          "alt": "maze",
+          "aonid": 187,
+          "game-obj": "Spells",
+          "name": "maze",
+          "type": "link"
+        },
+        {
+          "alt": "eclipse burst",
+          "aonid": 96,
+          "game-obj": "Spells",
+          "name": "eclipse burst",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 185,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "plane shift",
+          "aonid": 222,
+          "game-obj": "Spells",
+          "name": "plane shift",
+          "type": "link"
+        },
+        {
+          "alt": "chill touch",
+          "aonid": 35,
+          "game-obj": "Spells",
+          "name": "chill touch",
+          "type": "link"
+        },
+        {
+          "alt": "ghost sound",
+          "aonid": 132,
+          "game-obj": "Spells",
+          "name": "ghost sound",
+          "type": "link"
+        },
+        {
+          "alt": "ray of frost",
+          "aonid": 245,
+          "game-obj": "Spells",
+          "name": "ray of frost",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 286,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 95",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 95",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 95,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as adult umbral dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disjunction",
+                      "aonid": 77,
+                      "game-obj": "Spells",
+                      "name": "disjunction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disjunction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 186,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "weird",
+                      "aonid": 375,
+                      "game-obj": "Spells",
+                      "name": "weird",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "weird",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 73,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "horrid wilting",
+                      "aonid": 152,
+                      "game-obj": "Spells",
+                      "name": "horrid wilting",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "horrid wilting",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "maze",
+                      "aonid": 187,
+                      "game-obj": "Spells",
+                      "name": "maze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "maze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "eclipse burst",
+                      "aonid": 96,
+                      "game-obj": "Spells",
+                      "name": "eclipse burst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "eclipse burst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 185,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "plane shift",
+                      "aonid": 222,
+                      "game-obj": "Spells",
+                      "name": "plane shift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "plane shift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chill touch",
+                      "aonid": 35,
+                      "game-obj": "Spells",
+                      "name": "chill touch",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chill touch",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ghost sound",
+                      "aonid": 132,
+                      "game-obj": "Spells",
+                      "name": "ghost sound",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ghost sound",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ray of frost",
+                      "aonid": 245,
+                      "game-obj": "Spells",
+                      "name": "ray of frost",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ray of frost",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 286,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +38; as adult umbral dragon, plus **9th** *disjunction*, *massacre*, *weird*; **8th** *disappearance*, *horrid wilting*, *maze*; **7th** *eclipse burst*, *mask of terror*, *plane shift*; **Cantrips (9th)** *chill touch*, *ghost sound*, *ray of frost*, *read aura*, *sigil*",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_2/geniekin.json
+++ b/monster_families/bestiary_2/geniekin.json
@@ -39,135 +39,98 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fumesoul",
-                    "aonid": 2591,
-                    "game-obj": "Feats",
-                    "name": "fumesoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "smokesoul",
-                    "aonid": 2592,
-                    "game-obj": "Feats",
-                    "name": "smokesoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stormsoul",
-                    "aonid": 2593,
-                    "game-obj": "Feats",
-                    "name": "stormsoul",
-                    "type": "link"
-                  }
-                ],
-                "name": "Air",
-                "subtype": "ability",
-                "text": ": fumesoul (miasma sylph), smokesoul (haze sylph), stormsoul (lightning sylph)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "dustsoul",
-                    "aonid": 2565,
-                    "game-obj": "Feats",
-                    "name": "dustsoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "gemsoul",
-                    "aonid": 2567,
-                    "game-obj": "Feats",
-                    "name": "gemsoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "miresoul",
-                    "aonid": 2568,
-                    "game-obj": "Feats",
-                    "name": "miresoul",
-                    "type": "link"
-                  }
-                ],
-                "name": "Earth",
-                "subtype": "ability",
-                "text": ": dustsoul (soil oread), gemsoul (crystal oread), miresoul (mud oread)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "brightsoul",
-                    "aonid": 2551,
-                    "game-obj": "Feats",
-                    "name": "brightsoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "cindersoul",
-                    "aonid": 2552,
-                    "game-obj": "Feats",
-                    "name": "cindersoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "lavasoul",
-                    "aonid": 2555,
-                    "game-obj": "Feats",
-                    "name": "lavasoul",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fire",
-                "subtype": "ability",
-                "text": ": brightsoul (radiant ifrit), cindersoul (ash ifrit), lavasoul (magma ifrit)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "brinesoul",
-                    "aonid": 2606,
-                    "game-obj": "Feats",
-                    "name": "brinesoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "mistsoul",
-                    "aonid": 2607,
-                    "game-obj": "Feats",
-                    "name": "mistsoul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "rimesoul",
-                    "aonid": 2608,
-                    "game-obj": "Feats",
-                    "name": "rimesoul",
-                    "type": "link"
-                  }
-                ],
-                "name": "Water",
-                "subtype": "ability",
-                "text": ": brinesoul (saltwater undine), mistsoul (vapor undine), rimesoul (frost undine)",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Elemental Permutations')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fumesoul",
+                "aonid": 2591,
+                "game-obj": "Feats",
+                "name": "fumesoul",
+                "type": "link"
+              },
+              {
+                "alt": "smokesoul",
+                "aonid": 2592,
+                "game-obj": "Feats",
+                "name": "smokesoul",
+                "type": "link"
+              },
+              {
+                "alt": "stormsoul",
+                "aonid": 2593,
+                "game-obj": "Feats",
+                "name": "stormsoul",
+                "type": "link"
+              },
+              {
+                "alt": "dustsoul",
+                "aonid": 2565,
+                "game-obj": "Feats",
+                "name": "dustsoul",
+                "type": "link"
+              },
+              {
+                "alt": "gemsoul",
+                "aonid": 2567,
+                "game-obj": "Feats",
+                "name": "gemsoul",
+                "type": "link"
+              },
+              {
+                "alt": "miresoul",
+                "aonid": 2568,
+                "game-obj": "Feats",
+                "name": "miresoul",
+                "type": "link"
+              },
+              {
+                "alt": "brightsoul",
+                "aonid": 2551,
+                "game-obj": "Feats",
+                "name": "brightsoul",
+                "type": "link"
+              },
+              {
+                "alt": "cindersoul",
+                "aonid": 2552,
+                "game-obj": "Feats",
+                "name": "cindersoul",
+                "type": "link"
+              },
+              {
+                "alt": "lavasoul",
+                "aonid": 2555,
+                "game-obj": "Feats",
+                "name": "lavasoul",
+                "type": "link"
+              },
+              {
+                "alt": "brinesoul",
+                "aonid": 2606,
+                "game-obj": "Feats",
+                "name": "brinesoul",
+                "type": "link"
+              },
+              {
+                "alt": "mistsoul",
+                "aonid": 2607,
+                "game-obj": "Feats",
+                "name": "mistsoul",
+                "type": "link"
+              },
+              {
+                "alt": "rimesoul",
+                "aonid": 2608,
+                "game-obj": "Feats",
+                "name": "rimesoul",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -177,7 +140,6 @@
         ],
         "name": "Elemental Permutations",
         "subtype": "monster_family",
-        "text": "While other planar scions have lineages that reflect the specific fiends, celestials, or monitors from which their families descend, geniekin lineages are better described as permutations of elemental expression. Elements sometimes manifest in unique and unusual ways within a line of geniekin, regardless of the elemental they descend from. These permutations and their lineages are as follows.",
         "type": "stat_block_section"
       }
     ],
@@ -210,6 +172,241 @@
         }
       ],
       "text": "The term geniekin came into common parlance mostly thanks to tales from Casmaron and, in particular, the Padishah Empire of Kelesh. Many of these folk stories, songs, and other common tales include great figures who have genie parentage. The prominence and legacy of these stories, along with the fact that the most common geniekin are those with genie ancestors, have cemented \u201cgeniekin\u201d as a common term for any individual who manifests elemental traits. This is true even when genies are not part of a person's lineage, such as individuals descended from elementals or sorcerers with the elemental bloodline. Scholars have pushed to use the more accurate descriptor of \u201celemental scion,\u201d but the term has yet to permeate the common lexicon.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "fumesoul",
+              "aonid": 2591,
+              "game-obj": "Feats",
+              "name": "fumesoul",
+              "type": "link"
+            },
+            {
+              "alt": "smokesoul",
+              "aonid": 2592,
+              "game-obj": "Feats",
+              "name": "smokesoul",
+              "type": "link"
+            },
+            {
+              "alt": "stormsoul",
+              "aonid": 2593,
+              "game-obj": "Feats",
+              "name": "stormsoul",
+              "type": "link"
+            }
+          ],
+          "name": "Air",
+          "subtype": "ability",
+          "text": ": fumesoul (miasma sylph), smokesoul (haze sylph), stormsoul (lightning sylph)",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "dustsoul",
+              "aonid": 2565,
+              "game-obj": "Feats",
+              "name": "dustsoul",
+              "type": "link"
+            },
+            {
+              "alt": "gemsoul",
+              "aonid": 2567,
+              "game-obj": "Feats",
+              "name": "gemsoul",
+              "type": "link"
+            },
+            {
+              "alt": "miresoul",
+              "aonid": 2568,
+              "game-obj": "Feats",
+              "name": "miresoul",
+              "type": "link"
+            }
+          ],
+          "name": "Earth",
+          "subtype": "ability",
+          "text": ": dustsoul (soil oread), gemsoul (crystal oread), miresoul (mud oread)",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "brightsoul",
+              "aonid": 2551,
+              "game-obj": "Feats",
+              "name": "brightsoul",
+              "type": "link"
+            },
+            {
+              "alt": "cindersoul",
+              "aonid": 2552,
+              "game-obj": "Feats",
+              "name": "cindersoul",
+              "type": "link"
+            },
+            {
+              "alt": "lavasoul",
+              "aonid": 2555,
+              "game-obj": "Feats",
+              "name": "lavasoul",
+              "type": "link"
+            }
+          ],
+          "name": "Fire",
+          "subtype": "ability",
+          "text": ": brightsoul (radiant ifrit), cindersoul (ash ifrit), lavasoul (magma ifrit)",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "brinesoul",
+              "aonid": 2606,
+              "game-obj": "Feats",
+              "name": "brinesoul",
+              "type": "link"
+            },
+            {
+              "alt": "mistsoul",
+              "aonid": 2607,
+              "game-obj": "Feats",
+              "name": "mistsoul",
+              "type": "link"
+            },
+            {
+              "alt": "rimesoul",
+              "aonid": 2608,
+              "game-obj": "Feats",
+              "name": "rimesoul",
+              "type": "link"
+            }
+          ],
+          "name": "Water",
+          "subtype": "ability",
+          "text": ": brinesoul (saltwater undine), mistsoul (vapor undine), rimesoul (frost undine)",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "fumesoul",
+          "aonid": 2591,
+          "game-obj": "Feats",
+          "name": "fumesoul",
+          "type": "link"
+        },
+        {
+          "alt": "smokesoul",
+          "aonid": 2592,
+          "game-obj": "Feats",
+          "name": "smokesoul",
+          "type": "link"
+        },
+        {
+          "alt": "stormsoul",
+          "aonid": 2593,
+          "game-obj": "Feats",
+          "name": "stormsoul",
+          "type": "link"
+        },
+        {
+          "alt": "dustsoul",
+          "aonid": 2565,
+          "game-obj": "Feats",
+          "name": "dustsoul",
+          "type": "link"
+        },
+        {
+          "alt": "gemsoul",
+          "aonid": 2567,
+          "game-obj": "Feats",
+          "name": "gemsoul",
+          "type": "link"
+        },
+        {
+          "alt": "miresoul",
+          "aonid": 2568,
+          "game-obj": "Feats",
+          "name": "miresoul",
+          "type": "link"
+        },
+        {
+          "alt": "brightsoul",
+          "aonid": 2551,
+          "game-obj": "Feats",
+          "name": "brightsoul",
+          "type": "link"
+        },
+        {
+          "alt": "cindersoul",
+          "aonid": 2552,
+          "game-obj": "Feats",
+          "name": "cindersoul",
+          "type": "link"
+        },
+        {
+          "alt": "lavasoul",
+          "aonid": 2555,
+          "game-obj": "Feats",
+          "name": "lavasoul",
+          "type": "link"
+        },
+        {
+          "alt": "brinesoul",
+          "aonid": 2606,
+          "game-obj": "Feats",
+          "name": "brinesoul",
+          "type": "link"
+        },
+        {
+          "alt": "mistsoul",
+          "aonid": 2607,
+          "game-obj": "Feats",
+          "name": "mistsoul",
+          "type": "link"
+        },
+        {
+          "alt": "rimesoul",
+          "aonid": 2608,
+          "game-obj": "Feats",
+          "name": "rimesoul",
+          "type": "link"
+        }
+      ],
+      "name": "Elemental Permutations",
+      "sources": [
+        {
+          "errata": {
+            "alt": "2.0",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "2.0",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Bestiary 2 pg. 200",
+            "aonid": 32,
+            "game-obj": "Sources",
+            "name": "Bestiary 2 pg. 200",
+            "type": "link"
+          },
+          "name": "Bestiary 2",
+          "page": 200,
+          "type": "source"
+        }
+      ],
+      "text": "While other planar scions have lineages that reflect the specific fiends, celestials, or monitors from which their families descend, geniekin lineages are better described as permutations of elemental expression. Elements sometimes manifest in unique and unusual ways within a line of geniekin, regardless of the elemental they descend from. These permutations and their lineages are as follows.   \n  \n**Air**: fumesoul (miasma sylph), smokesoul (haze sylph), stormsoul (lightning sylph)   \n  \n**Earth**: dustsoul (soil oread), gemsoul (crystal oread), miresoul (mud oread)   \n  \n**Fire**: brightsoul (radiant ifrit), cindersoul (ash ifrit), lavasoul (magma ifrit)   \n  \n**Water**: brinesoul (saltwater undine), mistsoul (vapor undine), rimesoul (frost undine)",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_2/ravener.json
+++ b/monster_families/bestiary_2/ravener.json
@@ -243,432 +243,154 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "celestials",
-                    "aonid": 23,
-                    "game-obj": "Traits",
-                    "name": "celestials",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fiends",
-                    "aonid": 70,
-                    "game-obj": "Traits",
-                    "name": "fiends",
-                    "type": "link"
-                  }
-                ],
-                "name": "Soulsense",
-                "subtype": "ability",
-                "text": "A ravener senses the spiritual essence of living and undead creatures within the listed range. Creatures whose material bodies are one unit with their souls, like celestials and fiends, appear brighter to this sense.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, unconscious",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightful presence",
-                    "aonid": 17,
-                    "game-obj": "MonsterAbilities",
-                    "name": "frightful presence",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened 2",
-                    "aonid": 19,
-                    "game-obj": "Conditions",
-                    "name": "frightened 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "immobilized",
-                    "aonid": 24,
-                    "game-obj": "Conditions",
-                    "name": "immobilized",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cowering Fear",
-                "subtype": "ability",
-                "text": "A ravener's frightful presence causes creatures to cower in fear as well. As long as a creature is at least frightened 2 or more as a result of the ravener's frightful presence, it is also immobilized from the fear.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Soul Ward",
-                "subtype": "ability",
-                "text": "An intangible field of necromantic energy protects a ravener from total destruction. A soul ward has 150 maximum Hit Points, or 200 if the ravener is level 21 or higher. Whenever a ravener would be reduced below 1 Hit Point, all damage in excess of what would reduce them to 1 Hit Point is instead dealt to their soul ward. If this damage reduces the soul ward to fewer than 0 Hit Points, the ravener is destroyed. A soul ward's Hit Points can be restored only via specific ravener abilities such as Consume Soul, ravenous breath, or vicious criticals. A ravener who goes more than a week without successfully using Consume Soul to feed on a dying creature starves, and their soul ward loses 1d4 Hit Points each day until they feed. If the ravener's soul ward loses all its Hit Points while the ravener still has more than 1 HP, they become a ravener husk.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ravener tears the creature's soul from its body with their maw and gulps it down. The dying creature must attempt a DC 44 Fortitude save.",
-                "name": "Consume Soul",
-                "saving_throw": [
-                  {
-                    "dc": 44,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 44 Fortitude save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "death",
-                      "aonid": 40,
-                      "game-obj": "Traits",
-                      "name": "death",
-                      "type": "link"
-                    },
-                    "name": "death",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "A living creature within 30 feet of the ravener dies",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The ravener tears off a small chunk of the creature\u2019s soul. If the victim is restored to life, they are drained 1 in addition to any other side effects of returning to life. The ravener adds a number of Hit Points to their soul ward equal to half the creature\u2019s level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "As success, but the creature\u2019s soul is ravaged. The creature is drained 3 and the ravener adds a number of Hit Points to their soul ward equal to the creature\u2019s level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "miracle",
-                    "aonid": 196,
-                    "game-obj": "Spells",
-                    "name": "miracle",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "wish",
-                    "aonid": 377,
-                    "game-obj": "Spells",
-                    "name": "wish",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, but the ravener devours the entire soul. The victim can\u2019t be restored to life as long as the ravener exists except via a 10th-level effect such as *miracle* or *wish*, and the ravener adds a number of Hit Points to their soul ward equal to twice the creature\u2019s level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ravener draws deeply into their soul ward, discorporating their body into soul energy in order to escape. They take 50 damage to their soul ward and their physical body vanishes, reappearing 1d4 hours later in a random location within 1 mile from the location where they used Discorporate.",
-                "name": "Discorporate",
-                "range": {
-                  "range": 1,
-                  "subtype": "range",
-                  "text": "within 1 mile",
-                  "type": "stat_block_section",
-                  "unit": "miles"
-                },
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "The ravener takes excess damage to their soul ward but still has at least 51 Hit Points in their soul ward",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Ravenous Breath",
-                "subtype": "ability",
-                "text": "A ravener's Breath Weapon is infused with negative energy and strips life essence from the victims. Any creature that fails its save against the ravener's Breath Weapon is drained 1 (or drained 2 on a critical failure). If at least one creature is drained by the ravener's Breath Weapon, the ravener's soul ward gains 5 Hit Points.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Vicious Criticals",
-                "subtype": "ability",
-                "text": "The ravener treats an attack roll as a critical hit on a roll of 19 or 20, as long as the attack roll was a success. Additionally, whenever the ravener makes a critical hit with one of their Strikes, the target must succeed on a Fortitude save or gain the drained 1 condition. If the target already has a drained value of greater than 0, their drained value instead increases by 1, to a maximum of drained 4. Whenever the ravener applies drain to a creature in this way, their soul ward gains 5 Hit Points.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Ravener')].sections[?(@.name=='Ravener Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "celestials",
+                "aonid": 23,
+                "game-obj": "Traits",
+                "name": "celestials",
+                "type": "link"
+              },
+              {
+                "alt": "fiends",
+                "aonid": 70,
+                "game-obj": "Traits",
+                "name": "fiends",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "frightful presence",
+                "aonid": 17,
+                "game-obj": "MonsterAbilities",
+                "name": "frightful presence",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 2",
+                "aonid": 19,
+                "game-obj": "Conditions",
+                "name": "frightened 2",
+                "type": "link"
+              },
+              {
+                "alt": "immobilized",
+                "aonid": 24,
+                "game-obj": "Conditions",
+                "name": "immobilized",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "miracle",
+                "aonid": 196,
+                "game-obj": "Spells",
+                "name": "miracle",
+                "type": "link"
+              },
+              {
+                "alt": "wish",
+                "aonid": 377,
+                "game-obj": "Spells",
+                "name": "wish",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -678,7 +400,6 @@
         ],
         "name": "Ravener Abilities",
         "subtype": "monster_family",
-        "text": "A ravener gains the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -725,6 +446,594 @@
     {
       "name": "Ravener",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "celestials",
+                  "aonid": 23,
+                  "game-obj": "Traits",
+                  "name": "celestials",
+                  "type": "link"
+                },
+                {
+                  "alt": "fiends",
+                  "aonid": 70,
+                  "game-obj": "Traits",
+                  "name": "fiends",
+                  "type": "link"
+                }
+              ],
+              "name": "Soulsense",
+              "subtype": "ability",
+              "text": "A ravener senses the spiritual essence of living and undead creatures within the listed range. Creatures whose material bodies are one unit with their souls, like celestials and fiends, appear brighter to this sense.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, unconscious",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "frightful presence",
+                  "aonid": 17,
+                  "game-obj": "MonsterAbilities",
+                  "name": "frightful presence",
+                  "type": "link"
+                },
+                {
+                  "alt": "frightened 2",
+                  "aonid": 19,
+                  "game-obj": "Conditions",
+                  "name": "frightened 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "immobilized",
+                  "aonid": 24,
+                  "game-obj": "Conditions",
+                  "name": "immobilized",
+                  "type": "link"
+                }
+              ],
+              "name": "Cowering Fear",
+              "subtype": "ability",
+              "text": "A ravener's frightful presence causes creatures to cower in fear as well. As long as a creature is at least frightened 2 or more as a result of the ravener's frightful presence, it is also immobilized from the fear.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 60,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fear",
+                    "aonid": 68,
+                    "game-obj": "Traits",
+                    "name": "fear",
+                    "type": "link"
+                  },
+                  "name": "fear",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Soul Ward",
+              "subtype": "ability",
+              "text": "An intangible field of necromantic energy protects a ravener from total destruction. A soul ward has 150 maximum Hit Points, or 200 if the ravener is level 21 or higher. Whenever a ravener would be reduced below 1 Hit Point, all damage in excess of what would reduce them to 1 Hit Point is instead dealt to their soul ward. If this damage reduces the soul ward to fewer than 0 Hit Points, the ravener is destroyed. A soul ward's Hit Points can be restored only via specific ravener abilities such as Consume Soul, ravenous breath, or vicious criticals. A ravener who goes more than a week without successfully using Consume Soul to feed on a dying creature starves, and their soul ward loses 1d4 Hit Points each day until they feed. If the ravener's soul ward loses all its Hit Points while the ravener still has more than 1 HP, they become a ravener husk.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The ravener tears the creature's soul from its body with their maw and gulps it down. The dying creature must attempt a DC 44 Fortitude save.",
+              "name": "Consume Soul",
+              "saving_throw": [
+                {
+                  "dc": 44,
+                  "save_type": "Fort",
+                  "subtype": "save_dc",
+                  "text": "DC 44 Fortitude save",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "death",
+                    "aonid": 40,
+                    "game-obj": "Traits",
+                    "name": "death",
+                    "type": "link"
+                  },
+                  "name": "death",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "trigger": "A living creature within 30 feet of the ravener dies",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Critical Success",
+              "subtype": "ability",
+              "text": "The creature is unaffected.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Success",
+              "subtype": "ability",
+              "text": "The ravener tears off a small chunk of the creature\u2019s soul. If the victim is restored to life, they are drained 1 in addition to any other side effects of returning to life. The ravener adds a number of Hit Points to their soul ward equal to half the creature\u2019s level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Failure",
+              "subtype": "ability",
+              "text": "As success, but the creature\u2019s soul is ravaged. The creature is drained 3 and the ravener adds a number of Hit Points to their soul ward equal to the creature\u2019s level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "miracle",
+                  "aonid": 196,
+                  "game-obj": "Spells",
+                  "name": "miracle",
+                  "type": "link"
+                },
+                {
+                  "alt": "wish",
+                  "aonid": 377,
+                  "game-obj": "Spells",
+                  "name": "wish",
+                  "type": "link"
+                }
+              ],
+              "name": "Critical Failure",
+              "subtype": "ability",
+              "text": "As failure, but the ravener devours the entire soul. The victim can\u2019t be restored to life as long as the ravener exists except via a 10th-level effect such as *miracle* or *wish*, and the ravener adds a number of Hit Points to their soul ward equal to twice the creature\u2019s level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The ravener draws deeply into their soul ward, discorporating their body into soul energy in order to escape. They take 50 damage to their soul ward and their physical body vanishes, reappearing 1d4 hours later in a random location within 1 mile from the location where they used Discorporate.",
+              "name": "Discorporate",
+              "range": {
+                "range": 1,
+                "subtype": "range",
+                "text": "within 1 mile",
+                "type": "stat_block_section",
+                "unit": "miles"
+              },
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "trigger": "The ravener takes excess damage to their soul ward but still has at least 51 Hit Points in their soul ward",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Ravenous Breath",
+              "subtype": "ability",
+              "text": "A ravener's Breath Weapon is infused with negative energy and strips life essence from the victims. Any creature that fails its save against the ravener's Breath Weapon is drained 1 (or drained 2 on a critical failure). If at least one creature is drained by the ravener's Breath Weapon, the ravener's soul ward gains 5 Hit Points.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Vicious Criticals",
+              "subtype": "ability",
+              "text": "The ravener treats an attack roll as a critical hit on a roll of 19 or 20, as long as the attack roll was a success. Additionally, whenever the ravener makes a critical hit with one of their Strikes, the target must succeed on a Fortitude save or gain the drained 1 condition. If the target already has a drained value of greater than 0, their drained value instead increases by 1, to a maximum of drained 4. Whenever the ravener applies drain to a creature in this way, their soul ward gains 5 Hit Points.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "celestials",
+              "aonid": 23,
+              "game-obj": "Traits",
+              "name": "celestials",
+              "type": "link"
+            },
+            {
+              "alt": "fiends",
+              "aonid": 70,
+              "game-obj": "Traits",
+              "name": "fiends",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 60,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 68,
+              "game-obj": "Traits",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "frightful presence",
+              "aonid": 17,
+              "game-obj": "MonsterAbilities",
+              "name": "frightful presence",
+              "type": "link"
+            },
+            {
+              "alt": "frightened 2",
+              "aonid": 19,
+              "game-obj": "Conditions",
+              "name": "frightened 2",
+              "type": "link"
+            },
+            {
+              "alt": "immobilized",
+              "aonid": 24,
+              "game-obj": "Conditions",
+              "name": "immobilized",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "miracle",
+              "aonid": 196,
+              "game-obj": "Spells",
+              "name": "miracle",
+              "type": "link"
+            },
+            {
+              "alt": "wish",
+              "aonid": 377,
+              "game-obj": "Spells",
+              "name": "wish",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Ravener Abilities",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 222",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 222",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 222,
+              "type": "source"
+            }
+          ],
+          "text": "A ravener gains the following abilities.   \n  \n**Darkvision**   \n  \n**Soulsense** A ravener senses the spiritual essence of living and undead creatures within the listed range. Creatures whose material bodies are one unit with their souls, like celestials and fiends, appear brighter to this sense.   \n  \n**Negative Healing**   \n  \n**Immunities** death effects, disease, paralyzed, poison, unconscious   \n  \n**Cowering Fear** (aura, emotion, fear, mental) A ravener's frightful presence causes creatures to cower in fear as well. As long as a creature is at least frightened 2 or more as a result of the ravener's frightful presence, it is also immobilized from the fear.   \n  \n**Soul Ward** An intangible field of necromantic energy protects a ravener from total destruction. A soul ward has 150 maximum Hit Points, or 200 if the ravener is level 21 or higher. Whenever a ravener would be reduced below 1 Hit Point, all damage in excess of what would reduce them to 1 Hit Point is instead dealt to their soul ward. If this damage reduces the soul ward to fewer than 0 Hit Points, the ravener is destroyed. A soul ward's Hit Points can be restored only via specific ravener abilities such as Consume Soul, ravenous breath, or vicious criticals. A ravener who goes more than a week without successfully using Consume Soul to feed on a dying creature starves, and their soul ward loses 1d4 Hit Points each day until they feed. If the ravener's soul ward loses all its Hit Points while the ravener still has more than 1 HP, they become a ravener husk.   \n  \n**Consume Soul** [-] (death, divine, necromancy) **Trigger** A living creature within 30 feet of the ravener dies; **Effect** The ravener tears the creature's soul from its body with their maw and gulps it down. The dying creature must attempt a DC 44 Fortitude save.  \n**Critical Success** The creature is unaffected.  \n**Success** The ravener tears off a small chunk of the creature\u2019s soul. If the victim is restored to life, they are drained 1 in addition to any other side effects of returning to life. The ravener adds a number of Hit Points to their soul ward equal to half the creature\u2019s level.  \n**Failure** As success, but the creature\u2019s soul is ravaged. The creature is drained 3 and the ravener adds a number of Hit Points to their soul ward equal to the creature\u2019s level.  \n**Critical Failure** As failure, but the ravener devours the entire soul. The victim can\u2019t be restored to life as long as the ravener exists except via a 10th-level effect such as *miracle* or *wish*, and the ravener adds a number of Hit Points to their soul ward equal to twice the creature\u2019s level.  \n  \n**Discorporate** [-] (divine, necromancy) **Trigger** The ravener takes excess damage to their soul ward but still has at least 51 Hit Points in their soul ward; **Effect** The ravener draws deeply into their soul ward, discorporating their body into soul energy in order to escape. They take 50 damage to their soul ward and their physical body vanishes, reappearing 1d4 hours later in a random location within 1 mile from the location where they used Discorporate.   \n  \n**Ravenous Breath** A ravener's Breath Weapon is infused with negative energy and strips life essence from the victims. Any creature that fails its save against the ravener's Breath Weapon is drained 1 (or drained 2 on a critical failure). If at least one creature is drained by the ravener's Breath Weapon, the ravener's soul ward gains 5 Hit Points.   \n  \n**Vicious Criticals** The ravener treats an attack roll as a critical hit on a roll of 19 or 20, as long as the attack roll was a success. Additionally, whenever the ravener makes a critical hit with one of their Strikes, the target must succeed on a Fortitude save or gain the drained 1 condition. If the target already has a drained value of greater than 0, their drained value instead increases by 1, to a maximum of drained 4. Whenever the ravener applies drain to a creature in this way, their soul ward gains 5 Hit Points.",
+          "type": "section"
+        },
         {
           "links": [
             {

--- a/monster_families/bestiary_2/vampire_vrykolakas.json
+++ b/monster_families/bestiary_2/vampire_vrykolakas.json
@@ -228,472 +228,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Tracking",
-                    "aonid": 66,
-                    "game-obj": "Actions",
-                    "name": "Tracking",
-                    "type": "link"
-                  }
-                ],
-                "name": "Swift Tracker",
-                "subtype": "ability",
-                "text": "The vrykolakas moves at full Speed while Tracking.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 145,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "Unlike most other undead, a vrykolakas isn't destroyed when it reaches 0 HP. Instead, it attempts to cast its spirit into an animal within 100 feet, which must attempt a Will save (use a high DC for the vrykolakas's level from the Spell DC and Spell Attack Roll table). On a failure, the animal is possessed. This has the effects of the *possession* spell, but it lasts a number of days equal to the vrykolakas's level. This possession can't be counteracted with magic (though *remove curse* works against it normally).",
-                "links": [
-                  {
-                    "alt": "animal",
-                    "aonid": 9,
-                    "game-obj": "Traits",
-                    "name": "animal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Spell DC and Spell Attack Roll table",
-                    "aonid": 1020,
-                    "game-obj": "Rules",
-                    "name": "Spell DC and Spell Attack Roll table",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "possession",
-                    "aonid": 225,
-                    "game-obj": "Spells",
-                    "name": "possession",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteracted",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteracted",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "remove curse",
-                    "aonid": 250,
-                    "game-obj": "Spells",
-                    "name": "remove curse",
-                    "type": "link"
-                  }
-                ],
-                "name": "Feral Corruption",
-                "range": {
-                  "range": 100,
-                  "subtype": "range",
-                  "text": "within 100 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 38,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "possession",
-                      "aonid": 129,
-                      "game-obj": "Traits",
-                      "name": "possession",
-                      "type": "link"
-                    },
-                    "name": "possession",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "The vrykolakas is reduced to 0 Hit Points, and an animal is within 100 feet",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Vrykolakas Vulnerabilities",
-                "subtype": "ability",
-                "text": "Vrykolakas all have the following vulnerabilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Climb Speed",
-                "subtype": "ability",
-                "text": "A vrykolakas gains a climb Speed equal to one-half its land Speed.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Strike Damage",
-                    "aonid": 1018,
-                    "game-obj": "Rules",
-                    "name": "Strike Damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the base creature had hands, it gains an unarmed claw Strike that deals slashing damage and has the agile trait. Use the moderate damage for the creature's level on the Strike Damage table.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Fangs",
-                "subtype": "ability",
-                "text": "The teeth of the vrykolakas grow long, sharp, and deadly, granting it a fangs Strike: an unarmed attack that deals piercing damage and enables the use of its Drink Blood ability. Use the high damage for the creature's level on the Strike Damage table.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The vrykolakas sinks its fangs into that creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the vrykolakas regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire, but it increases the creature's drained condition value by 1. A vrykolakas can also consume blood that's been emptied into a vessel for sustenance, but it gains no HP from doing so.",
-                "links": [
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Blood",
-                "requirement": "The vrykolakas' last action was a successful fangs Strike",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Rend",
-                  "aonid": 30,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Rend",
-                  "type": "link"
-                },
-                "name": "Rend",
-                "subtype": "ability",
-                "text": "The vrykolakas gains the Rend action with its claws.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 30,
-                  "effect": "The monster automatically deals that Strike\u2019s damage again to the enemy.",
-                  "game-id": "8d0a751cabb8428977d34549d18b8904",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Rend",
-                  "requirement": "The monster hit the same enemy with two consecutive Strikes of the listed type in the same round.",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 344",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 344",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 344,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A Rend entry lists a Strike the monster has.",
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Vrykolakas')].sections[?(@.name=='Basic Vrykolakas Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -711,6 +250,202 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Tracking",
+                "aonid": 66,
+                "game-obj": "Actions",
+                "name": "Tracking",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 145,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 129,
+                "game-obj": "Traits",
+                "name": "possession",
+                "type": "link"
+              },
+              {
+                "alt": "animal",
+                "aonid": 9,
+                "game-obj": "Traits",
+                "name": "animal",
+                "type": "link"
+              },
+              {
+                "alt": "Spell DC and Spell Attack Roll table",
+                "aonid": 1020,
+                "game-obj": "Rules",
+                "name": "Spell DC and Spell Attack Roll table",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 225,
+                "game-obj": "Spells",
+                "name": "possession",
+                "type": "link"
+              },
+              {
+                "alt": "counteracted",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteracted",
+                "type": "link"
+              },
+              {
+                "alt": "remove curse",
+                "aonid": 250,
+                "game-obj": "Spells",
+                "name": "remove curse",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "Strike Damage",
+                "aonid": 1018,
+                "game-obj": "Rules",
+                "name": "Strike Damage",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "Medicine",
+                "aonid": 9,
+                "game-obj": "Skills",
+                "name": "Medicine",
+                "type": "link"
+              },
+              {
+                "alt": "Rend",
+                "aonid": 30,
+                "game-obj": "MonsterAbilities",
+                "name": "Rend",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -720,652 +455,250 @@
         ],
         "name": "Basic Vrykolakas Abilities",
         "subtype": "monster_family",
-        "text": "If the base creature becoming a vrykolakas has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vrykolakas' theme. All vrykolakas gain the following abilities.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "rat swarms",
-                    "aonid": 347,
-                    "game-obj": "Monsters",
-                    "name": "rat swarms",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "warg",
-                    "aonid": 402,
-                    "game-obj": "Monsters",
-                    "name": "warg",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "werewolves",
-                    "aonid": 411,
-                    "game-obj": "Monsters",
-                    "name": "werewolves",
-                    "type": "link"
-                  }
-                ],
-                "name": "Children of the Night",
-                "range": {
-                  "range": 100,
-                  "subtype": "range",
-                  "text": "within 100 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The presence of a vrykolakas master inspires savage creatures to crawl forth to do its bidding, including rat swarms, warg, werewolves, and similar creatures. The vrykolakas master can give telepathic orders to these creatures within 100 feet, but they can't communicate back.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "bubonic plague",
-                    "aonid": 6,
-                    "game-obj": "Diseases",
-                    "name": "bubonic plague",
-                    "type": "link"
-                  }
-                ],
-                "name": "Pestilential Aura",
-                "range": {
-                  "range": 5,
-                  "subtype": "range",
-                  "text": "5 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "Creatures beginning their turn in the area while the vrykolakas is in its true form are exposed to bubonic plague.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 202,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "frequency": "three times per day",
-                "links": [
-                  {
-                    "alt": "vampiric touch",
-                    "aonid": 354,
-                    "game-obj": "Spells",
-                    "name": "vampiric touch",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fear",
-                    "aonid": 110,
-                    "game-obj": "Deities",
-                    "name": "fear",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Innate Spells",
-                "subtype": "ability",
-                "text": "The vrykolakas master can cast *vampiric touch* (heightened to half its level rounded up) and 3rd-level fear three times per day each as divine innate spells. It uses a high DC for its level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "fatigued",
-                    "aonid": 15,
-                    "game-obj": "Conditions",
-                    "name": "fatigued",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enfeebled 2",
-                    "aonid": 13,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent bleed damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent bleed damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bubonic Plague",
-                "onset": "1 day",
-                "saving_throw": [
-                  {
-                    "modifiers": [
-                      {
-                        "name": "use a high DC for the vrykolakas's level",
-                        "subtype": "modifier",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "Fortitude (use a high DC for the vrykolakas's level)",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "fatigued (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "enfeebled 2 and fatigued (1 day); Stage 3 enfeebled 3, fatigued, and takes 1d6 persistent bleed damage every 1d20 minutes (1 day)",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid form",
-                    "aonid": 153,
-                    "game-obj": "Spells",
-                    "name": "humanoid form",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Deception",
-                    "aonid": 5,
-                    "game-obj": "Skills",
-                    "name": "Deception",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Impersonate",
-                    "aonid": 46,
-                    "game-obj": "Actions",
-                    "name": "Impersonate",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "A vrykolakas master can transform into a form resembling the body it had in life, with the effects of *humanoid form* but with unlimited duration. It loses its fangs and claw Strikes but gains a +2 circumstance bonus to Deception checks to Impersonate in this form.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "vrykolakas spawn",
-                    "aonid": 842,
-                    "game-obj": "Monsters",
-                    "name": "vrykolakas spawn",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "friendly",
-                    "aonid": 18,
-                    "game-obj": "Conditions",
-                    "name": "friendly",
-                    "type": "link"
-                  }
-                ],
-                "name": "Create Spawn",
-                "subtype": "ability",
-                "text": "If a creature dies after being reduced to 0 HP by Drink Blood, a vrykolakas master can turn this creature into a vrykolakas spawn by donating some of its own blood to the creature and burying it in earth for 3 nights. Such vrykolakas spawn are generally friendly to the vrykolakas that created them, but they are not under its control and typically wander off on their own rampage within 1d6 days of their creation.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "downtime",
-                      "aonid": 49,
-                      "game-obj": "Traits",
-                      "name": "downtime",
-                      "type": "link"
-                    },
-                    "name": "downtime",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 87,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dominate Animal",
-                "subtype": "ability",
-                "text": "The vrykolakas can cast *dominate* at will as a divine innate spell that affects only animals. The save DC is a high DC for the vrykolakas's level, and a creature that succeeds is immune to that vrykolakas's Dominate Animal for 24 hours. Destroying the vrykolakas ends the effect, but reducing it to 0 HP does not. A dominated animal takes a \u20134 circumstance penalty to saving throws against the vrykolakas's Feral Possession.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Drink Blood",
-                "subtype": "ability",
-                "text": "As a typical vrykolakas, but the creature is drained 2 instead of 1.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Vrykolakas')].sections[?(@.name=='Vrykolakas Master Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "rat swarms",
+                "aonid": 347,
+                "game-obj": "Monsters",
+                "name": "rat swarms",
+                "type": "link"
+              },
+              {
+                "alt": "warg",
+                "aonid": 402,
+                "game-obj": "Monsters",
+                "name": "warg",
+                "type": "link"
+              },
+              {
+                "alt": "werewolves",
+                "aonid": 411,
+                "game-obj": "Monsters",
+                "name": "werewolves",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 202,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "bubonic plague",
+                "aonid": 6,
+                "game-obj": "Diseases",
+                "name": "bubonic plague",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric touch",
+                "aonid": 354,
+                "game-obj": "Spells",
+                "name": "vampiric touch",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 110,
+                "game-obj": "Deities",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "fatigued",
+                "aonid": 15,
+                "game-obj": "Conditions",
+                "name": "fatigued",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled 2",
+                "aonid": 13,
+                "game-obj": "Conditions",
+                "name": "enfeebled 2",
+                "type": "link"
+              },
+              {
+                "alt": "persistent bleed damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent bleed damage",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 153,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              },
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "downtime",
+                "aonid": 49,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "vrykolakas spawn",
+                "aonid": 842,
+                "game-obj": "Monsters",
+                "name": "vrykolakas spawn",
+                "type": "link"
+              },
+              {
+                "alt": "friendly",
+                "aonid": 18,
+                "game-obj": "Conditions",
+                "name": "friendly",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 87,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1375,7 +708,6 @@
         ],
         "name": "Vrykolakas Master Abilities",
         "subtype": "monster_family",
-        "text": "Particularly powerful vrykolakas can create spawn from the bodies of their victims and gain additional abilities, as detailed below. Creatures of 9th level or higher can become a vrykolakas master, while those of 12th level or higher who have survived for centuries might become a vrykolakas ancient.",
         "type": "stat_block_section"
       }
     ],
@@ -1387,6 +719,1598 @@
     {
       "name": "Creating a Vrykolakas",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Tracking",
+                  "aonid": 66,
+                  "game-obj": "Actions",
+                  "name": "Tracking",
+                  "type": "link"
+                }
+              ],
+              "name": "Swift Tracker",
+              "subtype": "ability",
+              "text": "The vrykolakas moves at full Speed while Tracking.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "sleep",
+                  "aonid": 145,
+                  "game-obj": "Traits",
+                  "name": "sleep",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, sleep",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "Unlike most other undead, a vrykolakas isn't destroyed when it reaches 0 HP. Instead, it attempts to cast its spirit into an animal within 100 feet, which must attempt a Will save (use a high DC for the vrykolakas's level from the Spell DC and Spell Attack Roll table). On a failure, the animal is possessed. This has the effects of the *possession* spell, but it lasts a number of days equal to the vrykolakas's level. This possession can't be counteracted with magic (though *remove curse* works against it normally).",
+              "links": [
+                {
+                  "alt": "animal",
+                  "aonid": 9,
+                  "game-obj": "Traits",
+                  "name": "animal",
+                  "type": "link"
+                },
+                {
+                  "alt": "Spell DC and Spell Attack Roll table",
+                  "aonid": 1020,
+                  "game-obj": "Rules",
+                  "name": "Spell DC and Spell Attack Roll table",
+                  "type": "link"
+                },
+                {
+                  "alt": "possession",
+                  "aonid": 225,
+                  "game-obj": "Spells",
+                  "name": "possession",
+                  "type": "link"
+                },
+                {
+                  "alt": "counteracted",
+                  "aonid": 371,
+                  "game-obj": "Rules",
+                  "name": "counteracted",
+                  "type": "link"
+                },
+                {
+                  "alt": "remove curse",
+                  "aonid": 250,
+                  "game-obj": "Spells",
+                  "name": "remove curse",
+                  "type": "link"
+                }
+              ],
+              "name": "Feral Corruption",
+              "range": {
+                "range": 100,
+                "subtype": "range",
+                "text": "within 100 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "curse",
+                    "aonid": 38,
+                    "game-obj": "Traits",
+                    "name": "curse",
+                    "type": "link"
+                  },
+                  "name": "curse",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "possession",
+                    "aonid": 129,
+                    "game-obj": "Traits",
+                    "name": "possession",
+                    "type": "link"
+                  },
+                  "name": "possession",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "trigger": "The vrykolakas is reduced to 0 Hit Points, and an animal is within 100 feet",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Vrykolakas Vulnerabilities",
+              "subtype": "ability",
+              "text": "Vrykolakas all have the following vulnerabilities.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "name": "Climb Speed",
+              "subtype": "ability",
+              "text": "A vrykolakas gains a climb Speed equal to one-half its land Speed.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 170,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                },
+                {
+                  "alt": "Strike Damage",
+                  "aonid": 1018,
+                  "game-obj": "Rules",
+                  "name": "Strike Damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Claws",
+              "subtype": "ability",
+              "text": "If the base creature had hands, it gains an unarmed claw Strike that deals slashing damage and has the agile trait. Use the moderate damage for the creature's level on the Strike Damage table.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Fangs",
+              "subtype": "ability",
+              "text": "The teeth of the vrykolakas grow long, sharp, and deadly, granting it a fangs Strike: an unarmed attack that deals piercing damage and enables the use of its Drink Blood ability. Use the high damage for the creature's level on the Strike Damage table.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The vrykolakas sinks its fangs into that creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the vrykolakas regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire, but it increases the creature's drained condition value by 1. A vrykolakas can also consume blood that's been emptied into a vessel for sustenance, but it gains no HP from doing so.",
+              "links": [
+                {
+                  "alt": "Athletics",
+                  "aonid": 3,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                },
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Drink Blood",
+              "requirement": "The vrykolakas' last action was a successful fangs Strike",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Rend",
+                "aonid": 30,
+                "game-obj": "MonsterAbilities",
+                "name": "Rend",
+                "type": "link"
+              },
+              "name": "Rend",
+              "subtype": "ability",
+              "text": "The vrykolakas gains the Rend action with its claws.",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 30,
+                "effect": "The monster automatically deals that Strike\u2019s damage again to the enemy.",
+                "game-id": "8d0a751cabb8428977d34549d18b8904",
+                "game-obj": "MonsterAbilities",
+                "name": "Rend",
+                "requirement": "The monster hit the same enemy with two consecutive Strikes of the listed type in the same round.",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 344",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 344",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 344,
+                    "type": "source"
+                  }
+                ],
+                "text": "A Rend entry lists a Strike the monster has.",
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "human",
+              "aonid": 90,
+              "game-obj": "Traits",
+              "name": "human",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 91,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Tracking",
+              "aonid": 66,
+              "game-obj": "Actions",
+              "name": "Tracking",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 145,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            },
+            {
+              "alt": "curse",
+              "aonid": 38,
+              "game-obj": "Traits",
+              "name": "curse",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "possession",
+              "aonid": 129,
+              "game-obj": "Traits",
+              "name": "possession",
+              "type": "link"
+            },
+            {
+              "alt": "animal",
+              "aonid": 9,
+              "game-obj": "Traits",
+              "name": "animal",
+              "type": "link"
+            },
+            {
+              "alt": "Spell DC and Spell Attack Roll table",
+              "aonid": 1020,
+              "game-obj": "Rules",
+              "name": "Spell DC and Spell Attack Roll table",
+              "type": "link"
+            },
+            {
+              "alt": "possession",
+              "aonid": 225,
+              "game-obj": "Spells",
+              "name": "possession",
+              "type": "link"
+            },
+            {
+              "alt": "counteracted",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteracted",
+              "type": "link"
+            },
+            {
+              "alt": "remove curse",
+              "aonid": 250,
+              "game-obj": "Spells",
+              "name": "remove curse",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "Strike Damage",
+              "aonid": 1018,
+              "game-obj": "Rules",
+              "name": "Strike Damage",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "Medicine",
+              "aonid": 9,
+              "game-obj": "Skills",
+              "name": "Medicine",
+              "type": "link"
+            },
+            {
+              "alt": "Rend",
+              "aonid": 30,
+              "game-obj": "MonsterAbilities",
+              "name": "Rend",
+              "type": "link"
+            }
+          ],
+          "name": "Basic Vrykolakas Abilities",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 275",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 275",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 275,
+              "type": "source"
+            }
+          ],
+          "text": "If the base creature becoming a vrykolakas has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vrykolakas' theme. All vrykolakas gain the following abilities.   \n  \n**Darkvision**   \n  \n**Swift Tracker** The vrykolakas moves at full Speed while Tracking.   \n  \n**Negative Healing**   \n  \n**Immunities** death effects, disease, paralyzed, poison, sleep   \n  \n**Feral Corruption** [-] (curse, divine, incapacitation, mental, necromancy, possession) **Trigger** The vrykolakas is reduced to 0 Hit Points, and an animal is within 100 feet; **Effect** Unlike most other undead, a vrykolakas isn't destroyed when it reaches 0 HP. Instead, it attempts to cast its spirit into an animal within 100 feet, which must attempt a Will save (use a high DC for the vrykolakas's level from the Spell DC and Spell Attack Roll table). On a failure, the animal is possessed. This has the effects of the *possession* spell, but it lasts a number of days equal to the vrykolakas's level. This possession can't be counteracted with magic (though *remove curse* works against it normally).  \n  \n If the animal succeeds at its save, the vrykolakas can attempt to possess a different animal within 100 feet. If at any point an animal critically succeeds at its save or no animal is within 100 feet, the vrykolakas fails to possess anything and is destroyed.  \n  \n A vrykolakas possessing an animal seeks out its burial site (see Burial Site Bound below) immediately, burying itself there. While the vrykolakas is in this state of recovery, its animal host is paralyzed, and beheading it destroys the vrykolakas and kills its host. Removing the curse destroys the vrykolakas and returns the animal to normal. After 1d4 days, if the vrykolakas hasn't been destroyed, the animal dies and the vrykolakas rises in a new body that's identical to its previous one, formed from the animal's remains.   \n  \n**Vrykolakas Vulnerabilities** Vrykolakas all have the following vulnerabilities. **Climb Speed** A vrykolakas gains a climb Speed equal to one-half its land Speed.   \n  \n**Claws** If the base creature had hands, it gains an unarmed claw Strike that deals slashing damage and has the agile trait. Use the moderate damage for the creature's level on the Strike Damage table.   \n  \n**Fangs** The teeth of the vrykolakas grow long, sharp, and deadly, granting it a fangs Strike: an unarmed attack that deals piercing damage and enables the use of its Drink Blood ability. Use the high damage for the creature's level on the Strike Damage table.   \n  \n**Drink Blood** [#] (divine, necromancy) **Requirements** The vrykolakas' last action was a successful fangs Strike; **Effect** The vrykolakas sinks its fangs into that creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the vrykolakas regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire, but it increases the creature's drained condition value by 1. A vrykolakas can also consume blood that's been emptied into a vessel for sustenance, but it gains no HP from doing so.  \n  \n The target creature's drained condition value decreases by 1 per week. A blood transfusion, which requires a successful DC 20 Medicine check and sufficient blood or a blood donor, reduces the drained value by 1 after 10 minutes.   \n  \n**Rend** [#] The vrykolakas gains the Rend action with its claws.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "rat swarms",
+                  "aonid": 347,
+                  "game-obj": "Monsters",
+                  "name": "rat swarms",
+                  "type": "link"
+                },
+                {
+                  "alt": "warg",
+                  "aonid": 402,
+                  "game-obj": "Monsters",
+                  "name": "warg",
+                  "type": "link"
+                },
+                {
+                  "alt": "werewolves",
+                  "aonid": 411,
+                  "game-obj": "Monsters",
+                  "name": "werewolves",
+                  "type": "link"
+                }
+              ],
+              "name": "Children of the Night",
+              "range": {
+                "range": 100,
+                "subtype": "range",
+                "text": "within 100 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The presence of a vrykolakas master inspires savage creatures to crawl forth to do its bidding, including rat swarms, warg, werewolves, and similar creatures. The vrykolakas master can give telepathic orders to these creatures within 100 feet, but they can't communicate back.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "bubonic plague",
+                  "aonid": 6,
+                  "game-obj": "Diseases",
+                  "name": "bubonic plague",
+                  "type": "link"
+                }
+              ],
+              "name": "Pestilential Aura",
+              "range": {
+                "range": 5,
+                "subtype": "range",
+                "text": "5 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "Creatures beginning their turn in the area while the vrykolakas is in its true form are exposed to bubonic plague.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 202,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "frequency": "three times per day",
+              "links": [
+                {
+                  "alt": "vampiric touch",
+                  "aonid": 354,
+                  "game-obj": "Spells",
+                  "name": "vampiric touch",
+                  "type": "link"
+                },
+                {
+                  "alt": "fear",
+                  "aonid": 110,
+                  "game-obj": "Deities",
+                  "name": "fear",
+                  "type": "link"
+                }
+              ],
+              "name": "Divine Innate Spells",
+              "subtype": "ability",
+              "text": "The vrykolakas master can cast *vampiric touch* (heightened to half its level rounded up) and 3rd-level fear three times per day each as divine innate spells. It uses a high DC for its level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "affliction",
+              "links": [
+                {
+                  "alt": "fatigued",
+                  "aonid": 15,
+                  "game-obj": "Conditions",
+                  "name": "fatigued",
+                  "type": "link"
+                },
+                {
+                  "alt": "enfeebled 2",
+                  "aonid": 13,
+                  "game-obj": "Conditions",
+                  "name": "enfeebled 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "persistent bleed damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent bleed damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Bubonic Plague",
+              "onset": "1 day",
+              "saving_throw": [
+                {
+                  "modifiers": [
+                    {
+                      "name": "use a high DC for the vrykolakas's level",
+                      "subtype": "modifier",
+                      "type": "stat_block_section"
+                    }
+                  ],
+                  "save_type": "Fort",
+                  "subtype": "save_dc",
+                  "text": "Fortitude (use a high DC for the vrykolakas's level)",
+                  "type": "stat_block_section"
+                }
+              ],
+              "stages": [
+                {
+                  "name": "Stage 1",
+                  "subtype": "affliction_stage",
+                  "text": "fatigued (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 2",
+                  "subtype": "affliction_stage",
+                  "text": "enfeebled 2 and fatigued (1 day); Stage 3 enfeebled 3, fatigued, and takes 1d6 persistent bleed damage every 1d20 minutes (1 day)",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "humanoid form",
+                  "aonid": 153,
+                  "game-obj": "Spells",
+                  "name": "humanoid form",
+                  "type": "link"
+                },
+                {
+                  "alt": "Deception",
+                  "aonid": 5,
+                  "game-obj": "Skills",
+                  "name": "Deception",
+                  "type": "link"
+                },
+                {
+                  "alt": "Impersonate",
+                  "aonid": 46,
+                  "game-obj": "Actions",
+                  "name": "Impersonate",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "A vrykolakas master can transform into a form resembling the body it had in life, with the effects of *humanoid form* but with unlimited duration. It loses its fangs and claw Strikes but gains a +2 circumstance bonus to Deception checks to Impersonate in this form.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "vrykolakas spawn",
+                  "aonid": 842,
+                  "game-obj": "Monsters",
+                  "name": "vrykolakas spawn",
+                  "type": "link"
+                },
+                {
+                  "alt": "friendly",
+                  "aonid": 18,
+                  "game-obj": "Conditions",
+                  "name": "friendly",
+                  "type": "link"
+                }
+              ],
+              "name": "Create Spawn",
+              "subtype": "ability",
+              "text": "If a creature dies after being reduced to 0 HP by Drink Blood, a vrykolakas master can turn this creature into a vrykolakas spawn by donating some of its own blood to the creature and burying it in earth for 3 nights. Such vrykolakas spawn are generally friendly to the vrykolakas that created them, but they are not under its control and typically wander off on their own rampage within 1d6 days of their creation.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "downtime",
+                    "aonid": 49,
+                    "game-obj": "Traits",
+                    "name": "downtime",
+                    "type": "link"
+                  },
+                  "name": "downtime",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "dominate",
+                  "aonid": 87,
+                  "game-obj": "Spells",
+                  "name": "dominate",
+                  "type": "link"
+                }
+              ],
+              "name": "Dominate Animal",
+              "subtype": "ability",
+              "text": "The vrykolakas can cast *dominate* at will as a divine innate spell that affects only animals. The save DC is a high DC for the vrykolakas's level, and a creature that succeeds is immune to that vrykolakas's Dominate Animal for 24 hours. Destroying the vrykolakas ends the effect, but reducing it to 0 HP does not. A dominated animal takes a \u20134 circumstance penalty to saving throws against the vrykolakas's Feral Possession.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Drink Blood",
+              "subtype": "ability",
+              "text": "As a typical vrykolakas, but the creature is drained 2 instead of 1.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "rat swarms",
+              "aonid": 347,
+              "game-obj": "Monsters",
+              "name": "rat swarms",
+              "type": "link"
+            },
+            {
+              "alt": "warg",
+              "aonid": 402,
+              "game-obj": "Monsters",
+              "name": "warg",
+              "type": "link"
+            },
+            {
+              "alt": "werewolves",
+              "aonid": 411,
+              "game-obj": "Monsters",
+              "name": "werewolves",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 202,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "bubonic plague",
+              "aonid": 6,
+              "game-obj": "Diseases",
+              "name": "bubonic plague",
+              "type": "link"
+            },
+            {
+              "alt": "vampiric touch",
+              "aonid": 354,
+              "game-obj": "Spells",
+              "name": "vampiric touch",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 110,
+              "game-obj": "Deities",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "fatigued",
+              "aonid": 15,
+              "game-obj": "Conditions",
+              "name": "fatigued",
+              "type": "link"
+            },
+            {
+              "alt": "enfeebled 2",
+              "aonid": 13,
+              "game-obj": "Conditions",
+              "name": "enfeebled 2",
+              "type": "link"
+            },
+            {
+              "alt": "persistent bleed damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent bleed damage",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid form",
+              "aonid": 153,
+              "game-obj": "Spells",
+              "name": "humanoid form",
+              "type": "link"
+            },
+            {
+              "alt": "Deception",
+              "aonid": 5,
+              "game-obj": "Skills",
+              "name": "Deception",
+              "type": "link"
+            },
+            {
+              "alt": "Impersonate",
+              "aonid": 46,
+              "game-obj": "Actions",
+              "name": "Impersonate",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "downtime",
+              "aonid": 49,
+              "game-obj": "Traits",
+              "name": "downtime",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "vrykolakas spawn",
+              "aonid": 842,
+              "game-obj": "Monsters",
+              "name": "vrykolakas spawn",
+              "type": "link"
+            },
+            {
+              "alt": "friendly",
+              "aonid": 18,
+              "game-obj": "Conditions",
+              "name": "friendly",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "dominate",
+              "aonid": 87,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            }
+          ],
+          "name": "Vrykolakas Master Abilities",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 275",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 275",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 275,
+              "type": "source"
+            }
+          ],
+          "text": "Particularly powerful vrykolakas can create spawn from the bodies of their victims and gain additional abilities, as detailed below. Creatures of 9th level or higher can become a vrykolakas master, while those of 12th level or higher who have survived for centuries might become a vrykolakas ancient.   \n  \n**Children of the Night** (divine, enchantment, mental) The presence of a vrykolakas master inspires savage creatures to crawl forth to do its bidding, including rat swarms, warg, werewolves, and similar creatures. The vrykolakas master can give telepathic orders to these creatures within 100 feet, but they can't communicate back.   \n  \n**Pestilential Aura** (aura, divine, necromancy) 5 feet. Creatures beginning their turn in the area while the vrykolakas is in its true form are exposed to bubonic plague.   \n  \n**Divine Innate Spells** The vrykolakas master can cast *vampiric touch* (heightened to half its level rounded up) and 3rd-level fear three times per day each as divine innate spells. It uses a high DC for its level.   \n  \n**Bubonic Plague** (disease) **Saving Throw** Fortitude (use a high DC for the vrykolakas's level); **Onset** 1 day; **Stage 1** fatigued (1 day); **Stage 2** enfeebled 2 and fatigued (1 day); Stage 3 enfeebled 3, fatigued, and takes 1d6 persistent bleed damage every 1d20 minutes (1 day)   \n  \n**Change Shape** [#] (concentrate, divine, polymorph, transmutation) A vrykolakas master can transform into a form resembling the body it had in life, with the effects of *humanoid form* but with unlimited duration. It loses its fangs and claw Strikes but gains a +2 circumstance bonus to Deception checks to Impersonate in this form.   \n  \n**Create Spawn** (divine, downtime, necromancy) If a creature dies after being reduced to 0 HP by Drink Blood, a vrykolakas master can turn this creature into a vrykolakas spawn by donating some of its own blood to the creature and burying it in earth for 3 nights. Such vrykolakas spawn are generally friendly to the vrykolakas that created them, but they are not under its control and typically wander off on their own rampage within 1d6 days of their creation. **Dominate Animal** [#] (divine, enchantment, incapacitation, mental) The vrykolakas can cast *dominate* at will as a divine innate spell that affects only animals. The save DC is a high DC for the vrykolakas's level, and a creature that succeeds is immune to that vrykolakas's Dominate Animal for 24 hours. Destroying the vrykolakas ends the effect, but reducing it to 0 HP does not. A dominated animal takes a \u20134 circumstance penalty to saving throws against the vrykolakas's Feral Possession.   \n  \n**Drink Blood** As a typical vrykolakas, but the creature is drained 2 instead of 1.",
+          "type": "section"
+        },
         {
           "links": [
             {

--- a/monster_families/bestiary_2/worm_that_walks.json
+++ b/monster_families/bestiary_2/worm_that_walks.json
@@ -130,278 +130,84 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Tremorsense",
-                  "aonid": 40,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Tremorsense",
-                  "type": "link"
-                },
-                "name": "Tremorsense",
-                "subtype": "ability",
-                "text": "30 feet (imprecise)",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 40,
-                  "game-id": "0ee039798743b8879736178247f002d2",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Tremorsense",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 344",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 344",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 344,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "Tremorsense allows a monster to feel the vibrations through a solid surface caused by movement. It is an imprecise sense with a limited range (listed in the ability). Tremorsense functions only if the monster is on the same surface as the subject, and only if the subject is moving along (or burrowing through) the surface.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "swarm mind",
-                    "aonid": 36,
-                    "game-obj": "MonsterAbilities",
-                    "name": "swarm mind",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "mental",
-                    "aonid": 106,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "All worms that walk have immunity to disease, paralyzed, poison, precision, and unconscious. They also have the swarm mind ability, which makes them immune to mental effects that target a specific number of creatures, though they are still subject to mental effects that affect all creatures in an area.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "All-Around Vision",
-                  "aonid": 1,
-                  "game-obj": "MonsterAbilities",
-                  "name": "All-Around Vision",
-                  "type": "link"
-                },
-                "name": "All-Around Vision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 1,
-                  "game-id": "88dd1f466910b7acdbc5e465908bf003",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "flanked",
-                      "aonid": 458,
-                      "game-obj": "Rules",
-                      "name": "flanked",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "All-Around Vision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "This monster can see in all directions simultaneously, and therefore can't be flanked.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Discorporate",
-                "subtype": "ability",
-                "text": "When the worm that walks is reduced to 0 HP, it discorporates and the component worms that make up its body disperse in every direction. If even a single worm escapes, the worm that walks will eventually re-form using a process that typically takes 1d10 days.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "persistent piercing damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent piercing damage",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  }
-                ],
-                "name": "Tendril",
-                "subtype": "ability",
-                "text": "Regardless of the creature\u2019s former anatomy, it gains a tendril melee Strike with reach that deals persistent piercing damage as it leaves biting worms on the target. If it had any agile attacks, the damage dealt by its tendril should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its tendril should deal three-quarters of that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Squirming Embrace",
-                "subtype": "ability",
-                "text": "The worm that walks Strides, ending its movement sharing a space with a creature, and deals piercing damage to the creature equal to 1d8 plus an additional 1d8 for every 3 levels the worm that walks has. The creature can attempt a basic Reflex save with a DC of the worm that walks\u2019s spell DC \u2013 2.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Squeeze",
-                    "aonid": 31,
-                    "game-obj": "Actions",
-                    "name": "Squeeze",
-                    "type": "link"
-                  }
-                ],
-                "name": "Swarm Shape",
-                "subtype": "ability",
-                "text": "The worm that walks collapses into a shapeless swarm of worms. It drops all held, worn, and carried items. While discorporated, the worm that walks can\u2019t use attack actions and can\u2019t cast spells, but it can move through areas small enough for its individual worms to fit without having to Squeeze. It can use the same action to coalesce back into its normal form.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Worm That Walks')].sections[?(@.name=='Worm That Walks Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Tremorsense",
+                "aonid": 40,
+                "game-obj": "MonsterAbilities",
+                "name": "Tremorsense",
+                "type": "link"
+              },
+              {
+                "alt": "swarm mind",
+                "aonid": 36,
+                "game-obj": "MonsterAbilities",
+                "name": "swarm mind",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "All-Around Vision",
+                "aonid": 1,
+                "game-obj": "MonsterAbilities",
+                "name": "All-Around Vision",
+                "type": "link"
+              },
+              {
+                "alt": "splash",
+                "aonid": 150,
+                "game-obj": "Traits",
+                "name": "splash",
+                "type": "link"
+              },
+              {
+                "alt": "persistent piercing damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent piercing damage",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "Squeeze",
+                "aonid": 31,
+                "game-obj": "Actions",
+                "name": "Squeeze",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -411,36 +217,26 @@
         ],
         "name": "Worm That Walks Abilities",
         "subtype": "monster_family",
-        "text": "A worm that walks loses any abilities that came from its previous physical form and any traits that represent its life, such as human and humanoid. It retains any spellcasting abilities it had in life, regardless of their origin, and gains the abilities listed below. You might need to adjust other abilities that conflict with the monster\u2019s new theme as a worm that walks.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "light blindness",
-                    "aonid": 22,
-                    "game-obj": "MonsterAbilities",
-                    "name": "light blindness",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cockroaches",
-                "subtype": "ability",
-                "text": ": A worm that walks made of cockroaches gains a +1 bonus to AC and light blindness.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Worm That Walks')].sections[?(@.name=='Other Walking Vermin')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "light blindness",
+                "aonid": 22,
+                "game-obj": "MonsterAbilities",
+                "name": "light blindness",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -450,7 +246,6 @@
         ],
         "name": "Other Walking Vermin",
         "subtype": "monster_family",
-        "text": "While worms are the most common type of creature to form the composite body of a worm that walks, other verminous variations are possible. \n* \n* **Leeches**: A worm that walks made of leeches gains a swim Speed of 25 feet, but its land Speed is 10 feet.\n* **Spiders**: A worm that walks made of spiders gains a climb Speed equal to half its land Speed, and half the damage from its Squirming Embrace is poison damage.",
         "type": "stat_block_section"
       }
     ],
@@ -488,6 +283,423 @@
     {
       "name": "Worm That Walks",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Tremorsense",
+                "aonid": 40,
+                "game-obj": "MonsterAbilities",
+                "name": "Tremorsense",
+                "type": "link"
+              },
+              "name": "Tremorsense",
+              "subtype": "ability",
+              "text": "30 feet (imprecise)",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 40,
+                "game-id": "0ee039798743b8879736178247f002d2",
+                "game-obj": "MonsterAbilities",
+                "name": "Tremorsense",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 344",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 344",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 344,
+                    "type": "source"
+                  }
+                ],
+                "text": "Tremorsense allows a monster to feel the vibrations through a solid surface caused by movement. It is an imprecise sense with a limited range (listed in the ability). Tremorsense functions only if the monster is on the same surface as the subject, and only if the subject is moving along (or burrowing through) the surface.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "swarm mind",
+                  "aonid": 36,
+                  "game-obj": "MonsterAbilities",
+                  "name": "swarm mind",
+                  "type": "link"
+                },
+                {
+                  "alt": "mental",
+                  "aonid": 106,
+                  "game-obj": "Traits",
+                  "name": "mental",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "All worms that walk have immunity to disease, paralyzed, poison, precision, and unconscious. They also have the swarm mind ability, which makes them immune to mental effects that target a specific number of creatures, though they are still subject to mental effects that affect all creatures in an area.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "All-Around Vision",
+                "aonid": 1,
+                "game-obj": "MonsterAbilities",
+                "name": "All-Around Vision",
+                "type": "link"
+              },
+              "name": "All-Around Vision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 1,
+                "game-id": "88dd1f466910b7acdbc5e465908bf003",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "flanked",
+                    "aonid": 458,
+                    "game-obj": "Rules",
+                    "name": "flanked",
+                    "type": "link"
+                  }
+                ],
+                "name": "All-Around Vision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "This monster can see in all directions simultaneously, and therefore can't be flanked.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Discorporate",
+              "subtype": "ability",
+              "text": "When the worm that walks is reduced to 0 HP, it discorporates and the component worms that make up its body disperse in every direction. If even a single worm escapes, the worm that walks will eventually re-form using a process that typically takes 1d10 days.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "persistent piercing damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent piercing damage",
+                  "type": "link"
+                },
+                {
+                  "alt": "agile",
+                  "aonid": 170,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                }
+              ],
+              "name": "Tendril",
+              "subtype": "ability",
+              "text": "Regardless of the creature\u2019s former anatomy, it gains a tendril melee Strike with reach that deals persistent piercing damage as it leaves biting worms on the target. If it had any agile attacks, the damage dealt by its tendril should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its tendril should deal three-quarters of that damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "1d8",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Squirming Embrace",
+              "subtype": "ability",
+              "text": "The worm that walks Strides, ending its movement sharing a space with a creature, and deals piercing damage to the creature equal to 1d8 plus an additional 1d8 for every 3 levels the worm that walks has. The creature can attempt a basic Reflex save with a DC of the worm that walks\u2019s spell DC \u2013 2.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "Squeeze",
+                  "aonid": 31,
+                  "game-obj": "Actions",
+                  "name": "Squeeze",
+                  "type": "link"
+                }
+              ],
+              "name": "Swarm Shape",
+              "subtype": "ability",
+              "text": "The worm that walks collapses into a shapeless swarm of worms. It drops all held, worn, and carried items. While discorporated, the worm that walks can\u2019t use attack actions and can\u2019t cast spells, but it can move through areas small enough for its individual worms to fit without having to Squeeze. It can use the same action to coalesce back into its normal form.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Tremorsense",
+              "aonid": 40,
+              "game-obj": "MonsterAbilities",
+              "name": "Tremorsense",
+              "type": "link"
+            },
+            {
+              "alt": "swarm mind",
+              "aonid": 36,
+              "game-obj": "MonsterAbilities",
+              "name": "swarm mind",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "All-Around Vision",
+              "aonid": 1,
+              "game-obj": "MonsterAbilities",
+              "name": "All-Around Vision",
+              "type": "link"
+            },
+            {
+              "alt": "splash",
+              "aonid": 150,
+              "game-obj": "Traits",
+              "name": "splash",
+              "type": "link"
+            },
+            {
+              "alt": "persistent piercing damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent piercing damage",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "Squeeze",
+              "aonid": 31,
+              "game-obj": "Actions",
+              "name": "Squeeze",
+              "type": "link"
+            }
+          ],
+          "name": "Worm That Walks Abilities",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 296",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "A worm that walks loses any abilities that came from its previous physical form and any traits that represent its life, such as human and humanoid. It retains any spellcasting abilities it had in life, regardless of their origin, and gains the abilities listed below. You might need to adjust other abilities that conflict with the monster\u2019s new theme as a worm that walks.   \n  \n**Darkvision**   \n  \n**Tremorsense** 30 feet (imprecise)   \n  \n**Immunities** All worms that walk have immunity to disease, paralyzed, poison, precision, and unconscious. They also have the swarm mind ability, which makes them immune to mental effects that target a specific number of creatures, though they are still subject to mental effects that affect all creatures in an area.   \n  \n**All-Around Vision**   \n  \n**Discorporate** When the worm that walks is reduced to 0 HP, it discorporates and the component worms that make up its body disperse in every direction. If even a single worm escapes, the worm that walks will eventually re-form using a process that typically takes 1d10 days.  \n  \n While the exact circumstances and surroundings determine how long the worm that walks\u2019s foes have to dispatch the fleeing worms before they escape, usually its foes have only a single round. Typically, this requires the application of an area effect or splash weapon within 1 round to the space where the worm that walks collapsed. After any amount of area or splash damage is dealt to that space, the character dealing the damage must attempt a DC 15 flat check. Each subsequent area or splash damage effect performed on the area reduces the DC of this flat check by 2, to a minimum of DC 5. If any of these flat checks succeed, none of the worms escape, and the worm that walks is destroyed permanently. At the GM\u2019s discretion, clever means of trapping or otherwise detaining the vermin may extend the time allowed to finish off the worm that walks.   \n  \n**Tendril** Regardless of the creature\u2019s former anatomy, it gains a tendril melee Strike with reach that deals persistent piercing damage as it leaves biting worms on the target. If it had any agile attacks, the damage dealt by its tendril should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its tendril should deal three-quarters of that damage.   \n  \n**Squirming Embrace** [#] The worm that walks Strides, ending its movement sharing a space with a creature, and deals piercing damage to the creature equal to 1d8 plus an additional 1d8 for every 3 levels the worm that walks has. The creature can attempt a basic Reflex save with a DC of the worm that walks\u2019s spell DC \u2013 2.   \n  \n**Swarm Shape** [#] (concentrate) The worm that walks collapses into a shapeless swarm of worms. It drops all held, worn, and carried items. While discorporated, the worm that walks can\u2019t use attack actions and can\u2019t cast spells, but it can move through areas small enough for its individual worms to fit without having to Squeeze. It can use the same action to coalesce back into its normal form.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "light blindness",
+                  "aonid": 22,
+                  "game-obj": "MonsterAbilities",
+                  "name": "light blindness",
+                  "type": "link"
+                }
+              ],
+              "name": "Cockroaches",
+              "subtype": "ability",
+              "text": ": A worm that walks made of cockroaches gains a +1 bonus to AC and light blindness.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "light blindness",
+              "aonid": 22,
+              "game-obj": "MonsterAbilities",
+              "name": "light blindness",
+              "type": "link"
+            }
+          ],
+          "name": "Other Walking Vermin",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.0",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "2.0",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Bestiary 2 pg. 296",
+                "aonid": 32,
+                "game-obj": "Sources",
+                "name": "Bestiary 2 pg. 296",
+                "type": "link"
+              },
+              "name": "Bestiary 2",
+              "page": 296,
+              "type": "source"
+            }
+          ],
+          "text": "While worms are the most common type of creature to form the composite body of a worm that walks, other verminous variations are possible. \n* **Cockroaches**: A worm that walks made of cockroaches gains a +1 bonus to AC and light blindness.\n* **Leeches**: A worm that walks made of leeches gains a swim Speed of 25 feet, but its land Speed is 10 feet.\n* **Spiders**: A worm that walks made of spiders gains a climb Speed equal to half its land Speed, and half the damage from its Squirming Embrace is poison damage.",
+          "type": "section"
+        },
         {
           "name": "Worms Redeemed",
           "sources": [

--- a/monster_families/bestiary_3/beheaded.json
+++ b/monster_families/bestiary_3/beheaded.json
@@ -35,154 +35,77 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bleeding",
-                "subtype": "ability",
-                "text": "The beheaded is covered in slimy blood. The target of a successful Strike is splattered with gore and must succeed at a Fortitude save or become sickened 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Entangling",
-                "subtype": "ability",
-                "text": "Long, stringy hair clings to the beheaded's scalp. Its Strikes gain the Grab ability.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightened 1",
-                    "aonid": 19,
-                    "game-obj": "Conditions",
-                    "name": "frightened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fiendish",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The beheaded has a twisted, unsettling countenance. Foes that begin their turn in the area must succeed at a Will save or be frightened 1.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Giant",
-                "subtype": "ability",
-                "text": "A beheaded created from the head of a giant is a Medium creature, gaining 2 levels and one or more additional beheaded abilities.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Beheaded Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "sickened 1",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 1",
+                "aonid": 19,
+                "game-obj": "Conditions",
+                "name": "frightened 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -192,192 +115,103 @@
         ],
         "name": "Beheaded Abilities",
         "subtype": "monster_family",
-        "text": "Beheaded can manifest with a variety of abilities, such as those presented below.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "lifesense",
-                    "aonid": 21,
-                    "game-obj": "MonsterAbilities",
-                    "name": "lifesense",
-                    "type": "link"
-                  }
-                ],
-                "name": "Lifesense",
-                "subtype": "ability",
-                "text": "The beheaded has imprecise lifesense out to 60 feet.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 21,
-                  "game-id": "fb27e655dfdce59a449430811465c91f",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Lifesense",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "Lifesense allows a monster to sense the vital essence of living and undead creatures within the listed range. The sense can distinguish between the positive energy animating living creatures and the negative energy animating undead creatures, much as sight distinguishes colors.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "moderate DC for the beheaded's level",
-                    "aonid": 554,
-                    "game-obj": "Rules",
-                    "name": "moderate DC for the beheaded's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Whispering",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The beheaded constantly whispers twisted incantations in unknown languages secret and foul. Foes that enter or begin their turn in the area must succeed at a Will save or be stupefied 1. The aura uses the moderate DC for the beheaded's level.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "frequency": "once per round",
-                "links": [
-                  {
-                    "alt": "dragon",
-                    "aonid": 50,
-                    "game-obj": "Traits",
-                    "name": "dragon",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "medusa",
-                    "aonid": 297,
-                    "game-obj": "Monsters",
-                    "name": "medusa",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "skeleton",
-                    "aonid": 92,
-                    "game-obj": "MonsterFamilies",
-                    "name": "skeleton",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "zombie",
-                    "aonid": 103,
-                    "game-obj": "MonsterFamilies",
-                    "name": "zombie",
-                    "type": "link"
-                  }
-                ],
-                "name": "Furious Headbutt",
-                "subtype": "ability",
-                "text": "**Frequency** once per round; **Effect** The beheaded makes a wild Strike, taking a \u20132 penalty to its AC until the end of its next turn. If the Strike damages a creature, it deals additional damage equal to the beheaded's level.###  Monstrous Heads\n\nWhile the traditional image of a beheaded is that of a disembodied human head or skull, necromancers can create beheaded out of any sort of head. This variety can lead to extremely distinctive beheaded, including dragon heads, giant insect heads, medusa heads, or those of even rarer creatures. Occasionally, such beheaded retain weakened versions of their original special abilities from the constituent creature instead of a beheaded ability, such as a breath weapon for a dragon head or a gaze for a medusa head.###  More Beheaded Abilities\n\nSince beheaded are very similar to skeletons or zombies (or at least the heads from those creatures), you can also customize them with abilities from the skeleton and zombie entries, though take care to avoid abilities that require bodies or limbs. If you give the beheaded more than one additional ability, you might want to increase its level and adjust its statistics accordingly. Use the guidelines in Chapter 2 of the *Pathfinder Gamemastery Guide* to determine its new statistics.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Beheaded Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "lifesense",
+                "aonid": 21,
+                "game-obj": "MonsterAbilities",
+                "name": "lifesense",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 1",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
+              },
+              {
+                "alt": "moderate DC for the beheaded's level",
+                "aonid": 554,
+                "game-obj": "Rules",
+                "name": "moderate DC for the beheaded's level",
+                "type": "link"
+              },
+              {
+                "alt": "dragon",
+                "aonid": 50,
+                "game-obj": "Traits",
+                "name": "dragon",
+                "type": "link"
+              },
+              {
+                "alt": "medusa",
+                "aonid": 297,
+                "game-obj": "Monsters",
+                "name": "medusa",
+                "type": "link"
+              },
+              {
+                "alt": "skeleton",
+                "aonid": 92,
+                "game-obj": "MonsterFamilies",
+                "name": "skeleton",
+                "type": "link"
+              },
+              {
+                "alt": "zombie",
+                "aonid": 103,
+                "game-obj": "MonsterFamilies",
+                "name": "zombie",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -394,6 +228,523 @@
   },
   "name": "Beheaded",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "sickened 1",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Bleeding",
+          "subtype": "ability",
+          "text": "The beheaded is covered in slimy blood. The target of a successful Strike is splattered with gore and must succeed at a Fortitude save or become sickened 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Entangling",
+          "subtype": "ability",
+          "text": "Long, stringy hair clings to the beheaded's scalp. Its Strikes gain the Grab ability.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "frightened 1",
+              "aonid": 19,
+              "game-obj": "Conditions",
+              "name": "frightened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Fiendish",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The beheaded has a twisted, unsettling countenance. Foes that begin their turn in the area must succeed at a Will save or be frightened 1.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Giant",
+          "subtype": "ability",
+          "text": "A beheaded created from the head of a giant is a Medium creature, gaining 2 levels and one or more additional beheaded abilities.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "sickened 1",
+          "aonid": 34,
+          "game-obj": "Conditions",
+          "name": "sickened 1",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 18,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 206,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 68,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "frightened 1",
+          "aonid": 19,
+          "game-obj": "Conditions",
+          "name": "frightened 1",
+          "type": "link"
+        }
+      ],
+      "name": "Beheaded Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 30",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 30",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 30,
+          "type": "source"
+        },
+        {
+          "link": {
+            "alt": "Book of the Dead pg. 74",
+            "href": "https://paizo.com/products/btq02c0j",
+            "name": "Book of the Dead pg. 74",
+            "type": "link"
+          },
+          "name": "Book of the Dead",
+          "page": 74,
+          "type": "source"
+        }
+      ],
+      "text": "Beheaded can manifest with a variety of abilities, such as those presented below.   \n  \n**Bleeding** The beheaded is covered in slimy blood. The target of a successful Strike is splattered with gore and must succeed at a Fortitude save or become sickened 1.   \n  \n**Entangling** Long, stringy hair clings to the beheaded's scalp. Its Strikes gain the Grab ability.   \n  \n**Fiendish** (aura, divine, emotion, fear, mental, necromancy) 30 feet. The beheaded has a twisted, unsettling countenance. Foes that begin their turn in the area must succeed at a Will save or be frightened 1.   \n  \n**Giant** A beheaded created from the head of a giant is a Medium creature, gaining 2 levels and one or more additional beheaded abilities.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "lifesense",
+              "aonid": 21,
+              "game-obj": "MonsterAbilities",
+              "name": "lifesense",
+              "type": "link"
+            }
+          ],
+          "name": "Lifesense",
+          "subtype": "ability",
+          "text": "The beheaded has imprecise lifesense out to 60 feet.",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 21,
+            "game-id": "fb27e655dfdce59a449430811465c91f",
+            "game-obj": "MonsterAbilities",
+            "name": "Lifesense",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 343",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 343",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 343,
+                "type": "source"
+              }
+            ],
+            "text": "Lifesense allows a monster to sense the vital essence of living and undead creatures within the listed range. The sense can distinguish between the positive energy animating living creatures and the negative energy animating undead creatures, much as sight distinguishes colors.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "stupefied 1",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            },
+            {
+              "alt": "moderate DC for the beheaded's level",
+              "aonid": 554,
+              "game-obj": "Rules",
+              "name": "moderate DC for the beheaded's level",
+              "type": "link"
+            }
+          ],
+          "name": "Whispering",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The beheaded constantly whispers twisted incantations in unknown languages secret and foul. Foes that enter or begin their turn in the area must succeed at a Will save or be stupefied 1. The aura uses the moderate DC for the beheaded's level.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "frequency": "once per round",
+          "links": [
+            {
+              "alt": "dragon",
+              "aonid": 50,
+              "game-obj": "Traits",
+              "name": "dragon",
+              "type": "link"
+            },
+            {
+              "alt": "medusa",
+              "aonid": 297,
+              "game-obj": "Monsters",
+              "name": "medusa",
+              "type": "link"
+            },
+            {
+              "alt": "skeleton",
+              "aonid": 92,
+              "game-obj": "MonsterFamilies",
+              "name": "skeleton",
+              "type": "link"
+            },
+            {
+              "alt": "zombie",
+              "aonid": 103,
+              "game-obj": "MonsterFamilies",
+              "name": "zombie",
+              "type": "link"
+            }
+          ],
+          "name": "Furious Headbutt",
+          "subtype": "ability",
+          "text": "**Frequency** once per round; **Effect** The beheaded makes a wild Strike, taking a \u20132 penalty to its AC until the end of its next turn. If the Strike damages a creature, it deals additional damage equal to the beheaded's level.###  Monstrous Heads\n\nWhile the traditional image of a beheaded is that of a disembodied human head or skull, necromancers can create beheaded out of any sort of head. This variety can lead to extremely distinctive beheaded, including dragon heads, giant insect heads, medusa heads, or those of even rarer creatures. Occasionally, such beheaded retain weakened versions of their original special abilities from the constituent creature instead of a beheaded ability, such as a breath weapon for a dragon head or a gaze for a medusa head.###  More Beheaded Abilities\n\nSince beheaded are very similar to skeletons or zombies (or at least the heads from those creatures), you can also customize them with abilities from the skeleton and zombie entries, though take care to avoid abilities that require bodies or limbs. If you give the beheaded more than one additional ability, you might want to increase its level and adjust its statistics accordingly. Use the guidelines in Chapter 2 of the *Pathfinder Gamemastery Guide* to determine its new statistics.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "lifesense",
+          "aonid": 21,
+          "game-obj": "MonsterAbilities",
+          "name": "lifesense",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 206,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 68,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "stupefied 1",
+          "aonid": 37,
+          "game-obj": "Conditions",
+          "name": "stupefied 1",
+          "type": "link"
+        },
+        {
+          "alt": "moderate DC for the beheaded's level",
+          "aonid": 554,
+          "game-obj": "Rules",
+          "name": "moderate DC for the beheaded's level",
+          "type": "link"
+        },
+        {
+          "alt": "dragon",
+          "aonid": 50,
+          "game-obj": "Traits",
+          "name": "dragon",
+          "type": "link"
+        },
+        {
+          "alt": "medusa",
+          "aonid": 297,
+          "game-obj": "Monsters",
+          "name": "medusa",
+          "type": "link"
+        },
+        {
+          "alt": "skeleton",
+          "aonid": 92,
+          "game-obj": "MonsterFamilies",
+          "name": "skeleton",
+          "type": "link"
+        },
+        {
+          "alt": "zombie",
+          "aonid": 103,
+          "game-obj": "MonsterFamilies",
+          "name": "zombie",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Beheaded Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Book of the Dead pg. 74",
+            "href": "https://paizo.com/products/btq02c0j",
+            "name": "Book of the Dead pg. 74",
+            "type": "link"
+          },
+          "name": "Book of the Dead",
+          "page": 74,
+          "type": "source"
+        }
+      ],
+      "text": "**Lifesense** The beheaded has imprecise lifesense out to 60 feet.  \n  \n**Whispering** (aura, emotion, fear, mental, necromancy) 30 feet. The beheaded constantly whispers twisted incantations in unknown languages secret and foul. Foes that enter or begin their turn in the area must succeed at a Will save or be stupefied 1. The aura uses the moderate DC for the beheaded's level.  \n  \n**Furious Headbutt** **Frequency** once per round; **Effect** The beheaded makes a wild Strike, taking a \u20132 penalty to its AC until the end of its next turn. If the Strike damages a creature, it deals additional damage equal to the beheaded's level.###  Monstrous Heads\n\nWhile the traditional image of a beheaded is that of a disembodied human head or skull, necromancers can create beheaded out of any sort of head. This variety can lead to extremely distinctive beheaded, including dragon heads, giant insect heads, medusa heads, or those of even rarer creatures. Occasionally, such beheaded retain weakened versions of their original special abilities from the constituent creature instead of a beheaded ability, such as a breath weapon for a dragon head or a gaze for a medusa head.###  More Beheaded Abilities\n\nSince beheaded are very similar to skeletons or zombies (or at least the heads from those creatures), you can also customize them with abilities from the skeleton and zombie entries, though take care to avoid abilities that require bodies or limbs. If you give the beheaded more than one additional ability, you might want to increase its level and adjust its statistics accordingly. Use the guidelines in Chapter 2 of the *Pathfinder Gamemastery Guide* to determine its new statistics.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/bestiary_3/bore_worm.json
+++ b/monster_families/bestiary_3/bore_worm.json
@@ -24,67 +24,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Ice Worms",
-                "subtype": "ability",
-                "text": ": Found tunneling through the glaciers beneath the Crown of the World, these pale-blue worms behave similarly to their soil-bred cousins, but their frigid acid inflicts marks similar to frostbite on anything they touch. Ice worms still flee from liquid water but are immune to cold rather than to acid, and they substitute cold for acid in all of their attacks and abilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Lava Worms",
-                "subtype": "ability",
-                "text": ": Dwelling in the deepest, hottest reaches of the Darklands, these bizarre creatures consume not living matter but minerals and rare earths. They're most often found near volcanoes or open magma and will swim through the lava in pursuit of a meal. Lava worms are immune to fire rather than to acid, and they substitute fire for acid in all of their attacks and abilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "undead",
-                    "aonid": 160,
-                    "game-obj": "Traits",
-                    "name": "undead",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "negative healing",
-                    "aonid": 42,
-                    "game-obj": "MonsterAbilities",
-                    "name": "negative healing",
-                    "type": "link"
-                  }
-                ],
-                "name": "Necral Worms",
-                "subtype": "ability",
-                "text": ": An undead sorcerer in the ghoul-run Darklands city of Nemret Noktoria developed necral worms about 60 years ago by filling an empress bore worm's abandoned exoskeleton with a unique alchemical paste. These undead bore worms radiate the very energies of death, making them surprisingly sophisticated magical batteries. Less pleasant entities often use them as magical tools. Necral worms have the undead trait and negative healing. They substitute negative damage for acid damage in all of their attacks and abilities, and they gain a weakness to positive damage in place of their weakness to water.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "counteract",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mage-Eater Worms",
-                "subtype": "ability",
-                "text": ": These luminous, purple worms present just one more reason to avoid the Mana Wastes between Geb and Nex, where magic is unreliable at best and more often dangerously unpredictable. When a creature fails a save against Swarming Bites or Painful Bite, the worms also attempt a counteract check against a single spell affecting the creature (counteract level 3, counteract modifier +12).",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Variant Bore Worms')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "undead",
+                "aonid": 160,
+                "game-obj": "Traits",
+                "name": "undead",
+                "type": "link"
+              },
+              {
+                "alt": "negative healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "negative healing",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -94,7 +62,6 @@
         ],
         "name": "Variant Bore Worms",
         "subtype": "monster_family",
-        "text": "The humble bore worm is a small and simple creature, both biologically and magically. These qualities allow it to adapt rapidly to different environments, some of them quite extreme, and also makes it susceptible to magical radiation and experimentation. Many a Darklands apprentice takes their first steps in the school of transmutation by practicing on these worms, while variations\u2014 both natural and cultivated\u2014are scattered about beneath Golarion's surface.",
         "type": "stat_block_section"
       }
     ],
@@ -102,6 +69,145 @@
   },
   "name": "Bore Worm",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Ice Worms",
+          "subtype": "ability",
+          "text": ": Found tunneling through the glaciers beneath the Crown of the World, these pale-blue worms behave similarly to their soil-bred cousins, but their frigid acid inflicts marks similar to frostbite on anything they touch. Ice worms still flee from liquid water but are immune to cold rather than to acid, and they substitute cold for acid in all of their attacks and abilities.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Lava Worms",
+          "subtype": "ability",
+          "text": ": Dwelling in the deepest, hottest reaches of the Darklands, these bizarre creatures consume not living matter but minerals and rare earths. They're most often found near volcanoes or open magma and will swim through the lava in pursuit of a meal. Lava worms are immune to fire rather than to acid, and they substitute fire for acid in all of their attacks and abilities.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 160,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "negative healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "negative healing",
+              "type": "link"
+            }
+          ],
+          "name": "Necral Worms",
+          "subtype": "ability",
+          "text": ": An undead sorcerer in the ghoul-run Darklands city of Nemret Noktoria developed necral worms about 60 years ago by filling an empress bore worm's abandoned exoskeleton with a unique alchemical paste. These undead bore worms radiate the very energies of death, making them surprisingly sophisticated magical batteries. Less pleasant entities often use them as magical tools. Necral worms have the undead trait and negative healing. They substitute negative damage for acid damage in all of their attacks and abilities, and they gain a weakness to positive damage in place of their weakness to water.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "counteract",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            }
+          ],
+          "name": "Mage-Eater Worms",
+          "subtype": "ability",
+          "text": ": These luminous, purple worms present just one more reason to avoid the Mana Wastes between Geb and Nex, where magic is unreliable at best and more often dangerously unpredictable. When a creature fails a save against Swarming Bites or Painful Bite, the worms also attempt a counteract check against a single spell affecting the creature (counteract level 3, counteract modifier +12).",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "undead",
+          "aonid": 160,
+          "game-obj": "Traits",
+          "name": "undead",
+          "type": "link"
+        },
+        {
+          "alt": "negative healing",
+          "aonid": 42,
+          "game-obj": "MonsterAbilities",
+          "name": "negative healing",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 371,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        }
+      ],
+      "name": "Variant Bore Worms",
+      "sections": [
+        {
+          "name": "Bore Worm Farming",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 36",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 36",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 36,
+              "type": "source"
+            }
+          ],
+          "text": "Despite their repulsive appearance, bore worms play an important part in the Darklands ecosystem by transforming rotting plants and animals into rich, loamy soil. Many subterranean farmers lure them to their property but must keep them well fed to avoid the cannibalistic frenzy that creates an empress bore worm. Bore worms also serve as a staple of Darklands cuisine. If properly cooked with fungus and plenty of salt, they become a favored delicacy; uncooked, they prove considerably less appetizing.",
+          "type": "section"
+        },
+        {
+          "name": "Hydrophobia",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 36",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 36",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 36,
+              "type": "source"
+            }
+          ],
+          "text": "Water causes bore worms to curdle and die\u2014even an empress bore worm will smoke and twitch, its shell eventually turning a dull brown before caving inwards. The secret as to why lies in the chemical composition of the worm's acid. Normally, bore worms are immune to their own acid, but exposure to water alters the acid's nature, and so the worms burn alive in their own secretions.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 36",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 36",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 36,
+          "type": "source"
+        }
+      ],
+      "text": "The humble bore worm is a small and simple creature, both biologically and magically. These qualities allow it to adapt rapidly to different environments, some of them quite extreme, and also makes it susceptible to magical radiation and experimentation. Many a Darklands apprentice takes their first steps in the school of transmutation by practicing on these worms, while variations\u2014 both natural and cultivated\u2014are scattered about beneath Golarion's surface.  \n  \n**Ice Worms**: Found tunneling through the glaciers beneath the Crown of the World, these pale-blue worms behave similarly to their soil-bred cousins, but their frigid acid inflicts marks similar to frostbite on anything they touch. Ice worms still flee from liquid water but are immune to cold rather than to acid, and they substitute cold for acid in all of their attacks and abilities.  \n  \n**Lava Worms**: Dwelling in the deepest, hottest reaches of the Darklands, these bizarre creatures consume not living matter but minerals and rare earths. They're most often found near volcanoes or open magma and will swim through the lava in pursuit of a meal. Lava worms are immune to fire rather than to acid, and they substitute fire for acid in all of their attacks and abilities.  \n  \n**Necral Worms**: An undead sorcerer in the ghoul-run Darklands city of Nemret Noktoria developed necral worms about 60 years ago by filling an empress bore worm's abandoned exoskeleton with a unique alchemical paste. These undead bore worms radiate the very energies of death, making them surprisingly sophisticated magical batteries. Less pleasant entities often use them as magical tools. Necral worms have the undead trait and negative healing. They substitute negative damage for acid damage in all of their attacks and abilities, and they gain a weakness to positive damage in place of their weakness to water.  \n  \n**Mage-Eater Worms**: These luminous, purple worms present just one more reason to avoid the Mana Wastes between Geb and Nex, where magic is unreliable at best and more often dangerously unpredictable. When a creature fails a save against Swarming Bites or Painful Bite, the worms also attempt a counteract check against a single spell affecting the creature (counteract level 3, counteract modifier +12).",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/bestiary_3/clockworks.json
+++ b/monster_families/bestiary_3/clockworks.json
@@ -30,22 +30,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Wind-Up",
-                "subtype": "ability",
-                "text": "For a clockwork to act, it must be wound with a unique key by another creature. This takes 1 minute. Once wound, it remains operational for the listed amount of time, usually 24 hours, after which time it becomes unaware of its surroundings and can't act until it's wound again. Some clockworks' abilities require them to spend some of their remaining operational time. They can't spend more than they have and shut down immediately once they have 0 time remaining. If it's unclear when a clockwork was last wound, most clockwork keepers wind all their clockworks at a set time, typically 8 a.m.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Winding Clockworks')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Disable a Device",
+                "aonid": 69,
+                "game-obj": "Actions",
+                "name": "Disable a Device",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -59,80 +58,21 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_type": "ability",
-                    "area": [
-                      {
-                        "shape": "cone",
-                        "size": 15,
-                        "subtype": "area",
-                        "text": "15-foot cone",
-                        "type": "stat_block_section",
-                        "unit": "feet"
-                      }
-                    ],
-                    "damage": [
-                      {
-                        "damage_type": "fire",
-                        "formula": "2d6",
-                        "subtype": "attack_damage",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "links": [
-                      {
-                        "alt": "slowed 1",
-                        "aonid": 35,
-                        "game-obj": "Conditions",
-                        "name": "slowed 1",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Backfire",
-                    "saving_throw": [
-                      {
-                        "dc": 5,
-                        "save_type": "Flat Check",
-                        "subtype": "save_dc",
-                        "text": "DC 5 flat check",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "ability",
-                    "text": ": The clockwork rolls a DC 5 flat check at the start of each of its turns. On a failure, it backfires, dealing 2d6 fire damage in a 15-foot cone, including to itself (basic Reflex save at the standard DC for its level), and is slowed 1 this turn.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "name": "Damaged Propulsion",
-                    "subtype": "ability",
-                    "text": ": The clockwork loses 1d4 hours of operational time at the end of each of its turns.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "name": "Loose Screws",
-                    "saving_throw": [
-                      {
-                        "dc": 5,
-                        "save_type": "Flat Check",
-                        "subtype": "save_dc",
-                        "text": "DC 5 flat check",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "ability",
-                    "text": ": When damaged, the clockwork attempts a DC 5 flat check. On a failure, a plate of its armor falls loose. It takes a status penalty to AC equal to the number of lost plates (up to \u20134).",
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Winding Clockworks')].sections[?(@.name=='Malfunction!')].abilities",
                     "target": "$.defense.automatic_abilities"
+                  }
+                ],
+                "links": [
+                  {
+                    "alt": "slowed 1",
+                    "aonid": 35,
+                    "game-obj": "Conditions",
+                    "name": "slowed 1",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -142,11 +82,9 @@
             ],
             "name": "Malfunction!",
             "subtype": "monster_family",
-            "text": "Clockworks can be prone to errors if not well maintained or properly programmed. You might want to introduce one of the malfunctions listed below in a clockwork that is in disrepair or gets damaged heavily in battle (such as with a critical hit).",
             "type": "stat_block_section"
           }
         ],
-        "text": "A clockwork must be wound to remain operational. Each clockwork has the wind-up ability, with the specifics listed in its stat block.",
         "type": "stat_block_section"
       }
     ],
@@ -154,6 +92,217 @@
   },
   "name": "Clockworks",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Wind-Up",
+          "subtype": "ability",
+          "text": "For a clockwork to act, it must be wound with a unique key by another creature. This takes 1 minute. Once wound, it remains operational for the listed amount of time, usually 24 hours, after which time it becomes unaware of its surroundings and can't act until it's wound again. Some clockworks' abilities require them to spend some of their remaining operational time. They can't spend more than they have and shut down immediately once they have 0 time remaining. If it's unclear when a clockwork was last wound, most clockwork keepers wind all their clockworks at a set time, typically 8 a.m.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Disable a Device",
+          "aonid": 69,
+          "game-obj": "Actions",
+          "name": "Disable a Device",
+          "type": "link"
+        }
+      ],
+      "name": "Winding Clockworks",
+      "sections": [
+        {
+          "name": "Clockwork Research",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 48",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 48",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 48,
+              "type": "source"
+            }
+          ],
+          "text": "Clockworks were invented in ancient times, culminating in the clockwork army of Xin, the first emperor of ancient Thassilon, but were lost for millennia. Disparate peoples later rediscovered the techniques and began to alter and improve them. Today, the Clockwork Cathedral in Absalom is a center of clockwork research, with many breakthroughs also coming from the kingdom of Nex and the mechanically savvy Grand Duchy of Alkenstar. The Qadiran professor Hadia Al-Dannah, formerly of the Clockwork Cathedral, wrote the best-regarded modern text on clockwork design\u2014*Glorious Rhythms in Life and Mechanica*.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "area": [
+                {
+                  "shape": "cone",
+                  "size": 15,
+                  "subtype": "area",
+                  "text": "15-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "damage_type": "fire",
+                  "formula": "2d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "slowed 1",
+                  "aonid": 35,
+                  "game-obj": "Conditions",
+                  "name": "slowed 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Backfire",
+              "saving_throw": [
+                {
+                  "dc": 5,
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 5 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": ": The clockwork rolls a DC 5 flat check at the start of each of its turns. On a failure, it backfires, dealing 2d6 fire damage in a 15-foot cone, including to itself (basic Reflex save at the standard DC for its level), and is slowed 1 this turn.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Damaged Propulsion",
+              "subtype": "ability",
+              "text": ": The clockwork loses 1d4 hours of operational time at the end of each of its turns.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Loose Screws",
+              "saving_throw": [
+                {
+                  "dc": 5,
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 5 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": ": When damaged, the clockwork attempts a DC 5 flat check. On a failure, a plate of its armor falls loose. It takes a status penalty to AC equal to the number of lost plates (up to \u20134).",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "slowed 1",
+              "aonid": 35,
+              "game-obj": "Conditions",
+              "name": "slowed 1",
+              "type": "link"
+            }
+          ],
+          "name": "Malfunction!",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 48",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 48",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 48,
+              "type": "source"
+            }
+          ],
+          "text": "Clockworks can be prone to errors if not well maintained or properly programmed. You might want to introduce one of the malfunctions listed below in a clockwork that is in disrepair or gets damaged heavily in battle (such as with a critical hit).   \n  \n**Backfire**: The clockwork rolls a DC 5 flat check at the start of each of its turns. On a failure, it backfires, dealing 2d6 fire damage in a 15-foot cone, including to itself (basic Reflex save at the standard DC for its level), and is slowed 1 this turn.   \n  \n**Damaged Propulsion**: The clockwork loses 1d4 hours of operational time at the end of each of its turns.   \n  \n**Loose Screws**: When damaged, the clockwork attempts a DC 5 flat check. On a failure, a plate of its armor falls loose. It takes a status penalty to AC equal to the number of lost plates (up to \u20134).",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "clockwork door warden",
+              "aonid": 1946,
+              "game-obj": "Monsters",
+              "name": "clockwork door warden",
+              "type": "link"
+            },
+            {
+              "alt": "clockwork disposer",
+              "aonid": 1947,
+              "game-obj": "Monsters",
+              "name": "clockwork disposer",
+              "type": "link"
+            }
+          ],
+          "name": "Versatile Designs",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 48",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 48",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 48,
+              "type": "source"
+            }
+          ],
+          "text": "Most clockwork builders design their mechanical minions to perform a single specific task, as in the case of the clockwork door warden or clockwork disposer. Though these constructs' intended functions are typically limited, creative owners can find workarounds or loopholes to exploit, effectively turning their single-purpose clockwork into a versatile guardian or servant. Of course, nearly every clockwork is pre-programmed to defend itself against foes, a function which typically requires no special action on the clockwork's part.",
+          "type": "section"
+        },
+        {
+          "name": "Winding Routines",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 48",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 48",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 48,
+              "type": "source"
+            }
+          ],
+          "text": "Maintaining a group of clockworks that are meant to operate on a regular basis takes planning and attention. A cadre of clockwork soldiers set to patrol a location needs to be regularly wound. Typically, one or more servants are assigned to wind all the clockworks serving in one place at a standard time.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 48",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 48",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 48,
+          "type": "source"
+        }
+      ],
+      "text": "A clockwork must be wound to remain operational. Each clockwork has the wind-up ability, with the specifics listed in its stat block.   \n  \n**Wind-Up** For a clockwork to act, it must be wound with a unique key by another creature. This takes 1 minute. Once wound, it remains operational for the listed amount of time, usually 24 hours, after which time it becomes unaware of its surroundings and can't act until it's wound again. Some clockworks' abilities require them to spend some of their remaining operational time. They can't spend more than they have and shut down immediately once they have 0 time remaining. If it's unclear when a clockwork was last wound, most clockwork keepers wind all their clockworks at a set time, typically 8 a.m.  \n  \n A clockwork that lists standby in its wind-up entry can enter standby mode as a 3-action activity. Its operational time doesn't decrease in standby, but it can sense its surroundings (with a \u20132 penalty to Perception). It can't act, with one exception: when it perceives a creature, it can exit standby as a reaction (rolling initiative if appropriate).  \n  \n A creature can attempt to Disable a Device to wind a clockwork down (with a DC listed in the wind-up entry). For each success, the clockwork loses 1 hour of operational time. This can be done even if the clockwork is in standby mode.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/bestiary_3/divine_warden.json
+++ b/monster_families/bestiary_3/divine_warden.json
@@ -146,253 +146,119 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Divine Destruction",
-                "subtype": "ability",
-                "text": "When the divine warden is reduced to 0 HP, it erupts with divine energy in a 30-foot emanation, dealing 1d6 damage per level. This damage is either positive or negative, determined by the patron deity's divine font (chosen at the divine warden's creation if the deity offers a choice), and this ability gains the corresponding trait. Each creature in the area must attempt a Will save with the following outcomes.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature takes half damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature takes full damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "enfeebled 1",
-                    "aonid": 13,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "curse",
-                    "aonid": 38,
-                    "game-obj": "Traits",
-                    "name": "curse",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteract",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature takes full damage and becomes temporarily cursed by the patron deity. The creature becomes enfeebled 1 and stupefied 1 for 1 day; this is a curse effect that uses the Will save DC as the counteract DC.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, except the creature becomes enfeebled 2 and stupefied 2.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "divine lance",
-                    "aonid": 84,
-                    "game-obj": "Spells",
-                    "name": "divine lance",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "daze",
-                    "aonid": 61,
-                    "game-obj": "Spells",
-                    "name": "daze",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Innate Spells",
-                "subtype": "ability",
-                "text": "A divine warden whose patron deity has any alignment components gains *divine lance* as an innate cantrip. A divine warden with a neutral patron deity instead gains *daze* as an innate cantrip.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Refocus",
-                    "aonid": 71,
-                    "game-obj": "Actions",
-                    "name": "Refocus",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Domain Spells",
-                "subtype": "ability",
-                "text": "The divine warden selects two of its patron deity's domains. The divine warden can cast the basic domain spell for its chosen domains. The divine warden has a focus pool of 1 Focus Point. It can't Refocus, but its focus pool automatically refills 24 hours after it last used a Focus Point. If the divine warden is at least 10th level, it also gains the advanced domain spells for its chosen domains, and its focus pool increases to 2 Focus Points.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Sense Motive",
-                    "aonid": 85,
-                    "game-obj": "Actions",
-                    "name": "Sense Motive",
-                    "type": "link"
-                  }
-                ],
-                "name": "Faith Bound",
-                "subtype": "ability",
-                "text": "A divine warden can't attack a creature that openly wears or displays the religious symbol of the divine warden's patron deity unless that creature uses a hostile action against the divine warden first. If the divine warden is intelligent, it can also attack a creature it believes isn't faithful to its deity or who wears the religious symbol as a ruse (typically after succeeding at a Perception check to Sense Motive).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "abjuration",
-                      "aonid": 2,
-                      "game-obj": "Traits",
-                      "name": "abjuration",
-                      "type": "link"
-                    },
-                    "name": "abjuration",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "striking",
-                    "aonid": 280,
-                    "game-obj": "Equipment",
-                    "name": "striking",
-                    "type": "link"
-                  }
-                ],
-                "name": "Faithful Weapon",
-                "subtype": "ability",
-                "text": "A divine warden always wields its patron deity's favored weapon. If the weapon is a ranged weapon, the divine warden automatically generates new ammunition with each attack. For a divine warden of 4th level or higher, the deity's favored weapon gains the effects of a *striking* rune while the divine warden wields it; at 12th level, these effects are of a *greater striking* rune, and at 19th level, they're instead of a *major striking* rune.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "cleric",
-                    "aonid": 5,
-                    "game-obj": "Classes",
-                    "name": "cleric",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "heal",
-                    "aonid": 148,
-                    "game-obj": "Spells",
-                    "name": "heal",
-                    "type": "link"
-                  }
-                ],
-                "name": "Instrument of Faith",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The divine warden is a beacon for its deity's faith. A cleric of the divine warden's patron deity can channel a *heal* spell through a divine warden they can see within 60 feet. The cleric determines any targets or area for the spell as if they were standing in the divine warden's space.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Divine Warden Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled 1",
+                "aonid": 13,
+                "game-obj": "Conditions",
+                "name": "enfeebled 1",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 1",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 84,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 61,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "Refocus",
+                "aonid": 71,
+                "game-obj": "Actions",
+                "name": "Refocus",
+                "type": "link"
+              },
+              {
+                "alt": "abjuration",
+                "aonid": 2,
+                "game-obj": "Traits",
+                "name": "abjuration",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "Sense Motive",
+                "aonid": 85,
+                "game-obj": "Actions",
+                "name": "Sense Motive",
+                "type": "link"
+              },
+              {
+                "alt": "striking",
+                "aonid": 280,
+                "game-obj": "Equipment",
+                "name": "striking",
+                "type": "link"
+              },
+              {
+                "alt": "cleric",
+                "aonid": 5,
+                "game-obj": "Classes",
+                "name": "cleric",
+                "type": "link"
+              },
+              {
+                "alt": "heal",
+                "aonid": 148,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -402,7 +268,6 @@
         ],
         "name": "Divine Warden Abilities",
         "subtype": "monster_family",
-        "text": "A divine warden retains any abilities it had previously, and it gains the abilities listed below. You might need to adjust or remove other abilities that conflict with the construct's new theme as a divine warden.",
         "type": "stat_block_section"
       }
     ],
@@ -428,6 +293,413 @@
         }
       ],
       "text": "You can build a divine warden from the ground up using the standard rules for monster creation (which is how the divine warden on the following page was built), or you can turn an existing construct into a divine warden by taking the following steps. In either case, the specific divine warden abilities listed below work the same.   \n  \nSelect the deity that empowered the divine warden. This deity is the divine warden's patron deity. Increase the creature's level by 1 and change its statistics as follows. \n\n|  |  |\n| --- | --- |\n| **Starting Level** | **HP Increase** |\n| 1 or lower | 10 |\n| 2-4 | 15 |\n| 5-19 | 20 |\n| 20+ | 30 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Divine Destruction",
+          "subtype": "ability",
+          "text": "When the divine warden is reduced to 0 HP, it erupts with divine energy in a 30-foot emanation, dealing 1d6 damage per level. This damage is either positive or negative, determined by the patron deity's divine font (chosen at the divine warden's creation if the deity offers a choice), and this ability gains the corresponding trait. Each creature in the area must attempt a Will save with the following outcomes.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature takes half damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature takes full damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "enfeebled 1",
+              "aonid": 13,
+              "game-obj": "Conditions",
+              "name": "enfeebled 1",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied 1",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            },
+            {
+              "alt": "curse",
+              "aonid": 38,
+              "game-obj": "Traits",
+              "name": "curse",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            }
+          ],
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature takes full damage and becomes temporarily cursed by the patron deity. The creature becomes enfeebled 1 and stupefied 1 for 1 day; this is a curse effect that uses the Will save DC as the counteract DC.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, except the creature becomes enfeebled 2 and stupefied 2.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "divine lance",
+              "aonid": 84,
+              "game-obj": "Spells",
+              "name": "divine lance",
+              "type": "link"
+            },
+            {
+              "alt": "daze",
+              "aonid": 61,
+              "game-obj": "Spells",
+              "name": "daze",
+              "type": "link"
+            }
+          ],
+          "name": "Divine Innate Spells",
+          "subtype": "ability",
+          "text": "A divine warden whose patron deity has any alignment components gains *divine lance* as an innate cantrip. A divine warden with a neutral patron deity instead gains *daze* as an innate cantrip.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Refocus",
+              "aonid": 71,
+              "game-obj": "Actions",
+              "name": "Refocus",
+              "type": "link"
+            }
+          ],
+          "name": "Divine Domain Spells",
+          "subtype": "ability",
+          "text": "The divine warden selects two of its patron deity's domains. The divine warden can cast the basic domain spell for its chosen domains. The divine warden has a focus pool of 1 Focus Point. It can't Refocus, but its focus pool automatically refills 24 hours after it last used a Focus Point. If the divine warden is at least 10th level, it also gains the advanced domain spells for its chosen domains, and its focus pool increases to 2 Focus Points.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Sense Motive",
+              "aonid": 85,
+              "game-obj": "Actions",
+              "name": "Sense Motive",
+              "type": "link"
+            }
+          ],
+          "name": "Faith Bound",
+          "subtype": "ability",
+          "text": "A divine warden can't attack a creature that openly wears or displays the religious symbol of the divine warden's patron deity unless that creature uses a hostile action against the divine warden first. If the divine warden is intelligent, it can also attack a creature it believes isn't faithful to its deity or who wears the religious symbol as a ruse (typically after succeeding at a Perception check to Sense Motive).",
+          "traits": [
+            {
+              "link": {
+                "alt": "abjuration",
+                "aonid": 2,
+                "game-obj": "Traits",
+                "name": "abjuration",
+                "type": "link"
+              },
+              "name": "abjuration",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "striking",
+              "aonid": 280,
+              "game-obj": "Equipment",
+              "name": "striking",
+              "type": "link"
+            }
+          ],
+          "name": "Faithful Weapon",
+          "subtype": "ability",
+          "text": "A divine warden always wields its patron deity's favored weapon. If the weapon is a ranged weapon, the divine warden automatically generates new ammunition with each attack. For a divine warden of 4th level or higher, the deity's favored weapon gains the effects of a *striking* rune while the divine warden wields it; at 12th level, these effects are of a *greater striking* rune, and at 19th level, they're instead of a *major striking* rune.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "cleric",
+              "aonid": 5,
+              "game-obj": "Classes",
+              "name": "cleric",
+              "type": "link"
+            },
+            {
+              "alt": "heal",
+              "aonid": 148,
+              "game-obj": "Spells",
+              "name": "heal",
+              "type": "link"
+            }
+          ],
+          "name": "Instrument of Faith",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "within 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The divine warden is a beacon for its deity's faith. A cleric of the divine warden's patron deity can channel a *heal* spell through a divine warden they can see within 60 feet. The cleric determines any targets or area for the spell as if they were standing in the divine warden's space.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "enfeebled 1",
+          "aonid": 13,
+          "game-obj": "Conditions",
+          "name": "enfeebled 1",
+          "type": "link"
+        },
+        {
+          "alt": "stupefied 1",
+          "aonid": 37,
+          "game-obj": "Conditions",
+          "name": "stupefied 1",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 38,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 371,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 84,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 61,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "Refocus",
+          "aonid": 71,
+          "game-obj": "Actions",
+          "name": "Refocus",
+          "type": "link"
+        },
+        {
+          "alt": "abjuration",
+          "aonid": 2,
+          "game-obj": "Traits",
+          "name": "abjuration",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "Sense Motive",
+          "aonid": 85,
+          "game-obj": "Actions",
+          "name": "Sense Motive",
+          "type": "link"
+        },
+        {
+          "alt": "striking",
+          "aonid": 280,
+          "game-obj": "Equipment",
+          "name": "striking",
+          "type": "link"
+        },
+        {
+          "alt": "cleric",
+          "aonid": 5,
+          "game-obj": "Classes",
+          "name": "cleric",
+          "type": "link"
+        },
+        {
+          "alt": "heal",
+          "aonid": 148,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        }
+      ],
+      "name": "Divine Warden Abilities",
+      "sections": [
+        {
+          "name": "Heroes of the Faith",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 72",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 72",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 72,
+              "type": "source"
+            }
+          ],
+          "text": "In the rare instances where a deity personally creates a divine warden, the deity tends to animate depictions of great heroes from their faith. The specific image of the hero serves to inspire devotees and act as a leader in combat. Occasionally, the deity will call on the spirit of the hero to actually embody the divine warden, allowing the hero to fight for their faith once again.",
+          "type": "section"
+        },
+        {
+          "name": "Mouths of the Gods",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 72",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 72",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 72,
+              "type": "source"
+            }
+          ],
+          "text": "While most divine wardens lack the ability to speak, a deity might imbue a divine warden with the capability by quoting scripture. The guardian can therefore communicate the deity's will to their faithful, though typically in a cryptic fashion. Divine wardens might also have the ability to lead in song or prayer.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 72",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 72",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 72,
+          "type": "source"
+        }
+      ],
+      "text": "A divine warden retains any abilities it had previously, and it gains the abilities listed below. You might need to adjust or remove other abilities that conflict with the construct's new theme as a divine warden.  \n  \n**Divine Destruction** (divine, necromancy) When the divine warden is reduced to 0 HP, it erupts with divine energy in a 30-foot emanation, dealing 1d6 damage per level. This damage is either positive or negative, determined by the patron deity's divine font (chosen at the divine warden's creation if the deity offers a choice), and this ability gains the corresponding trait. Each creature in the area must attempt a Will save with the following outcomes.   \n**Critical Success** The creature takes half damage.   \n**Success** The creature takes full damage.   \n**Failure** The creature takes full damage and becomes temporarily cursed by the patron deity. The creature becomes enfeebled 1 and stupefied 1 for 1 day; this is a curse effect that uses the Will save DC as the counteract DC.   \n**Critical Failure** As failure, except the creature becomes enfeebled 2 and stupefied 2.   \n  \n**Divine Innate Spells** A divine warden whose patron deity has any alignment components gains *divine lance* as an innate cantrip. A divine warden with a neutral patron deity instead gains *daze* as an innate cantrip.   \n  \n**Divine Domain Spells** The divine warden selects two of its patron deity's domains. The divine warden can cast the basic domain spell for its chosen domains. The divine warden has a focus pool of 1 Focus Point. It can't Refocus, but its focus pool automatically refills 24 hours after it last used a Focus Point. If the divine warden is at least 10th level, it also gains the advanced domain spells for its chosen domains, and its focus pool increases to 2 Focus Points.   \n  \n**Faith Bound** (abjuration, divine) A divine warden can't attack a creature that openly wears or displays the religious symbol of the divine warden's patron deity unless that creature uses a hostile action against the divine warden first. If the divine warden is intelligent, it can also attack a creature it believes isn't faithful to its deity or who wears the religious symbol as a ruse (typically after succeeding at a Perception check to Sense Motive).   \n  \n**Faithful Weapon** A divine warden always wields its patron deity's favored weapon. If the weapon is a ranged weapon, the divine warden automatically generates new ammunition with each attack. For a divine warden of 4th level or higher, the deity's favored weapon gains the effects of a *striking* rune while the divine warden wields it; at 12th level, these effects are of a *greater striking* rune, and at 19th level, they're instead of a *major striking* rune.   \n  \n**Instrument of Faith** The divine warden is a beacon for its deity's faith. A cleric of the divine warden's patron deity can channel a *heal* spell through a divine warden they can see within 60 feet. The cleric determines any targets or area for the spell as if they were standing in the divine warden's space.",
       "type": "section"
     }
   ],

--- a/monster_families/bestiary_3/dragon_forest.json
+++ b/monster_families/bestiary_3/dragon_forest.json
@@ -75,341 +75,139 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gaseous form",
-                            "aonid": 129,
-                            "game-obj": "Spells",
-                            "name": "gaseous form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gaseous form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucinatory terrain",
-                            "aonid": 145,
-                            "game-obj": "Spells",
-                            "name": "hallucinatory terrain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucinatory terrain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "solid fog",
-                            "aonid": 290,
-                            "game-obj": "Spells",
-                            "name": "solid fog",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "solid fog",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "animal vision",
-                            "aonid": 12,
-                            "game-obj": "Spells",
-                            "name": "animal vision",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "animal vision",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stinking cloud",
-                            "aonid": 309,
-                            "game-obj": "Spells",
-                            "name": "stinking cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stinking cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of thorns",
-                            "aonid": 366,
-                            "game-obj": "Spells",
-                            "name": "wall of thorns",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of thorns",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "animal messenger",
-                            "aonid": 11,
-                            "game-obj": "Spells",
-                            "name": "animal messenger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "animal messenger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "darkness",
-                            "aonid": 59,
-                            "game-obj": "Spells",
-                            "name": "darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water breathing",
-                            "aonid": 370,
-                            "game-obj": "Spells",
-                            "name": "water breathing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water breathing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create water",
-                            "aonid": 53,
-                            "game-obj": "Spells",
-                            "name": "create water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "goblin pox",
-                            "aonid": 139,
-                            "game-obj": "Spells",
-                            "name": "goblin pox",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "goblin pox",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pest form",
-                            "aonid": 217,
-                            "game-obj": "Spells",
-                            "name": "pest form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pest form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 142,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tanglefoot",
-                            "aonid": 330,
-                            "game-obj": "Spells",
-                            "name": "tanglefoot",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tanglefoot",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "plant growth",
-                            "aonid": 18,
-                            "game-obj": "Rituals",
-                            "name": "plant growth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "plant growth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Forest Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "gaseous form",
+                "aonid": 129,
+                "game-obj": "Spells",
+                "name": "gaseous form",
+                "type": "link"
+              },
+              {
+                "alt": "hallucinatory terrain",
+                "aonid": 145,
+                "game-obj": "Spells",
+                "name": "hallucinatory terrain",
+                "type": "link"
+              },
+              {
+                "alt": "solid fog",
+                "aonid": 290,
+                "game-obj": "Spells",
+                "name": "solid fog",
+                "type": "link"
+              },
+              {
+                "alt": "animal vision",
+                "aonid": 12,
+                "game-obj": "Spells",
+                "name": "animal vision",
+                "type": "link"
+              },
+              {
+                "alt": "stinking cloud",
+                "aonid": 309,
+                "game-obj": "Spells",
+                "name": "stinking cloud",
+                "type": "link"
+              },
+              {
+                "alt": "wall of thorns",
+                "aonid": 366,
+                "game-obj": "Spells",
+                "name": "wall of thorns",
+                "type": "link"
+              },
+              {
+                "alt": "animal messenger",
+                "aonid": 11,
+                "game-obj": "Spells",
+                "name": "animal messenger",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 59,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "water breathing",
+                "aonid": 370,
+                "game-obj": "Spells",
+                "name": "water breathing",
+                "type": "link"
+              },
+              {
+                "alt": "create water",
+                "aonid": 53,
+                "game-obj": "Spells",
+                "name": "create water",
+                "type": "link"
+              },
+              {
+                "alt": "goblin pox",
+                "aonid": 139,
+                "game-obj": "Spells",
+                "name": "goblin pox",
+                "type": "link"
+              },
+              {
+                "alt": "pest form",
+                "aonid": 217,
+                "game-obj": "Spells",
+                "name": "pest form",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 142,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tanglefoot",
+                "aonid": 330,
+                "game-obj": "Spells",
+                "name": "tanglefoot",
+                "type": "link"
+              },
+              {
+                "alt": "plant growth",
+                "aonid": 18,
+                "game-obj": "Rituals",
+                "name": "plant growth",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -425,238 +223,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young forest dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "baleful polymorph",
-                            "aonid": 17,
-                            "game-obj": "Spells",
-                            "name": "baleful polymorph",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "baleful polymorph",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "purple worm sting",
-                            "aonid": 242,
-                            "game-obj": "Spells",
-                            "name": "purple worm sting",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "purple worm sting",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangling creepers",
-                            "aonid": 331,
-                            "game-obj": "Spells",
-                            "name": "tangling creepers",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangling creepers",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cloudkill",
-                            "aonid": 42,
-                            "game-obj": "Spells",
-                            "name": "cloudkill",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cloudkill",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moon frenzy",
-                            "aonid": 203,
-                            "game-obj": "Spells",
-                            "name": "moon frenzy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moon frenzy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tree stride",
-                            "aonid": 343,
-                            "game-obj": "Spells",
-                            "name": "tree stride",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tree stride",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 142,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tanglefoot",
-                            "aonid": 330,
-                            "game-obj": "Spells",
-                            "name": "tanglefoot",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tanglefoot",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "commune with nature",
-                            "aonid": 7,
-                            "game-obj": "Rituals",
-                            "name": "commune with nature",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "commune with nature",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Forest Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "baleful polymorph",
+                "aonid": 17,
+                "game-obj": "Spells",
+                "name": "baleful polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "purple worm sting",
+                "aonid": 242,
+                "game-obj": "Spells",
+                "name": "purple worm sting",
+                "type": "link"
+              },
+              {
+                "alt": "tangling creepers",
+                "aonid": 331,
+                "game-obj": "Spells",
+                "name": "tangling creepers",
+                "type": "link"
+              },
+              {
+                "alt": "cloudkill",
+                "aonid": 42,
+                "game-obj": "Spells",
+                "name": "cloudkill",
+                "type": "link"
+              },
+              {
+                "alt": "moon frenzy",
+                "aonid": 203,
+                "game-obj": "Spells",
+                "name": "moon frenzy",
+                "type": "link"
+              },
+              {
+                "alt": "tree stride",
+                "aonid": 343,
+                "game-obj": "Spells",
+                "name": "tree stride",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 142,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tanglefoot",
+                "aonid": 330,
+                "game-obj": "Spells",
+                "name": "tanglefoot",
+                "type": "link"
+              },
+              {
+                "alt": "commune with nature",
+                "aonid": 7,
+                "game-obj": "Rituals",
+                "name": "commune with nature",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -672,253 +329,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult forest dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 35,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 162,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nature's enmity",
-                            "aonid": 205,
-                            "game-obj": "Spells",
-                            "name": "nature's enmity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nature's enmity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "horrid wilting",
-                            "aonid": 152,
-                            "game-obj": "Spells",
-                            "name": "horrid wilting",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "horrid wilting",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "polar ray",
-                            "aonid": 224,
-                            "game-obj": "Spells",
-                            "name": "polar ray",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "polar ray",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "punishing winds",
-                            "aonid": 240,
-                            "game-obj": "Spells",
-                            "name": "punishing winds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "punishing winds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "eclipse burst",
-                            "aonid": 96,
-                            "game-obj": "Spells",
-                            "name": "eclipse burst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "eclipse burst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prismatic spray",
-                            "aonid": 233,
-                            "game-obj": "Spells",
-                            "name": "prismatic spray",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prismatic spray",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true target",
-                            "aonid": 346,
-                            "game-obj": "Spells",
-                            "name": "true target",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true target",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 142,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tanglefoot",
-                            "aonid": 330,
-                            "game-obj": "Spells",
-                            "name": "tanglefoot",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tanglefoot",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Forest Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "implosion",
+                "aonid": 162,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "nature's enmity",
+                "aonid": 205,
+                "game-obj": "Spells",
+                "name": "nature's enmity",
+                "type": "link"
+              },
+              {
+                "alt": "horrid wilting",
+                "aonid": 152,
+                "game-obj": "Spells",
+                "name": "horrid wilting",
+                "type": "link"
+              },
+              {
+                "alt": "polar ray",
+                "aonid": 224,
+                "game-obj": "Spells",
+                "name": "polar ray",
+                "type": "link"
+              },
+              {
+                "alt": "punishing winds",
+                "aonid": 240,
+                "game-obj": "Spells",
+                "name": "punishing winds",
+                "type": "link"
+              },
+              {
+                "alt": "eclipse burst",
+                "aonid": 96,
+                "game-obj": "Spells",
+                "name": "eclipse burst",
+                "type": "link"
+              },
+              {
+                "alt": "prismatic spray",
+                "aonid": 233,
+                "game-obj": "Spells",
+                "name": "prismatic spray",
+                "type": "link"
+              },
+              {
+                "alt": "true target",
+                "aonid": 346,
+                "game-obj": "Spells",
+                "name": "true target",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 142,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tanglefoot",
+                "aonid": 330,
+                "game-obj": "Spells",
+                "name": "tanglefoot",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -933,240 +441,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 8,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 8,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1176,7 +486,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:",
         "type": "stat_block_section"
       }
     ],
@@ -1221,6 +530,1190 @@
         }
       ],
       "text": "Forest dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "gaseous form",
+          "aonid": 129,
+          "game-obj": "Spells",
+          "name": "gaseous form",
+          "type": "link"
+        },
+        {
+          "alt": "hallucinatory terrain",
+          "aonid": 145,
+          "game-obj": "Spells",
+          "name": "hallucinatory terrain",
+          "type": "link"
+        },
+        {
+          "alt": "solid fog",
+          "aonid": 290,
+          "game-obj": "Spells",
+          "name": "solid fog",
+          "type": "link"
+        },
+        {
+          "alt": "animal vision",
+          "aonid": 12,
+          "game-obj": "Spells",
+          "name": "animal vision",
+          "type": "link"
+        },
+        {
+          "alt": "stinking cloud",
+          "aonid": 309,
+          "game-obj": "Spells",
+          "name": "stinking cloud",
+          "type": "link"
+        },
+        {
+          "alt": "wall of thorns",
+          "aonid": 366,
+          "game-obj": "Spells",
+          "name": "wall of thorns",
+          "type": "link"
+        },
+        {
+          "alt": "animal messenger",
+          "aonid": 11,
+          "game-obj": "Spells",
+          "name": "animal messenger",
+          "type": "link"
+        },
+        {
+          "alt": "darkness",
+          "aonid": 59,
+          "game-obj": "Spells",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "water breathing",
+          "aonid": 370,
+          "game-obj": "Spells",
+          "name": "water breathing",
+          "type": "link"
+        },
+        {
+          "alt": "create water",
+          "aonid": 53,
+          "game-obj": "Spells",
+          "name": "create water",
+          "type": "link"
+        },
+        {
+          "alt": "goblin pox",
+          "aonid": 139,
+          "game-obj": "Spells",
+          "name": "goblin pox",
+          "type": "link"
+        },
+        {
+          "alt": "pest form",
+          "aonid": 217,
+          "game-obj": "Spells",
+          "name": "pest form",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 142,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tanglefoot",
+          "aonid": 330,
+          "game-obj": "Spells",
+          "name": "tanglefoot",
+          "type": "link"
+        },
+        {
+          "alt": "plant growth",
+          "aonid": 18,
+          "game-obj": "Rituals",
+          "name": "plant growth",
+          "type": "link"
+        }
+      ],
+      "name": "Young Forest Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 74",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 74",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 74,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gaseous form",
+                      "aonid": 129,
+                      "game-obj": "Spells",
+                      "name": "gaseous form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gaseous form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucinatory terrain",
+                      "aonid": 145,
+                      "game-obj": "Spells",
+                      "name": "hallucinatory terrain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucinatory terrain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "solid fog",
+                      "aonid": 290,
+                      "game-obj": "Spells",
+                      "name": "solid fog",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "solid fog",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "animal vision",
+                      "aonid": 12,
+                      "game-obj": "Spells",
+                      "name": "animal vision",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "animal vision",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stinking cloud",
+                      "aonid": 309,
+                      "game-obj": "Spells",
+                      "name": "stinking cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stinking cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of thorns",
+                      "aonid": 366,
+                      "game-obj": "Spells",
+                      "name": "wall of thorns",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of thorns",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "animal messenger",
+                      "aonid": 11,
+                      "game-obj": "Spells",
+                      "name": "animal messenger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "animal messenger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "darkness",
+                      "aonid": 59,
+                      "game-obj": "Spells",
+                      "name": "darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water breathing",
+                      "aonid": 370,
+                      "game-obj": "Spells",
+                      "name": "water breathing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water breathing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create water",
+                      "aonid": 53,
+                      "game-obj": "Spells",
+                      "name": "create water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "goblin pox",
+                      "aonid": 139,
+                      "game-obj": "Spells",
+                      "name": "goblin pox",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "goblin pox",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pest form",
+                      "aonid": 217,
+                      "game-obj": "Spells",
+                      "name": "pest form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pest form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 142,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tanglefoot",
+                      "aonid": 330,
+                      "game-obj": "Spells",
+                      "name": "tanglefoot",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tanglefoot",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "plant growth",
+                      "aonid": 18,
+                      "game-obj": "Rituals",
+                      "name": "plant growth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "plant growth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 29, attack +22; **4th** *gaseous form*, *hallucinatory terrain*, *solid fog*; **3rd** *animal vision*, *stinking cloud*, *wall of thorns*; **2nd** *animal messenger*, *darkness*, *water breathing*; **1st** *create water*, *goblin pox*, *pest form*; **Cantrips (4th)** *acid splash*, *detect magic*, *guidance*, *read aura*, *tanglefoot*; **Rituals** DC 29; plant growth",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "baleful polymorph",
+          "aonid": 17,
+          "game-obj": "Spells",
+          "name": "baleful polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "purple worm sting",
+          "aonid": 242,
+          "game-obj": "Spells",
+          "name": "purple worm sting",
+          "type": "link"
+        },
+        {
+          "alt": "tangling creepers",
+          "aonid": 331,
+          "game-obj": "Spells",
+          "name": "tangling creepers",
+          "type": "link"
+        },
+        {
+          "alt": "cloudkill",
+          "aonid": 42,
+          "game-obj": "Spells",
+          "name": "cloudkill",
+          "type": "link"
+        },
+        {
+          "alt": "moon frenzy",
+          "aonid": 203,
+          "game-obj": "Spells",
+          "name": "moon frenzy",
+          "type": "link"
+        },
+        {
+          "alt": "tree stride",
+          "aonid": 343,
+          "game-obj": "Spells",
+          "name": "tree stride",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 142,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tanglefoot",
+          "aonid": 330,
+          "game-obj": "Spells",
+          "name": "tanglefoot",
+          "type": "link"
+        },
+        {
+          "alt": "commune with nature",
+          "aonid": 7,
+          "game-obj": "Rituals",
+          "name": "commune with nature",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Forest Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 74",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 74",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 74,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young forest dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "baleful polymorph",
+                      "aonid": 17,
+                      "game-obj": "Spells",
+                      "name": "baleful polymorph",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "baleful polymorph",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "purple worm sting",
+                      "aonid": 242,
+                      "game-obj": "Spells",
+                      "name": "purple worm sting",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "purple worm sting",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangling creepers",
+                      "aonid": 331,
+                      "game-obj": "Spells",
+                      "name": "tangling creepers",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangling creepers",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cloudkill",
+                      "aonid": 42,
+                      "game-obj": "Spells",
+                      "name": "cloudkill",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cloudkill",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moon frenzy",
+                      "aonid": 203,
+                      "game-obj": "Spells",
+                      "name": "moon frenzy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moon frenzy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tree stride",
+                      "aonid": 343,
+                      "game-obj": "Spells",
+                      "name": "tree stride",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tree stride",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 142,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tanglefoot",
+                      "aonid": 330,
+                      "game-obj": "Spells",
+                      "name": "tanglefoot",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tanglefoot",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "commune with nature",
+                      "aonid": 7,
+                      "game-obj": "Rituals",
+                      "name": "commune with nature",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "commune with nature",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 34, attack +28; As young forest dragon, plus **6th** *baleful polymorph*, *purple worm sting*, *tangling creepers*; **5th** *cloudkill*, *moon frenzy*, *tree stride*; **Cantrips (6th)** *acid splash*, *detect magic*, *guidance*, *read aura*, *tanglefoot*; **Rituals** DC 34; commune with nature",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "implosion",
+          "aonid": 162,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "nature's enmity",
+          "aonid": 205,
+          "game-obj": "Spells",
+          "name": "nature's enmity",
+          "type": "link"
+        },
+        {
+          "alt": "horrid wilting",
+          "aonid": 152,
+          "game-obj": "Spells",
+          "name": "horrid wilting",
+          "type": "link"
+        },
+        {
+          "alt": "polar ray",
+          "aonid": 224,
+          "game-obj": "Spells",
+          "name": "polar ray",
+          "type": "link"
+        },
+        {
+          "alt": "punishing winds",
+          "aonid": 240,
+          "game-obj": "Spells",
+          "name": "punishing winds",
+          "type": "link"
+        },
+        {
+          "alt": "eclipse burst",
+          "aonid": 96,
+          "game-obj": "Spells",
+          "name": "eclipse burst",
+          "type": "link"
+        },
+        {
+          "alt": "prismatic spray",
+          "aonid": 233,
+          "game-obj": "Spells",
+          "name": "prismatic spray",
+          "type": "link"
+        },
+        {
+          "alt": "true target",
+          "aonid": 346,
+          "game-obj": "Spells",
+          "name": "true target",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 142,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tanglefoot",
+          "aonid": 330,
+          "game-obj": "Spells",
+          "name": "tanglefoot",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Forest Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 74",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 74",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 74,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult forest dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 35,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 162,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nature's enmity",
+                      "aonid": 205,
+                      "game-obj": "Spells",
+                      "name": "nature's enmity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nature's enmity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "horrid wilting",
+                      "aonid": 152,
+                      "game-obj": "Spells",
+                      "name": "horrid wilting",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "horrid wilting",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "polar ray",
+                      "aonid": 224,
+                      "game-obj": "Spells",
+                      "name": "polar ray",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "polar ray",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "punishing winds",
+                      "aonid": 240,
+                      "game-obj": "Spells",
+                      "name": "punishing winds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "punishing winds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "eclipse burst",
+                      "aonid": 96,
+                      "game-obj": "Spells",
+                      "name": "eclipse burst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "eclipse burst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prismatic spray",
+                      "aonid": 233,
+                      "game-obj": "Spells",
+                      "name": "prismatic spray",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prismatic spray",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true target",
+                      "aonid": 346,
+                      "game-obj": "Spells",
+                      "name": "true target",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true target",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 142,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tanglefoot",
+                      "aonid": 330,
+                      "game-obj": "Spells",
+                      "name": "tanglefoot",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tanglefoot",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +35; As adult forest dragon, plus **9th** *implosion*, *nature's enmity*; **8th** *horrid wilting*, *polar ray*, *punishing winds*; **7th** *eclipse burst*, *prismatic spray*, *true target*; **Cantrips (9th)** *acid splash*, *detect magic*, *guidance*, *read aura*, *tanglefoot*",
       "type": "section"
     },
     {
@@ -1289,6 +1782,283 @@
         }
       ],
       "text": "Five elements underpin the magical powers of imperial dragons, influencing their relationships to all things and, especially, to others of their kind. These elements interlink in two cycles. In the first cycle, each element feeds one other: wood feeds fire, fire feeds earth, earth feeds metal, metal feeds water, and water feeds wood. In the second cycle, each element counters another: wood counters earth, earth counters water, water counters fire, fire counters metal, and metal counters wood.   \n  \nEach imperial dragon represents one element and has four abilities related to the cycle. For example, the forest dragon\u2014linked to wood\u2014feeds fire, is fed by water, counters earth, and is countered by metal.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 8,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "Change Shape",
+          "aonid": 8,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 74",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 74",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 74,
+          "type": "source"
+        }
+      ],
+      "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:   \n  \n**Change Shape** [#] (concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_3/dragon_imperial.json
+++ b/monster_families/bestiary_3/dragon_imperial.json
@@ -68,233 +68,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -304,7 +106,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:",
         "type": "stat_block_section"
       }
     ],
@@ -330,6 +131,269 @@
         }
       ],
       "text": "Five elements underpin the magical powers of imperial dragons, influencing their relationships to all things and, especially, to others of their kind. These elements interlink in two cycles. In the first cycle, each element feeds one other: wood feeds fire, fire feeds earth, earth feeds metal, metal feeds water, and water feeds wood. In the second cycle, each element counters another: wood counters earth, earth counters water, water counters fire, fire counters metal, and metal counters wood. Each imperial dragon represents one element and has four abilities related to the cycle. For example, the forest dragon\u2014linked to wood\u2014feeds fire, is fed by water, counters earth, and is countered by metal.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 74",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 74",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 74,
+          "type": "source"
+        }
+      ],
+      "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:   \n  \n**Change Shape** [#] (concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_3/dragon_sea.json
+++ b/monster_families/bestiary_3/dragon_sea.json
@@ -75,265 +75,111 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 19,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "feet to fins",
-                            "aonid": 113,
-                            "game-obj": "Spells",
-                            "name": "feet to fins",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "feet to fins",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 147,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of wind",
-                            "aonid": 367,
-                            "game-obj": "Spells",
-                            "name": "wall of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hideous laughter",
-                            "aonid": 150,
-                            "game-obj": "Spells",
-                            "name": "hideous laughter",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hideous laughter",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resist energy",
-                            "aonid": 256,
-                            "game-obj": "Spells",
-                            "name": "resist energy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resist energy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water breathing",
-                            "aonid": 370,
-                            "game-obj": "Spells",
-                            "name": "water breathing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water breathing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "air bubble",
-                            "aonid": 5,
-                            "game-obj": "Spells",
-                            "name": "air bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "air bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 140,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grim tendrils",
-                            "aonid": 141,
-                            "game-obj": "Spells",
-                            "name": "grim tendrils",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grim tendrils",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 190,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Sea Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "feet to fins",
+                "aonid": 113,
+                "game-obj": "Spells",
+                "name": "feet to fins",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 147,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "wall of wind",
+                "aonid": 367,
+                "game-obj": "Spells",
+                "name": "wall of wind",
+                "type": "link"
+              },
+              {
+                "alt": "hideous laughter",
+                "aonid": 150,
+                "game-obj": "Spells",
+                "name": "hideous laughter",
+                "type": "link"
+              },
+              {
+                "alt": "resist energy",
+                "aonid": 256,
+                "game-obj": "Spells",
+                "name": "resist energy",
+                "type": "link"
+              },
+              {
+                "alt": "water breathing",
+                "aonid": 370,
+                "game-obj": "Spells",
+                "name": "water breathing",
+                "type": "link"
+              },
+              {
+                "alt": "air bubble",
+                "aonid": 5,
+                "game-obj": "Spells",
+                "name": "air bubble",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 140,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "grim tendrils",
+                "aonid": 141,
+                "game-obj": "Spells",
+                "name": "grim tendrils",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 190,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -349,238 +195,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young sea dragon"
-                ],
-                "saving_throw": {
-                  "dc": 32,
-                  "subtype": "save_dc",
-                  "text": "DC 32",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mariner's curse",
-                            "aonid": 184,
-                            "game-obj": "Spells",
-                            "name": "mariner's curse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mariner's curse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tongues",
-                            "aonid": 340,
-                            "game-obj": "Spells",
-                            "name": "tongues",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tongues",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of ice",
-                            "aonid": 364,
-                            "game-obj": "Spells",
-                            "name": "wall of ice",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of ice",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dimension door",
-                            "aonid": 69,
-                            "game-obj": "Spells",
-                            "name": "dimension door",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dimension door",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gaseous form",
-                            "aonid": 129,
-                            "game-obj": "Spells",
-                            "name": "gaseous form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gaseous form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resilient sphere",
-                            "aonid": 255,
-                            "game-obj": "Spells",
-                            "name": "resilient sphere",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resilient sphere",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 190,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "commune with nature",
-                            "aonid": 7,
-                            "game-obj": "Rituals",
-                            "name": "commune with nature",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "commune with nature",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Sea Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mariner's curse",
+                "aonid": 184,
+                "game-obj": "Spells",
+                "name": "mariner's curse",
+                "type": "link"
+              },
+              {
+                "alt": "tongues",
+                "aonid": 340,
+                "game-obj": "Spells",
+                "name": "tongues",
+                "type": "link"
+              },
+              {
+                "alt": "wall of ice",
+                "aonid": 364,
+                "game-obj": "Spells",
+                "name": "wall of ice",
+                "type": "link"
+              },
+              {
+                "alt": "dimension door",
+                "aonid": 69,
+                "game-obj": "Spells",
+                "name": "dimension door",
+                "type": "link"
+              },
+              {
+                "alt": "gaseous form",
+                "aonid": 129,
+                "game-obj": "Spells",
+                "name": "gaseous form",
+                "type": "link"
+              },
+              {
+                "alt": "resilient sphere",
+                "aonid": 255,
+                "game-obj": "Spells",
+                "name": "resilient sphere",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 190,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "commune with nature",
+                "aonid": 7,
+                "game-obj": "Rituals",
+                "name": "commune with nature",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -596,291 +301,118 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult sea dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 73,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "discern location",
-                            "aonid": 75,
-                            "game-obj": "Spells",
-                            "name": "discern location",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "discern location",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "horrid wilting",
-                            "aonid": 152,
-                            "game-obj": "Spells",
-                            "name": "horrid wilting",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "horrid wilting",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 100,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 237,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spell turning",
-                            "aonid": 297,
-                            "game-obj": "Spells",
-                            "name": "spell turning",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spell turning",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal calamity",
-                            "aonid": 218,
-                            "game-obj": "Spells",
-                            "name": "phantasmal calamity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal calamity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "repulsion",
-                            "aonid": 254,
-                            "game-obj": "Spells",
-                            "name": "repulsion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "repulsion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 190,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "commune with nature",
-                            "aonid": 7,
-                            "game-obj": "Rituals",
-                            "name": "commune with nature",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "commune with nature",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Sea Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disappearance",
+                "aonid": 73,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "discern location",
+                "aonid": 75,
+                "game-obj": "Spells",
+                "name": "discern location",
+                "type": "link"
+              },
+              {
+                "alt": "horrid wilting",
+                "aonid": 152,
+                "game-obj": "Spells",
+                "name": "horrid wilting",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 100,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "project image",
+                "aonid": 237,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
+              },
+              {
+                "alt": "spell turning",
+                "aonid": 297,
+                "game-obj": "Spells",
+                "name": "spell turning",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal calamity",
+                "aonid": 218,
+                "game-obj": "Spells",
+                "name": "phantasmal calamity",
+                "type": "link"
+              },
+              {
+                "alt": "repulsion",
+                "aonid": 254,
+                "game-obj": "Spells",
+                "name": "repulsion",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 190,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "commune with nature",
+                "aonid": 7,
+                "game-obj": "Rituals",
+                "name": "commune with nature",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -895,240 +427,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 8,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 8,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1138,7 +472,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:",
         "type": "stat_block_section"
       }
     ],
@@ -1164,6 +497,1178 @@
         }
       ],
       "text": "Sea dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "feet to fins",
+          "aonid": 113,
+          "game-obj": "Spells",
+          "name": "feet to fins",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 147,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "wall of wind",
+          "aonid": 367,
+          "game-obj": "Spells",
+          "name": "wall of wind",
+          "type": "link"
+        },
+        {
+          "alt": "hideous laughter",
+          "aonid": 150,
+          "game-obj": "Spells",
+          "name": "hideous laughter",
+          "type": "link"
+        },
+        {
+          "alt": "resist energy",
+          "aonid": 256,
+          "game-obj": "Spells",
+          "name": "resist energy",
+          "type": "link"
+        },
+        {
+          "alt": "water breathing",
+          "aonid": 370,
+          "game-obj": "Spells",
+          "name": "water breathing",
+          "type": "link"
+        },
+        {
+          "alt": "air bubble",
+          "aonid": 5,
+          "game-obj": "Spells",
+          "name": "air bubble",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 140,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "grim tendrils",
+          "aonid": 141,
+          "game-obj": "Spells",
+          "name": "grim tendrils",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 190,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Young Sea Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 77",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 77",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 77,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 19,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "feet to fins",
+                      "aonid": 113,
+                      "game-obj": "Spells",
+                      "name": "feet to fins",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "feet to fins",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 147,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of wind",
+                      "aonid": 367,
+                      "game-obj": "Spells",
+                      "name": "wall of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hideous laughter",
+                      "aonid": 150,
+                      "game-obj": "Spells",
+                      "name": "hideous laughter",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hideous laughter",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resist energy",
+                      "aonid": 256,
+                      "game-obj": "Spells",
+                      "name": "resist energy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resist energy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water breathing",
+                      "aonid": 370,
+                      "game-obj": "Spells",
+                      "name": "water breathing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water breathing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "air bubble",
+                      "aonid": 5,
+                      "game-obj": "Spells",
+                      "name": "air bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "air bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 140,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grim tendrils",
+                      "aonid": 141,
+                      "game-obj": "Spells",
+                      "name": "grim tendrils",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grim tendrils",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 190,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 26, attack +19; **3rd** *feet to fins*, *haste*, *wall of wind*; **2nd** *hideous laughter*, *resist energy*, *water breathing*; **1st** *air bubble*, *grease*, *grim tendrils*; **Cantrips (3rd)** *detect magic*, *message*, *prestidigitation*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "mariner's curse",
+          "aonid": 184,
+          "game-obj": "Spells",
+          "name": "mariner's curse",
+          "type": "link"
+        },
+        {
+          "alt": "tongues",
+          "aonid": 340,
+          "game-obj": "Spells",
+          "name": "tongues",
+          "type": "link"
+        },
+        {
+          "alt": "wall of ice",
+          "aonid": 364,
+          "game-obj": "Spells",
+          "name": "wall of ice",
+          "type": "link"
+        },
+        {
+          "alt": "dimension door",
+          "aonid": 69,
+          "game-obj": "Spells",
+          "name": "dimension door",
+          "type": "link"
+        },
+        {
+          "alt": "gaseous form",
+          "aonid": 129,
+          "game-obj": "Spells",
+          "name": "gaseous form",
+          "type": "link"
+        },
+        {
+          "alt": "resilient sphere",
+          "aonid": 255,
+          "game-obj": "Spells",
+          "name": "resilient sphere",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 190,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "commune with nature",
+          "aonid": 7,
+          "game-obj": "Rituals",
+          "name": "commune with nature",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Sea Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 77",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 77",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 77,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young sea dragon"
+          ],
+          "saving_throw": {
+            "dc": 32,
+            "subtype": "save_dc",
+            "text": "DC 32",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mariner's curse",
+                      "aonid": 184,
+                      "game-obj": "Spells",
+                      "name": "mariner's curse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mariner's curse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tongues",
+                      "aonid": 340,
+                      "game-obj": "Spells",
+                      "name": "tongues",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tongues",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of ice",
+                      "aonid": 364,
+                      "game-obj": "Spells",
+                      "name": "wall of ice",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of ice",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dimension door",
+                      "aonid": 69,
+                      "game-obj": "Spells",
+                      "name": "dimension door",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dimension door",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gaseous form",
+                      "aonid": 129,
+                      "game-obj": "Spells",
+                      "name": "gaseous form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gaseous form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resilient sphere",
+                      "aonid": 255,
+                      "game-obj": "Spells",
+                      "name": "resilient sphere",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resilient sphere",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 190,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "commune with nature",
+                      "aonid": 7,
+                      "game-obj": "Rituals",
+                      "name": "commune with nature",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "commune with nature",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 32, attack +26; As young sea dragon, plus **5th** *mariner's curse*, *tongues*, *wall of ice*; **4th** *dimension door*, *gaseous form*, *resilient sphere*; **Cantrips (5th)** *detect magic*, *message*, *prestidigitation*, *read aura*, *shield*; **Rituals** DC 32; commune with nature",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "disappearance",
+          "aonid": 73,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "discern location",
+          "aonid": 75,
+          "game-obj": "Spells",
+          "name": "discern location",
+          "type": "link"
+        },
+        {
+          "alt": "horrid wilting",
+          "aonid": 152,
+          "game-obj": "Spells",
+          "name": "horrid wilting",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 100,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "project image",
+          "aonid": 237,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        },
+        {
+          "alt": "spell turning",
+          "aonid": 297,
+          "game-obj": "Spells",
+          "name": "spell turning",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal calamity",
+          "aonid": 218,
+          "game-obj": "Spells",
+          "name": "phantasmal calamity",
+          "type": "link"
+        },
+        {
+          "alt": "repulsion",
+          "aonid": 254,
+          "game-obj": "Spells",
+          "name": "repulsion",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 190,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "commune with nature",
+          "aonid": 7,
+          "game-obj": "Rituals",
+          "name": "commune with nature",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Sea Dragon",
+      "sections": [
+        {
+          "name": "Unexpected Homes",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 77",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 77",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 77,
+              "type": "source"
+            }
+          ],
+          "text": "Sea dragons, despite their friendliness, don't like to share their territory. The youngest and weakest sea dragons are often ousted by older and stronger opponents from even the smallest ponds. In desperation, these dragons sometimes take up residence in wells and cisterns, much to the shock of unsuspecting villagers.",
+          "type": "section"
+        },
+        {
+          "name": "Weixiyuan",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 77",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 77",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 77,
+              "type": "source"
+            }
+          ],
+          "text": "Sailors who brave the treacherous Valashmai Sea tell of the ancient sea dragon Weixiyuan, who rules the pristine waters bordering the monster-infested straits. Weixiyuan has been known to aid good-hearted voyagers who run into trouble near his territory. Though, powerful as he is, even he prefers not to enter the dangerous waters of the Valashmai Sea itself",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 77",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 77",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 77,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult sea dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 73,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "discern location",
+                      "aonid": 75,
+                      "game-obj": "Spells",
+                      "name": "discern location",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "discern location",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "horrid wilting",
+                      "aonid": 152,
+                      "game-obj": "Spells",
+                      "name": "horrid wilting",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "horrid wilting",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 100,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 237,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spell turning",
+                      "aonid": 297,
+                      "game-obj": "Spells",
+                      "name": "spell turning",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spell turning",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal calamity",
+                      "aonid": 218,
+                      "game-obj": "Spells",
+                      "name": "phantasmal calamity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal calamity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "repulsion",
+                      "aonid": 254,
+                      "game-obj": "Spells",
+                      "name": "repulsion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "repulsion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 190,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "commune with nature",
+                      "aonid": 7,
+                      "game-obj": "Rituals",
+                      "name": "commune with nature",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "commune with nature",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 38, attack +33; As adult sea dragon, plus **8th** *disappearance*, *discern location*, *horrid wilting*; **7th** *energy aegis*, *project image*, *spell turning*; **6th** *phantasmal calamity*, *repulsion*, *true seeing*; **Cantrips (8th)** *detect magic*, *message*, *prestidigitation*, *read aura*, *shield*; **Rituals** DC 38; commune with nature",
       "type": "section"
     },
     {
@@ -1232,6 +1737,283 @@
         }
       ],
       "text": "Five elements underpin the magical powers of imperial dragons, influencing their relationships to all things and, especially, to others of their kind. These elements interlink in two cycles. In the first cycle, each element feeds one other: wood feeds fire, fire feeds earth, earth feeds metal, metal feeds water, and water feeds wood. In the second cycle, each element counters another: wood counters earth, earth counters water, water counters fire, fire counters metal, and metal counters wood.   \n  \nEach imperial dragon represents one element and has four abilities related to the cycle. For example, the forest dragon\u2014linked to wood\u2014feeds fire, is fed by water, counters earth, and is countered by metal.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 8,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "Change Shape",
+          "aonid": 8,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 77",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 77",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 77,
+          "type": "source"
+        }
+      ],
+      "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:   \n  \n**Change Shape** [#] (concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_3/dragon_sky.json
+++ b/monster_families/bestiary_3/dragon_sky.json
@@ -75,356 +75,146 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "discern lies",
-                            "aonid": 74,
-                            "game-obj": "Spells",
-                            "name": "discern lies",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "discern lies",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 78,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine wrath",
-                            "aonid": 86,
-                            "game-obj": "Spells",
-                            "name": "divine wrath",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine wrath",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heroism",
-                            "aonid": 149,
-                            "game-obj": "Spells",
-                            "name": "heroism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "locate",
-                            "aonid": 173,
-                            "game-obj": "Spells",
-                            "name": "locate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "locate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wanderer's guide",
-                            "aonid": 368,
-                            "game-obj": "Spells",
-                            "name": "wanderer's guide",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wanderer's guide",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "augury",
-                            "aonid": 15,
-                            "game-obj": "Spells",
-                            "name": "augury",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "augury",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "comprehend language",
-                            "aonid": 46,
-                            "game-obj": "Spells",
-                            "name": "comprehend language",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "comprehend language",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create food",
-                            "aonid": 52,
-                            "game-obj": "Spells",
-                            "name": "create food",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create food",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "alarm",
-                            "aonid": 7,
-                            "game-obj": "Spells",
-                            "name": "alarm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "alarm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bless",
-                            "aonid": 25,
-                            "game-obj": "Spells",
-                            "name": "bless",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bless",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count_text": "at will, evil only",
-                        "links": [
-                          {
-                            "alt": "detect alignment",
-                            "aonid": 65,
-                            "game-obj": "Spells",
-                            "name": "detect alignment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect alignment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sanctuary",
-                            "aonid": 266,
-                            "game-obj": "Spells",
-                            "name": "sanctuary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sanctuary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 84,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 307,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "consecrate",
-                            "aonid": 8,
-                            "game-obj": "Rituals",
-                            "name": "consecrate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "consecrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Sky Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "discern lies",
+                "aonid": 74,
+                "game-obj": "Spells",
+                "name": "discern lies",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 78,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine wrath",
+                "aonid": 86,
+                "game-obj": "Spells",
+                "name": "divine wrath",
+                "type": "link"
+              },
+              {
+                "alt": "heroism",
+                "aonid": 149,
+                "game-obj": "Spells",
+                "name": "heroism",
+                "type": "link"
+              },
+              {
+                "alt": "locate",
+                "aonid": 173,
+                "game-obj": "Spells",
+                "name": "locate",
+                "type": "link"
+              },
+              {
+                "alt": "wanderer's guide",
+                "aonid": 368,
+                "game-obj": "Spells",
+                "name": "wanderer's guide",
+                "type": "link"
+              },
+              {
+                "alt": "augury",
+                "aonid": 15,
+                "game-obj": "Spells",
+                "name": "augury",
+                "type": "link"
+              },
+              {
+                "alt": "comprehend language",
+                "aonid": 46,
+                "game-obj": "Spells",
+                "name": "comprehend language",
+                "type": "link"
+              },
+              {
+                "alt": "create food",
+                "aonid": 52,
+                "game-obj": "Spells",
+                "name": "create food",
+                "type": "link"
+              },
+              {
+                "alt": "alarm",
+                "aonid": 7,
+                "game-obj": "Spells",
+                "name": "alarm",
+                "type": "link"
+              },
+              {
+                "alt": "bless",
+                "aonid": 25,
+                "game-obj": "Spells",
+                "name": "bless",
+                "type": "link"
+              },
+              {
+                "alt": "detect alignment",
+                "aonid": 65,
+                "game-obj": "Spells",
+                "name": "detect alignment",
+                "type": "link"
+              },
+              {
+                "alt": "sanctuary",
+                "aonid": 266,
+                "game-obj": "Spells",
+                "name": "sanctuary",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 84,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 307,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
+              },
+              {
+                "alt": "consecrate",
+                "aonid": 8,
+                "game-obj": "Rituals",
+                "name": "consecrate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -440,238 +230,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young sky dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blade barrier",
-                            "aonid": 24,
-                            "game-obj": "Spells",
-                            "name": "blade barrier",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blade barrier",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "righteous might",
-                            "aonid": 263,
-                            "game-obj": "Spells",
-                            "name": "righteous might",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "righteous might",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 19,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prying eye",
-                            "aonid": 239,
-                            "game-obj": "Spells",
-                            "name": "prying eye",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prying eye",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tongues",
-                            "aonid": 340,
-                            "game-obj": "Spells",
-                            "name": "tongues",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tongues",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 84,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 307,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "atone",
-                            "aonid": 2,
-                            "game-obj": "Rituals",
-                            "name": "atone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "atone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Sky Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "blade barrier",
+                "aonid": 24,
+                "game-obj": "Spells",
+                "name": "blade barrier",
+                "type": "link"
+              },
+              {
+                "alt": "righteous might",
+                "aonid": 263,
+                "game-obj": "Spells",
+                "name": "righteous might",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 19,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "prying eye",
+                "aonid": 239,
+                "game-obj": "Spells",
+                "name": "prying eye",
+                "type": "link"
+              },
+              {
+                "alt": "tongues",
+                "aonid": 340,
+                "game-obj": "Spells",
+                "name": "tongues",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 84,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 307,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
+              },
+              {
+                "alt": "atone",
+                "aonid": 2,
+                "game-obj": "Rituals",
+                "name": "atone",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -687,238 +336,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult sky dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "discern location",
-                            "aonid": 75,
-                            "game-obj": "Spells",
-                            "name": "discern location",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "discern location",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine aura",
-                            "aonid": 81,
-                            "game-obj": "Spells",
-                            "name": "divine aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine decree",
-                            "aonid": 82,
-                            "game-obj": "Spells",
-                            "name": "divine decree",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine decree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 100,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prismatic spray",
-                            "aonid": 233,
-                            "game-obj": "Spells",
-                            "name": "prismatic spray",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prismatic spray",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sunburst",
-                            "aonid": 326,
-                            "game-obj": "Spells",
-                            "name": "sunburst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sunburst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 84,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 307,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "legend lore",
-                            "aonid": 15,
-                            "game-obj": "Rituals",
-                            "name": "legend lore",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "legend lore",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Sky Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "discern location",
+                "aonid": 75,
+                "game-obj": "Spells",
+                "name": "discern location",
+                "type": "link"
+              },
+              {
+                "alt": "divine aura",
+                "aonid": 81,
+                "game-obj": "Spells",
+                "name": "divine aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine decree",
+                "aonid": 82,
+                "game-obj": "Spells",
+                "name": "divine decree",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 100,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "prismatic spray",
+                "aonid": 233,
+                "game-obj": "Spells",
+                "name": "prismatic spray",
+                "type": "link"
+              },
+              {
+                "alt": "sunburst",
+                "aonid": 326,
+                "game-obj": "Spells",
+                "name": "sunburst",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 84,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 307,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
+              },
+              {
+                "alt": "legend lore",
+                "aonid": 15,
+                "game-obj": "Rituals",
+                "name": "legend lore",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -933,240 +441,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 8,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 8,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1176,7 +486,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:",
         "type": "stat_block_section"
       }
     ],
@@ -1254,6 +563,1190 @@
     {
       "links": [
         {
+          "alt": "discern lies",
+          "aonid": 74,
+          "game-obj": "Spells",
+          "name": "discern lies",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 78,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine wrath",
+          "aonid": 86,
+          "game-obj": "Spells",
+          "name": "divine wrath",
+          "type": "link"
+        },
+        {
+          "alt": "heroism",
+          "aonid": 149,
+          "game-obj": "Spells",
+          "name": "heroism",
+          "type": "link"
+        },
+        {
+          "alt": "locate",
+          "aonid": 173,
+          "game-obj": "Spells",
+          "name": "locate",
+          "type": "link"
+        },
+        {
+          "alt": "wanderer's guide",
+          "aonid": 368,
+          "game-obj": "Spells",
+          "name": "wanderer's guide",
+          "type": "link"
+        },
+        {
+          "alt": "augury",
+          "aonid": 15,
+          "game-obj": "Spells",
+          "name": "augury",
+          "type": "link"
+        },
+        {
+          "alt": "comprehend language",
+          "aonid": 46,
+          "game-obj": "Spells",
+          "name": "comprehend language",
+          "type": "link"
+        },
+        {
+          "alt": "create food",
+          "aonid": 52,
+          "game-obj": "Spells",
+          "name": "create food",
+          "type": "link"
+        },
+        {
+          "alt": "alarm",
+          "aonid": 7,
+          "game-obj": "Spells",
+          "name": "alarm",
+          "type": "link"
+        },
+        {
+          "alt": "bless",
+          "aonid": 25,
+          "game-obj": "Spells",
+          "name": "bless",
+          "type": "link"
+        },
+        {
+          "alt": "detect alignment",
+          "aonid": 65,
+          "game-obj": "Spells",
+          "name": "detect alignment",
+          "type": "link"
+        },
+        {
+          "alt": "sanctuary",
+          "aonid": 266,
+          "game-obj": "Spells",
+          "name": "sanctuary",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 84,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 307,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        },
+        {
+          "alt": "consecrate",
+          "aonid": 8,
+          "game-obj": "Rituals",
+          "name": "consecrate",
+          "type": "link"
+        }
+      ],
+      "name": "Young Sky Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 79",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 79",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 79,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "discern lies",
+                      "aonid": 74,
+                      "game-obj": "Spells",
+                      "name": "discern lies",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "discern lies",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 78,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine wrath",
+                      "aonid": 86,
+                      "game-obj": "Spells",
+                      "name": "divine wrath",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine wrath",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heroism",
+                      "aonid": 149,
+                      "game-obj": "Spells",
+                      "name": "heroism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "locate",
+                      "aonid": 173,
+                      "game-obj": "Spells",
+                      "name": "locate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "locate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wanderer's guide",
+                      "aonid": 368,
+                      "game-obj": "Spells",
+                      "name": "wanderer's guide",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wanderer's guide",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "augury",
+                      "aonid": 15,
+                      "game-obj": "Spells",
+                      "name": "augury",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "augury",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "comprehend language",
+                      "aonid": 46,
+                      "game-obj": "Spells",
+                      "name": "comprehend language",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "comprehend language",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create food",
+                      "aonid": 52,
+                      "game-obj": "Spells",
+                      "name": "create food",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create food",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "alarm",
+                      "aonid": 7,
+                      "game-obj": "Spells",
+                      "name": "alarm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "alarm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bless",
+                      "aonid": 25,
+                      "game-obj": "Spells",
+                      "name": "bless",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bless",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count_text": "at will, evil only",
+                  "links": [
+                    {
+                      "alt": "detect alignment",
+                      "aonid": 65,
+                      "game-obj": "Spells",
+                      "name": "detect alignment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect alignment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sanctuary",
+                      "aonid": 266,
+                      "game-obj": "Spells",
+                      "name": "sanctuary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sanctuary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 84,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 307,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "consecrate",
+                      "aonid": 8,
+                      "game-obj": "Rituals",
+                      "name": "consecrate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "consecrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 28, attack +21; **4th** *discern lies*, *dispel magic*, *divine wrath*; **3rd** *heroism*, *locate*, *wanderer's guide*; **2nd** *augury*, *comprehend language*, *create food*; **1st** *alarm*, *bless*, *detect alignment* (at will, evil only), *sanctuary*; **Cantrips (4th)** *detect magic*, *divine lance*, *read aura*, *shield*, *stabilize*; **Rituals** DC 28; consecrate",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "blade barrier",
+          "aonid": 24,
+          "game-obj": "Spells",
+          "name": "blade barrier",
+          "type": "link"
+        },
+        {
+          "alt": "righteous might",
+          "aonid": 263,
+          "game-obj": "Spells",
+          "name": "righteous might",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 19,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "prying eye",
+          "aonid": 239,
+          "game-obj": "Spells",
+          "name": "prying eye",
+          "type": "link"
+        },
+        {
+          "alt": "tongues",
+          "aonid": 340,
+          "game-obj": "Spells",
+          "name": "tongues",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 84,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 307,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        },
+        {
+          "alt": "atone",
+          "aonid": 2,
+          "game-obj": "Rituals",
+          "name": "atone",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Sky Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 79",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 79",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 79,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young sky dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blade barrier",
+                      "aonid": 24,
+                      "game-obj": "Spells",
+                      "name": "blade barrier",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blade barrier",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "righteous might",
+                      "aonid": 263,
+                      "game-obj": "Spells",
+                      "name": "righteous might",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "righteous might",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 19,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prying eye",
+                      "aonid": 239,
+                      "game-obj": "Spells",
+                      "name": "prying eye",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prying eye",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tongues",
+                      "aonid": 340,
+                      "game-obj": "Spells",
+                      "name": "tongues",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tongues",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 84,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 307,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "atone",
+                      "aonid": 2,
+                      "game-obj": "Rituals",
+                      "name": "atone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "atone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 33, attack +26; As young sky dragon, plus **6th** *blade barrier*, *righteous might*, *true seeing*; **5th** *banishment*, *prying eye*, *tongues*; **Cantrips (6th)** *detect magic*, *divine lance*, *read aura*, *shield*, *stabilize*; **Rituals** DC 33; atone",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "discern location",
+          "aonid": 75,
+          "game-obj": "Spells",
+          "name": "discern location",
+          "type": "link"
+        },
+        {
+          "alt": "divine aura",
+          "aonid": 81,
+          "game-obj": "Spells",
+          "name": "divine aura",
+          "type": "link"
+        },
+        {
+          "alt": "divine decree",
+          "aonid": 82,
+          "game-obj": "Spells",
+          "name": "divine decree",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 100,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "prismatic spray",
+          "aonid": 233,
+          "game-obj": "Spells",
+          "name": "prismatic spray",
+          "type": "link"
+        },
+        {
+          "alt": "sunburst",
+          "aonid": 326,
+          "game-obj": "Spells",
+          "name": "sunburst",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 84,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 307,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        },
+        {
+          "alt": "legend lore",
+          "aonid": 15,
+          "game-obj": "Rituals",
+          "name": "legend lore",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Sky Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 79",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 79",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 79,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult sky dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "discern location",
+                      "aonid": 75,
+                      "game-obj": "Spells",
+                      "name": "discern location",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "discern location",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine aura",
+                      "aonid": 81,
+                      "game-obj": "Spells",
+                      "name": "divine aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine decree",
+                      "aonid": 82,
+                      "game-obj": "Spells",
+                      "name": "divine decree",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine decree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 100,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prismatic spray",
+                      "aonid": 233,
+                      "game-obj": "Spells",
+                      "name": "prismatic spray",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prismatic spray",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sunburst",
+                      "aonid": 326,
+                      "game-obj": "Spells",
+                      "name": "sunburst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sunburst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 84,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 307,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "legend lore",
+                      "aonid": 15,
+                      "game-obj": "Rituals",
+                      "name": "legend lore",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "legend lore",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 42, attack +36; As adult sky dragon, plus **8th** *discern location*, *divine aura*, *divine decree*; **7th** *energy aegis*, *prismatic spray*, *sunburst*; **Cantrips (9th)** *detect magic*, *divine lance*, *read aura*, *shield*, *stabilize*; **Rituals** DC 42; legend lore",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
           "alt": "Dragon, Forest",
           "aonid": 227,
           "game-obj": "MonsterFamilies",
@@ -1317,6 +1810,283 @@
         }
       ],
       "text": "Five elements underpin the magical powers of imperial dragons, influencing their relationships to all things and, especially, to others of their kind. These elements interlink in two cycles. In the first cycle, each element feeds one other: wood feeds fire, fire feeds earth, earth feeds metal, metal feeds water, and water feeds wood. In the second cycle, each element counters another: wood counters earth, earth counters water, water counters fire, fire counters metal, and metal counters wood.   \n  \nEach imperial dragon represents one element and has four abilities related to the cycle. For example, the forest dragon\u2014linked to wood\u2014feeds fire, is fed by water, counters earth, and is countered by metal.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 8,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "Change Shape",
+          "aonid": 8,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 79",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 79",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 79,
+          "type": "source"
+        }
+      ],
+      "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:   \n  \n**Change Shape** [#] (concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_3/dragon_sovereign.json
+++ b/monster_families/bestiary_3/dragon_sovereign.json
@@ -75,318 +75,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 23,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "calm emotions",
-                            "aonid": 31,
-                            "game-obj": "Spells",
-                            "name": "calm emotions",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "calm emotions",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect scrying",
-                            "aonid": 68,
-                            "game-obj": "Spells",
-                            "name": "detect scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "silence",
-                            "aonid": 287,
-                            "game-obj": "Spells",
-                            "name": "silence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "silence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enthrall",
-                            "aonid": 104,
-                            "game-obj": "Spells",
-                            "name": "enthrall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enthrall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heroism",
-                            "aonid": 149,
-                            "game-obj": "Spells",
-                            "name": "heroism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hypnotic pattern",
-                            "aonid": 157,
-                            "game-obj": "Spells",
-                            "name": "hypnotic pattern",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hypnotic pattern",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "comprehend language",
-                            "aonid": 46,
-                            "game-obj": "Spells",
-                            "name": "comprehend language",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "comprehend language",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "remove fear",
-                            "aonid": 252,
-                            "game-obj": "Spells",
-                            "name": "remove fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "remove fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "status",
-                            "aonid": 308,
-                            "game-obj": "Spells",
-                            "name": "status",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "status",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 45,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory disguise",
-                            "aonid": 159,
-                            "game-obj": "Spells",
-                            "name": "illusory disguise",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "illusory disguise",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true strike",
-                            "aonid": 345,
-                            "game-obj": "Spells",
-                            "name": "true strike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true strike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 61,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Sovereign Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "calm emotions",
+                "aonid": 31,
+                "game-obj": "Spells",
+                "name": "calm emotions",
+                "type": "link"
+              },
+              {
+                "alt": "detect scrying",
+                "aonid": 68,
+                "game-obj": "Spells",
+                "name": "detect scrying",
+                "type": "link"
+              },
+              {
+                "alt": "silence",
+                "aonid": 287,
+                "game-obj": "Spells",
+                "name": "silence",
+                "type": "link"
+              },
+              {
+                "alt": "enthrall",
+                "aonid": 104,
+                "game-obj": "Spells",
+                "name": "enthrall",
+                "type": "link"
+              },
+              {
+                "alt": "heroism",
+                "aonid": 149,
+                "game-obj": "Spells",
+                "name": "heroism",
+                "type": "link"
+              },
+              {
+                "alt": "hypnotic pattern",
+                "aonid": 157,
+                "game-obj": "Spells",
+                "name": "hypnotic pattern",
+                "type": "link"
+              },
+              {
+                "alt": "comprehend language",
+                "aonid": 46,
+                "game-obj": "Spells",
+                "name": "comprehend language",
+                "type": "link"
+              },
+              {
+                "alt": "remove fear",
+                "aonid": 252,
+                "game-obj": "Spells",
+                "name": "remove fear",
+                "type": "link"
+              },
+              {
+                "alt": "status",
+                "aonid": 308,
+                "game-obj": "Spells",
+                "name": "status",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 45,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "illusory disguise",
+                "aonid": 159,
+                "game-obj": "Spells",
+                "name": "illusory disguise",
+                "type": "link"
+              },
+              {
+                "alt": "true strike",
+                "aonid": 345,
+                "game-obj": "Spells",
+                "name": "true strike",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 61,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -402,215 +216,90 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young sovereign dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dominate",
-                            "aonid": 87,
-                            "game-obj": "Spells",
-                            "name": "dominate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dominate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "feeblemind",
-                            "aonid": 112,
-                            "game-obj": "Spells",
-                            "name": "feeblemind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "feeblemind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "zealous conviction",
-                            "aonid": 378,
-                            "game-obj": "Spells",
-                            "name": "zealous conviction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "zealous conviction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dreaming potential",
-                            "aonid": 91,
-                            "game-obj": "Spells",
-                            "name": "dreaming potential",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dreaming potential",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "subconscious suggestion",
-                            "aonid": 314,
-                            "game-obj": "Spells",
-                            "name": "subconscious suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "subconscious suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tongues",
-                            "aonid": 340,
-                            "game-obj": "Spells",
-                            "name": "tongues",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tongues",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 61,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Sovereign Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dominate",
+                "aonid": 87,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "feeblemind",
+                "aonid": 112,
+                "game-obj": "Spells",
+                "name": "feeblemind",
+                "type": "link"
+              },
+              {
+                "alt": "zealous conviction",
+                "aonid": 378,
+                "game-obj": "Spells",
+                "name": "zealous conviction",
+                "type": "link"
+              },
+              {
+                "alt": "dreaming potential",
+                "aonid": 91,
+                "game-obj": "Spells",
+                "name": "dreaming potential",
+                "type": "link"
+              },
+              {
+                "alt": "subconscious suggestion",
+                "aonid": 314,
+                "game-obj": "Spells",
+                "name": "subconscious suggestion",
+                "type": "link"
+              },
+              {
+                "alt": "tongues",
+                "aonid": 340,
+                "game-obj": "Spells",
+                "name": "tongues",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 61,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -626,268 +315,111 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult sovereign dragon"
-                ],
-                "saving_throw": {
-                  "dc": 43,
-                  "subtype": "save_dc",
-                  "text": "DC 43",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 127,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 212,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telepathic demand",
-                            "aonid": 336,
-                            "game-obj": "Spells",
-                            "name": "telepathic demand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telepathic demand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 73,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dream council",
-                            "aonid": 89,
-                            "game-obj": "Spells",
-                            "name": "dream council",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dream council",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "maze",
-                            "aonid": 187,
-                            "game-obj": "Spells",
-                            "name": "maze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "maze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dimensional lock",
-                            "aonid": 71,
-                            "game-obj": "Spells",
-                            "name": "dimensional lock",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dimensional lock",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "magnificent mansion",
-                            "aonid": 183,
-                            "game-obj": "Spells",
-                            "name": "magnificent mansion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "magnificent mansion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true target",
-                            "aonid": 346,
-                            "game-obj": "Spells",
-                            "name": "true target",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true target",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 61,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 66,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 229,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Sovereign Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "foresight",
+                "aonid": 127,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 212,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "telepathic demand",
+                "aonid": 336,
+                "game-obj": "Spells",
+                "name": "telepathic demand",
+                "type": "link"
+              },
+              {
+                "alt": "disappearance",
+                "aonid": 73,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "dream council",
+                "aonid": 89,
+                "game-obj": "Spells",
+                "name": "dream council",
+                "type": "link"
+              },
+              {
+                "alt": "maze",
+                "aonid": 187,
+                "game-obj": "Spells",
+                "name": "maze",
+                "type": "link"
+              },
+              {
+                "alt": "dimensional lock",
+                "aonid": 71,
+                "game-obj": "Spells",
+                "name": "dimensional lock",
+                "type": "link"
+              },
+              {
+                "alt": "magnificent mansion",
+                "aonid": 183,
+                "game-obj": "Spells",
+                "name": "magnificent mansion",
+                "type": "link"
+              },
+              {
+                "alt": "true target",
+                "aonid": 346,
+                "game-obj": "Spells",
+                "name": "true target",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 61,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 229,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -902,240 +434,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 8,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 8,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1145,7 +479,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:",
         "type": "stat_block_section"
       }
     ],
@@ -1190,6 +523,1152 @@
         }
       ],
       "text": "Sovereign dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "calm emotions",
+          "aonid": 31,
+          "game-obj": "Spells",
+          "name": "calm emotions",
+          "type": "link"
+        },
+        {
+          "alt": "detect scrying",
+          "aonid": 68,
+          "game-obj": "Spells",
+          "name": "detect scrying",
+          "type": "link"
+        },
+        {
+          "alt": "silence",
+          "aonid": 287,
+          "game-obj": "Spells",
+          "name": "silence",
+          "type": "link"
+        },
+        {
+          "alt": "enthrall",
+          "aonid": 104,
+          "game-obj": "Spells",
+          "name": "enthrall",
+          "type": "link"
+        },
+        {
+          "alt": "heroism",
+          "aonid": 149,
+          "game-obj": "Spells",
+          "name": "heroism",
+          "type": "link"
+        },
+        {
+          "alt": "hypnotic pattern",
+          "aonid": 157,
+          "game-obj": "Spells",
+          "name": "hypnotic pattern",
+          "type": "link"
+        },
+        {
+          "alt": "comprehend language",
+          "aonid": 46,
+          "game-obj": "Spells",
+          "name": "comprehend language",
+          "type": "link"
+        },
+        {
+          "alt": "remove fear",
+          "aonid": 252,
+          "game-obj": "Spells",
+          "name": "remove fear",
+          "type": "link"
+        },
+        {
+          "alt": "status",
+          "aonid": 308,
+          "game-obj": "Spells",
+          "name": "status",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 45,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "illusory disguise",
+          "aonid": 159,
+          "game-obj": "Spells",
+          "name": "illusory disguise",
+          "type": "link"
+        },
+        {
+          "alt": "true strike",
+          "aonid": 345,
+          "game-obj": "Spells",
+          "name": "true strike",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 61,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Young Sovereign Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 81",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 81",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 81,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 23,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "calm emotions",
+                      "aonid": 31,
+                      "game-obj": "Spells",
+                      "name": "calm emotions",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "calm emotions",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect scrying",
+                      "aonid": 68,
+                      "game-obj": "Spells",
+                      "name": "detect scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "silence",
+                      "aonid": 287,
+                      "game-obj": "Spells",
+                      "name": "silence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "silence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enthrall",
+                      "aonid": 104,
+                      "game-obj": "Spells",
+                      "name": "enthrall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enthrall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heroism",
+                      "aonid": 149,
+                      "game-obj": "Spells",
+                      "name": "heroism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hypnotic pattern",
+                      "aonid": 157,
+                      "game-obj": "Spells",
+                      "name": "hypnotic pattern",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hypnotic pattern",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "comprehend language",
+                      "aonid": 46,
+                      "game-obj": "Spells",
+                      "name": "comprehend language",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "comprehend language",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "remove fear",
+                      "aonid": 252,
+                      "game-obj": "Spells",
+                      "name": "remove fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "remove fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "status",
+                      "aonid": 308,
+                      "game-obj": "Spells",
+                      "name": "status",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "status",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 45,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory disguise",
+                      "aonid": 159,
+                      "game-obj": "Spells",
+                      "name": "illusory disguise",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "illusory disguise",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true strike",
+                      "aonid": 345,
+                      "game-obj": "Spells",
+                      "name": "true strike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true strike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 61,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 29, attack +23; **4th** *calm emotions*, *detect scrying*, *silence*; **3rd** *enthrall*, *heroism*, *hypnotic pattern*; **2nd** *comprehend language*, *remove fear*, *status*; **1st** *command*, *illusory disguise*, *true strike*; **Cantrips (4th)** *daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dominate",
+          "aonid": 87,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "feeblemind",
+          "aonid": 112,
+          "game-obj": "Spells",
+          "name": "feeblemind",
+          "type": "link"
+        },
+        {
+          "alt": "zealous conviction",
+          "aonid": 378,
+          "game-obj": "Spells",
+          "name": "zealous conviction",
+          "type": "link"
+        },
+        {
+          "alt": "dreaming potential",
+          "aonid": 91,
+          "game-obj": "Spells",
+          "name": "dreaming potential",
+          "type": "link"
+        },
+        {
+          "alt": "subconscious suggestion",
+          "aonid": 314,
+          "game-obj": "Spells",
+          "name": "subconscious suggestion",
+          "type": "link"
+        },
+        {
+          "alt": "tongues",
+          "aonid": 340,
+          "game-obj": "Spells",
+          "name": "tongues",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 61,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Sovereign Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 81",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 81",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 81,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young sovereign dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dominate",
+                      "aonid": 87,
+                      "game-obj": "Spells",
+                      "name": "dominate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dominate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "feeblemind",
+                      "aonid": 112,
+                      "game-obj": "Spells",
+                      "name": "feeblemind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "feeblemind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "zealous conviction",
+                      "aonid": 378,
+                      "game-obj": "Spells",
+                      "name": "zealous conviction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "zealous conviction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dreaming potential",
+                      "aonid": 91,
+                      "game-obj": "Spells",
+                      "name": "dreaming potential",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dreaming potential",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "subconscious suggestion",
+                      "aonid": 314,
+                      "game-obj": "Spells",
+                      "name": "subconscious suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "subconscious suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tongues",
+                      "aonid": 340,
+                      "game-obj": "Spells",
+                      "name": "tongues",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tongues",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 61,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 36, attack +30; As young sovereign dragon, plus **6th** *dominate*, *feeblemind*, *zealous conviction*; **5th** *dreaming potential*, *subconscious suggestion*, *tongues*; **Cantrips (6th)** *daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "foresight",
+          "aonid": 127,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 212,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "telepathic demand",
+          "aonid": 336,
+          "game-obj": "Spells",
+          "name": "telepathic demand",
+          "type": "link"
+        },
+        {
+          "alt": "disappearance",
+          "aonid": 73,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "dream council",
+          "aonid": 89,
+          "game-obj": "Spells",
+          "name": "dream council",
+          "type": "link"
+        },
+        {
+          "alt": "maze",
+          "aonid": 187,
+          "game-obj": "Spells",
+          "name": "maze",
+          "type": "link"
+        },
+        {
+          "alt": "dimensional lock",
+          "aonid": 71,
+          "game-obj": "Spells",
+          "name": "dimensional lock",
+          "type": "link"
+        },
+        {
+          "alt": "magnificent mansion",
+          "aonid": 183,
+          "game-obj": "Spells",
+          "name": "magnificent mansion",
+          "type": "link"
+        },
+        {
+          "alt": "true target",
+          "aonid": 346,
+          "game-obj": "Spells",
+          "name": "true target",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 61,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 229,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Sovereign Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 81",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 81",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 81,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult sovereign dragon"
+          ],
+          "saving_throw": {
+            "dc": 43,
+            "subtype": "save_dc",
+            "text": "DC 43",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 127,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 212,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telepathic demand",
+                      "aonid": 336,
+                      "game-obj": "Spells",
+                      "name": "telepathic demand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telepathic demand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 73,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dream council",
+                      "aonid": 89,
+                      "game-obj": "Spells",
+                      "name": "dream council",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dream council",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "maze",
+                      "aonid": 187,
+                      "game-obj": "Spells",
+                      "name": "maze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "maze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dimensional lock",
+                      "aonid": 71,
+                      "game-obj": "Spells",
+                      "name": "dimensional lock",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dimensional lock",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "magnificent mansion",
+                      "aonid": 183,
+                      "game-obj": "Spells",
+                      "name": "magnificent mansion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "magnificent mansion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true target",
+                      "aonid": 346,
+                      "game-obj": "Spells",
+                      "name": "true target",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true target",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 61,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 66,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 229,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 43, attack +38; As adult sovereign dragon, plus **9th** *foresight*, *overwhelming presence*, *telepathic demand*; **8th** *disappearance*, *dream council*, *maze*; **7th** *dimensional lock*, *magnificent mansion*, *true target*; **Cantrips (9th)** *daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
       "type": "section"
     },
     {
@@ -1258,6 +1737,283 @@
         }
       ],
       "text": "Five elements underpin the magical powers of imperial dragons, influencing their relationships to all things and, especially, to others of their kind. These elements interlink in two cycles. In the first cycle, each element feeds one other: wood feeds fire, fire feeds earth, earth feeds metal, metal feeds water, and water feeds wood. In the second cycle, each element counters another: wood counters earth, earth counters water, water counters fire, fire counters metal, and metal counters wood.   \n  \nEach imperial dragon represents one element and has four abilities related to the cycle. For example, the forest dragon\u2014linked to wood\u2014feeds fire, is fed by water, counters earth, and is countered by metal.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 8,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "Change Shape",
+          "aonid": 8,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 81",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 81",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 81,
+          "type": "source"
+        }
+      ],
+      "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:   \n  \n**Change Shape** [#] (concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_3/dragon_underworld.json
+++ b/monster_families/bestiary_3/dragon_underworld.json
@@ -75,250 +75,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Prepared Arcane Spells",
-                "saving_throw": {
-                  "dc": 25,
-                  "subtype": "save_dc",
-                  "text": "DC 25",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 94,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stinking cloud",
-                            "aonid": 309,
-                            "game-obj": "Spells",
-                            "name": "stinking cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stinking cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "glitterdust",
-                            "aonid": 136,
-                            "game-obj": "Spells",
-                            "name": "glitterdust",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "glitterdust",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "knock",
-                            "aonid": 168,
-                            "game-obj": "Spells",
-                            "name": "knock",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "knock",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resist energy",
-                            "aonid": 256,
-                            "game-obj": "Spells",
-                            "name": "resist energy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resist energy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "floating disk",
-                            "aonid": 124,
-                            "game-obj": "Spells",
-                            "name": "floating disk",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "floating disk",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "magic missile",
-                            "aonid": 180,
-                            "game-obj": "Spells",
-                            "name": "magic missile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "magic missile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ray of enfeeblement",
-                            "aonid": 244,
-                            "game-obj": "Spells",
-                            "name": "ray of enfeeblement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ray of enfeeblement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mage hand",
-                            "aonid": 177,
-                            "game-obj": "Spells",
-                            "name": "mage hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mage hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "produce flame",
-                            "aonid": 236,
-                            "game-obj": "Spells",
-                            "name": "produce flame",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "produce flame",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Underworld Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "earthbind",
+                "aonid": 94,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "stinking cloud",
+                "aonid": 309,
+                "game-obj": "Spells",
+                "name": "stinking cloud",
+                "type": "link"
+              },
+              {
+                "alt": "glitterdust",
+                "aonid": 136,
+                "game-obj": "Spells",
+                "name": "glitterdust",
+                "type": "link"
+              },
+              {
+                "alt": "knock",
+                "aonid": 168,
+                "game-obj": "Spells",
+                "name": "knock",
+                "type": "link"
+              },
+              {
+                "alt": "resist energy",
+                "aonid": 256,
+                "game-obj": "Spells",
+                "name": "resist energy",
+                "type": "link"
+              },
+              {
+                "alt": "floating disk",
+                "aonid": 124,
+                "game-obj": "Spells",
+                "name": "floating disk",
+                "type": "link"
+              },
+              {
+                "alt": "magic missile",
+                "aonid": 180,
+                "game-obj": "Spells",
+                "name": "magic missile",
+                "type": "link"
+              },
+              {
+                "alt": "ray of enfeeblement",
+                "aonid": 244,
+                "game-obj": "Spells",
+                "name": "ray of enfeeblement",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "mage hand",
+                "aonid": 177,
+                "game-obj": "Spells",
+                "name": "mage hand",
+                "type": "link"
+              },
+              {
+                "alt": "produce flame",
+                "aonid": 236,
+                "game-obj": "Spells",
+                "name": "produce flame",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -334,191 +188,90 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Prepared Arcane Spells",
-                "notes": [
-                  "As young underworld dragon"
-                ],
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cloudkill",
-                            "aonid": 42,
-                            "game-obj": "Spells",
-                            "name": "cloudkill",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cloudkill",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prying eye",
-                            "aonid": 239,
-                            "game-obj": "Spells",
-                            "name": "prying eye",
-                            "type": "link"
-                          },
-                          {
-                            "alt": "dimension door",
-                            "aonid": 69,
-                            "game-obj": "Spells",
-                            "name": "dimension door",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prying eye; 4th dimension door",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucinatory terrain",
-                            "aonid": 145,
-                            "game-obj": "Spells",
-                            "name": "hallucinatory terrain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucinatory terrain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "private sanctum",
-                            "aonid": 235,
-                            "game-obj": "Spells",
-                            "name": "private sanctum",
-                            "type": "link"
-                          },
-                          {
-                            "alt": "slow",
-                            "aonid": 289,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "private sanctum; 3rd slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mage hand",
-                            "aonid": 177,
-                            "game-obj": "Spells",
-                            "name": "mage hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mage hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "produce flame",
-                            "aonid": 236,
-                            "game-obj": "Spells",
-                            "name": "produce flame",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "produce flame",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Underworld Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cloudkill",
+                "aonid": 42,
+                "game-obj": "Spells",
+                "name": "cloudkill",
+                "type": "link"
+              },
+              {
+                "alt": "prying eye",
+                "aonid": 239,
+                "game-obj": "Spells",
+                "name": "prying eye",
+                "type": "link"
+              },
+              {
+                "alt": "dimension door",
+                "aonid": 69,
+                "game-obj": "Spells",
+                "name": "dimension door",
+                "type": "link"
+              },
+              {
+                "alt": "hallucinatory terrain",
+                "aonid": 145,
+                "game-obj": "Spells",
+                "name": "hallucinatory terrain",
+                "type": "link"
+              },
+              {
+                "alt": "private sanctum",
+                "aonid": 235,
+                "game-obj": "Spells",
+                "name": "private sanctum",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 289,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "mage hand",
+                "aonid": 177,
+                "game-obj": "Spells",
+                "name": "mage hand",
+                "type": "link"
+              },
+              {
+                "alt": "produce flame",
+                "aonid": 236,
+                "game-obj": "Spells",
+                "name": "produce flame",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -534,238 +287,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Prepared Arcane Spells",
-                "notes": [
-                  "As adult underworld dragon"
-                ],
-                "saving_throw": {
-                  "dc": 37,
-                  "subtype": "save_dc",
-                  "text": "DC 37",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fiery body",
-                            "aonid": 115,
-                            "game-obj": "Spells",
-                            "name": "fiery body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fiery body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "power word blind",
-                            "aonid": 226,
-                            "game-obj": "Spells",
-                            "name": "power word blind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "power word blind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "reverse gravity",
-                            "aonid": 261,
-                            "game-obj": "Spells",
-                            "name": "reverse gravity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "reverse gravity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mislead",
-                            "aonid": 199,
-                            "game-obj": "Spells",
-                            "name": "mislead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mislead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spellwrack",
-                            "aonid": 298,
-                            "game-obj": "Spells",
-                            "name": "spellwrack",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spellwrack",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true seeing",
-                            "aonid": 344,
-                            "game-obj": "Spells",
-                            "name": "true seeing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true seeing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mind probe",
-                            "aonid": 193,
-                            "game-obj": "Spells",
-                            "name": "mind probe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mind probe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid splash",
-                            "aonid": 3,
-                            "game-obj": "Spells",
-                            "name": "acid splash",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid splash",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mage hand",
-                            "aonid": 177,
-                            "game-obj": "Spells",
-                            "name": "mage hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mage hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "produce flame",
-                            "aonid": 236,
-                            "game-obj": "Spells",
-                            "name": "produce flame",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "produce flame",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 246,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 280,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Underworld Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fiery body",
+                "aonid": 115,
+                "game-obj": "Spells",
+                "name": "fiery body",
+                "type": "link"
+              },
+              {
+                "alt": "power word blind",
+                "aonid": 226,
+                "game-obj": "Spells",
+                "name": "power word blind",
+                "type": "link"
+              },
+              {
+                "alt": "reverse gravity",
+                "aonid": 261,
+                "game-obj": "Spells",
+                "name": "reverse gravity",
+                "type": "link"
+              },
+              {
+                "alt": "mislead",
+                "aonid": 199,
+                "game-obj": "Spells",
+                "name": "mislead",
+                "type": "link"
+              },
+              {
+                "alt": "spellwrack",
+                "aonid": 298,
+                "game-obj": "Spells",
+                "name": "spellwrack",
+                "type": "link"
+              },
+              {
+                "alt": "true seeing",
+                "aonid": 344,
+                "game-obj": "Spells",
+                "name": "true seeing",
+                "type": "link"
+              },
+              {
+                "alt": "mind probe",
+                "aonid": 193,
+                "game-obj": "Spells",
+                "name": "mind probe",
+                "type": "link"
+              },
+              {
+                "alt": "acid splash",
+                "aonid": 3,
+                "game-obj": "Spells",
+                "name": "acid splash",
+                "type": "link"
+              },
+              {
+                "alt": "mage hand",
+                "aonid": 177,
+                "game-obj": "Spells",
+                "name": "mage hand",
+                "type": "link"
+              },
+              {
+                "alt": "produce flame",
+                "aonid": 236,
+                "game-obj": "Spells",
+                "name": "produce flame",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 246,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -780,240 +392,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 8,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 8,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1023,7 +437,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:",
         "type": "stat_block_section"
       }
     ],
@@ -1068,6 +481,988 @@
         }
       ],
       "text": "Underworld dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "earthbind",
+          "aonid": 94,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "stinking cloud",
+          "aonid": 309,
+          "game-obj": "Spells",
+          "name": "stinking cloud",
+          "type": "link"
+        },
+        {
+          "alt": "glitterdust",
+          "aonid": 136,
+          "game-obj": "Spells",
+          "name": "glitterdust",
+          "type": "link"
+        },
+        {
+          "alt": "knock",
+          "aonid": 168,
+          "game-obj": "Spells",
+          "name": "knock",
+          "type": "link"
+        },
+        {
+          "alt": "resist energy",
+          "aonid": 256,
+          "game-obj": "Spells",
+          "name": "resist energy",
+          "type": "link"
+        },
+        {
+          "alt": "floating disk",
+          "aonid": 124,
+          "game-obj": "Spells",
+          "name": "floating disk",
+          "type": "link"
+        },
+        {
+          "alt": "magic missile",
+          "aonid": 180,
+          "game-obj": "Spells",
+          "name": "magic missile",
+          "type": "link"
+        },
+        {
+          "alt": "ray of enfeeblement",
+          "aonid": 244,
+          "game-obj": "Spells",
+          "name": "ray of enfeeblement",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "mage hand",
+          "aonid": 177,
+          "game-obj": "Spells",
+          "name": "mage hand",
+          "type": "link"
+        },
+        {
+          "alt": "produce flame",
+          "aonid": 236,
+          "game-obj": "Spells",
+          "name": "produce flame",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Young Underworld Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 83",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 83",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 83,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Prepared Arcane Spells",
+          "saving_throw": {
+            "dc": 25,
+            "subtype": "save_dc",
+            "text": "DC 25",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 94,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stinking cloud",
+                      "aonid": 309,
+                      "game-obj": "Spells",
+                      "name": "stinking cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stinking cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "glitterdust",
+                      "aonid": 136,
+                      "game-obj": "Spells",
+                      "name": "glitterdust",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "glitterdust",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "knock",
+                      "aonid": 168,
+                      "game-obj": "Spells",
+                      "name": "knock",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "knock",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resist energy",
+                      "aonid": 256,
+                      "game-obj": "Spells",
+                      "name": "resist energy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resist energy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "floating disk",
+                      "aonid": 124,
+                      "game-obj": "Spells",
+                      "name": "floating disk",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "floating disk",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "magic missile",
+                      "aonid": 180,
+                      "game-obj": "Spells",
+                      "name": "magic missile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "magic missile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ray of enfeeblement",
+                      "aonid": 244,
+                      "game-obj": "Spells",
+                      "name": "ray of enfeeblement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ray of enfeeblement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mage hand",
+                      "aonid": 177,
+                      "game-obj": "Spells",
+                      "name": "mage hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mage hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "produce flame",
+                      "aonid": 236,
+                      "game-obj": "Spells",
+                      "name": "produce flame",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "produce flame",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Prepared Arcane Spells** DC 25, attack +18; **3rd** *earthbind*, *stinking cloud*; **2nd** *glitterdust*, *knock*, *resist energy*; **1st** *floating disk*, *magic missile*, *ray of enfeeblement*; **Cantrips (3rd)** *acid splash*, *mage hand*, *produce flame*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cloudkill",
+          "aonid": 42,
+          "game-obj": "Spells",
+          "name": "cloudkill",
+          "type": "link"
+        },
+        {
+          "alt": "prying eye",
+          "aonid": 239,
+          "game-obj": "Spells",
+          "name": "prying eye",
+          "type": "link"
+        },
+        {
+          "alt": "dimension door",
+          "aonid": 69,
+          "game-obj": "Spells",
+          "name": "dimension door",
+          "type": "link"
+        },
+        {
+          "alt": "hallucinatory terrain",
+          "aonid": 145,
+          "game-obj": "Spells",
+          "name": "hallucinatory terrain",
+          "type": "link"
+        },
+        {
+          "alt": "private sanctum",
+          "aonid": 235,
+          "game-obj": "Spells",
+          "name": "private sanctum",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 289,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "mage hand",
+          "aonid": 177,
+          "game-obj": "Spells",
+          "name": "mage hand",
+          "type": "link"
+        },
+        {
+          "alt": "produce flame",
+          "aonid": 236,
+          "game-obj": "Spells",
+          "name": "produce flame",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Underworld Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 83",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 83",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 83,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Prepared Arcane Spells",
+          "notes": [
+            "As young underworld dragon"
+          ],
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cloudkill",
+                      "aonid": 42,
+                      "game-obj": "Spells",
+                      "name": "cloudkill",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cloudkill",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prying eye",
+                      "aonid": 239,
+                      "game-obj": "Spells",
+                      "name": "prying eye",
+                      "type": "link"
+                    },
+                    {
+                      "alt": "dimension door",
+                      "aonid": 69,
+                      "game-obj": "Spells",
+                      "name": "dimension door",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prying eye; 4th dimension door",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucinatory terrain",
+                      "aonid": 145,
+                      "game-obj": "Spells",
+                      "name": "hallucinatory terrain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucinatory terrain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "private sanctum",
+                      "aonid": 235,
+                      "game-obj": "Spells",
+                      "name": "private sanctum",
+                      "type": "link"
+                    },
+                    {
+                      "alt": "slow",
+                      "aonid": 289,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "private sanctum; 3rd slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mage hand",
+                      "aonid": 177,
+                      "game-obj": "Spells",
+                      "name": "mage hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mage hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "produce flame",
+                      "aonid": 236,
+                      "game-obj": "Spells",
+                      "name": "produce flame",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "produce flame",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Prepared Arcane Spells** DC 30, attack +24; As young underworld dragon, plus **5th** *cloudkill*, *prying eye*; 4th *dimension door*, *hallucinatory terrain*, *private sanctum*; 3rd *slow*; **Cantrips (5th)** *acid splash*, *mage hand*, *produce flame*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fiery body",
+          "aonid": 115,
+          "game-obj": "Spells",
+          "name": "fiery body",
+          "type": "link"
+        },
+        {
+          "alt": "power word blind",
+          "aonid": 226,
+          "game-obj": "Spells",
+          "name": "power word blind",
+          "type": "link"
+        },
+        {
+          "alt": "reverse gravity",
+          "aonid": 261,
+          "game-obj": "Spells",
+          "name": "reverse gravity",
+          "type": "link"
+        },
+        {
+          "alt": "mislead",
+          "aonid": 199,
+          "game-obj": "Spells",
+          "name": "mislead",
+          "type": "link"
+        },
+        {
+          "alt": "spellwrack",
+          "aonid": 298,
+          "game-obj": "Spells",
+          "name": "spellwrack",
+          "type": "link"
+        },
+        {
+          "alt": "true seeing",
+          "aonid": 344,
+          "game-obj": "Spells",
+          "name": "true seeing",
+          "type": "link"
+        },
+        {
+          "alt": "mind probe",
+          "aonid": 193,
+          "game-obj": "Spells",
+          "name": "mind probe",
+          "type": "link"
+        },
+        {
+          "alt": "acid splash",
+          "aonid": 3,
+          "game-obj": "Spells",
+          "name": "acid splash",
+          "type": "link"
+        },
+        {
+          "alt": "mage hand",
+          "aonid": 177,
+          "game-obj": "Spells",
+          "name": "mage hand",
+          "type": "link"
+        },
+        {
+          "alt": "produce flame",
+          "aonid": 236,
+          "game-obj": "Spells",
+          "name": "produce flame",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 246,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Underworld Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 83",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 83",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 83,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Prepared Arcane Spells",
+          "notes": [
+            "As adult underworld dragon"
+          ],
+          "saving_throw": {
+            "dc": 37,
+            "subtype": "save_dc",
+            "text": "DC 37",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fiery body",
+                      "aonid": 115,
+                      "game-obj": "Spells",
+                      "name": "fiery body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fiery body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "power word blind",
+                      "aonid": 226,
+                      "game-obj": "Spells",
+                      "name": "power word blind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "power word blind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "reverse gravity",
+                      "aonid": 261,
+                      "game-obj": "Spells",
+                      "name": "reverse gravity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "reverse gravity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mislead",
+                      "aonid": 199,
+                      "game-obj": "Spells",
+                      "name": "mislead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mislead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spellwrack",
+                      "aonid": 298,
+                      "game-obj": "Spells",
+                      "name": "spellwrack",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spellwrack",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true seeing",
+                      "aonid": 344,
+                      "game-obj": "Spells",
+                      "name": "true seeing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true seeing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mind probe",
+                      "aonid": 193,
+                      "game-obj": "Spells",
+                      "name": "mind probe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mind probe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid splash",
+                      "aonid": 3,
+                      "game-obj": "Spells",
+                      "name": "acid splash",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid splash",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mage hand",
+                      "aonid": 177,
+                      "game-obj": "Spells",
+                      "name": "mage hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mage hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "produce flame",
+                      "aonid": 236,
+                      "game-obj": "Spells",
+                      "name": "produce flame",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "produce flame",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 246,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 280,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Prepared Arcane Spells** DC 37, attack +32; As adult underworld dragon, plus **7th** *fiery body*, *power word blind*, *reverse gravity*; **6th** *mislead*, *spellwrack*, *true seeing*; **5th** *mind probe*; **Cantrips (7th)** *acid splash*, *mage hand*, *produce flame*, *read aura*, *shield*",
       "type": "section"
     },
     {
@@ -1136,6 +1531,283 @@
         }
       ],
       "text": "Five elements underpin the magical powers of imperial dragons, influencing their relationships to all things and, especially, to others of their kind. These elements interlink in two cycles. In the first cycle, each element feeds one other: wood feeds fire, fire feeds earth, earth feeds metal, metal feeds water, and water feeds wood. In the second cycle, each element counters another: wood counters earth, earth counters water, water counters fire, fire counters metal, and metal counters wood.   \n  \nEach imperial dragon represents one element and has four abilities related to the cycle. For example, the forest dragon\u2014linked to wood\u2014feeds fire, is fed by water, counters earth, and is countered by metal.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 8,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 8,
+            "game-id": "7564ef41c1e467932029913cee1f7b20",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 46,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 5,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              },
+              {
+                "edition": "legacy",
+                "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                "game-obj": "Traits",
+                "name": "Transmutation",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 637",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 637",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 637,
+                    "type": "source"
+                  }
+                ],
+                "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "Change Shape",
+          "aonid": 8,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 127,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        }
+      ],
+      "name": "Shape-Changing Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 83",
+            "aonid": 66,
+            "game-obj": "Sources",
+            "name": "Bestiary 3 pg. 83",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 83,
+          "type": "source"
+        }
+      ],
+      "text": "Imperial dragons are the most likely (and willing) of Golarion's dragons to take humanoid forms. The vast majority of them have the following ability, with the tradition trait matching the dragon's innate spells:   \n  \n**Change Shape** [#] (concentrate, polymorph, transmutation) The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage modifiers with their Strikes, but it might change the damage type their Strikes deal (typically to bludgeoning).",
       "type": "section"
     },
     {

--- a/monster_families/bestiary_3/vampire_nosferatu.json
+++ b/monster_families/bestiary_3/vampire_nosferatu.json
@@ -376,817 +376,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 145,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Nosferatu Vulnerabilities",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Plagued Coffin Restoration",
-                "subtype": "ability",
-                "text": "Unlike other undead, a nosferatu isn't destroyed at 0 HP. Instead, they disperse into an immense number of individual rats heading in every direction in an attempt to return to their coffin. If even a single rat reaches the coffin, the nosferatu can recover. A nosferatu regains their strength through resting in earth taken from the grave of a creature who died of plague. If their body rests in their earth-filled coffin for 1 hour, the nosferatu gains 1 HP, after which their fast healing begins to function normally. If the coffin doesn't contain this plagued grave dirt, they instead need to rest in their coffin for 1 day before they gain 1 HP and regain their fast healing.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "negative",
-                      "aonid": 118,
-                      "game-obj": "Traits",
-                      "name": "negative",
-                      "type": "link"
-                    },
-                    "name": "negative",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d10",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 8,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "swarm",
-                    "aonid": 239,
-                    "game-obj": "Traits",
-                    "name": "swarm",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high DC for the creature's level",
-                    "aonid": 1020,
-                    "game-obj": "Rules",
-                    "name": "high DC for the creature's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. Each enemy in the swarm's space takes 2d10 piercing damage and must attempt a basic Reflex save with a high DC for the creature's level. A creature that fails its save is exposed to plague of ancients (see below).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 8,
-                  "game-id": "7564ef41c1e467932029913cee1f7b20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 46,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 5,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    },
-                    {
-                      "edition": "legacy",
-                      "game-id": "e15261ef9d67eae23579ccf106d27c86",
-                      "game-obj": "Traits",
-                      "name": "Transmutation",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 637",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 637",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 637,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The nosferatu gives a single command to one of their thralls, which the thrall follows to the best of its ability during its next turn.",
-                "name": "Command Thrall",
-                "requirement": "One of the nosferatu's thralls is present and can hear the nosferatu",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 16,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "frequency": "three times per day",
-                "links": [
-                  {
-                    "alt": "telekinetic haul",
-                    "aonid": 332,
-                    "game-obj": "Spells",
-                    "name": "telekinetic haul",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Innate Spells",
-                "subtype": "ability",
-                "text": "The nosferatu can cast *telekinetic haul* (heightened to half their level rounded up) three times per day as a divine innate spell. They use a high DC for their level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enfeebled 2",
-                    "aonid": 13,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "doomed 1",
-                    "aonid": 9,
-                    "game-obj": "Conditions",
-                    "name": "doomed 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Plague of Ancients",
-                "onset": "1 day",
-                "saving_throw": [
-                  {
-                    "modifiers": [
-                      {
-                        "name": "use a high DC for the nosferatu's level",
-                        "subtype": "modifier",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "Fortitude (use a high DC for the nosferatu's level)",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "drained 1 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "drained 2 and enfeebled 2 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 1, drained 3, and enfeebled 3 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 4",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 2, drained 3, and enfeebled 3 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 5",
-                    "subtype": "affliction_stage",
-                    "text": "unconscious (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 6",
-                    "subtype": "affliction_stage",
-                    "text": "death",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "virulent",
-                      "aonid": 162,
-                      "game-obj": "Traits",
-                      "name": "virulent",
-                      "type": "link"
-                    },
-                    "name": "virulent",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 87,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "visual",
-                    "aonid": 163,
-                    "game-obj": "Traits",
-                    "name": "visual",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dominate",
-                "subtype": "ability",
-                "text": "The nosferatu can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses a high DC for the nosferatu's level, and a creature that succeeds is temporarily immune to that nosferatu's Dominate for 24 hours. Fully destroying the nosferatu ends the domination, but merely reducing the nosferatu to 0 HP is insufficient to break the spell.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The nosferatu sinks their fangs into the targeted creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the nosferatu regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the nosferatu, but increases the creature's drained condition value by 1. A nosferatu can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.",
-                "links": [
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Blood",
-                "requirement": "The nosferatu's last action was a successful fangs Strike",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Nosferatu')].sections[?(@.name=='Basic Nosferatu Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1204,6 +398,279 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 145,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "negative",
+                "aonid": 118,
+                "game-obj": "Traits",
+                "name": "negative",
+                "type": "link"
+              },
+              {
+                "alt": "Change Shape",
+                "aonid": 8,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "swarm",
+                "aonid": 239,
+                "game-obj": "Traits",
+                "name": "swarm",
+                "type": "link"
+              },
+              {
+                "alt": "high DC for the creature's level",
+                "aonid": 1020,
+                "game-obj": "Rules",
+                "name": "high DC for the creature's level",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 16,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic haul",
+                "aonid": 332,
+                "game-obj": "Spells",
+                "name": "telekinetic haul",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "virulent",
+                "aonid": 162,
+                "game-obj": "Traits",
+                "name": "virulent",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled 2",
+                "aonid": 13,
+                "game-obj": "Conditions",
+                "name": "enfeebled 2",
+                "type": "link"
+              },
+              {
+                "alt": "doomed 1",
+                "aonid": 9,
+                "game-obj": "Conditions",
+                "name": "doomed 1",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 87,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "Medicine",
+                "aonid": 9,
+                "game-obj": "Skills",
+                "name": "Medicine",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1213,213 +680,103 @@
         ],
         "name": "Basic Nosferatu Abilities",
         "subtype": "monster_family",
-        "text": "If the base creature becoming a nosferatu has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the nosferatu's theme.  \n  \n All nosferatus gain the following abilities.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "diseases",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "diseases",
-                    "type": "link"
-                  }
-                ],
-                "name": "Air of Sickness",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "A creature entering or starting its turn in the aura must attempt a Fortitude save with a moderate DC for the nosferatu's level. On a failure, the creature is sickened 1 and takes a \u20132 status penalty to saves made to resist diseases and remove the sickened condition for 1 hour.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "frequency": "twice per day",
-                "links": [
-                  {
-                    "alt": "vampiric exsanguination",
-                    "aonid": 353,
-                    "game-obj": "Spells",
-                    "name": "vampiric exsanguination",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Innate Spells",
-                "subtype": "ability",
-                "text": "As nosferatu, but they can also cast *vampiric exsanguination* twice per day as a divine innate spell.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The nosferatu drags the target of the Strike close and freezes its mind in terror. The target must attempt a Will save with a moderate DC for the nosferatu's level.",
-                "name": "Paralytic Fear",
-                "requirement": "The nosferatu overlord's last action was a successful claw Strike",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The target is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "immobilized",
-                    "aonid": 24,
-                    "game-obj": "Conditions",
-                    "name": "immobilized",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The target is immobilized by fear until the end of the nosferatu's next turn.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "restrained",
-                    "aonid": 33,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The target is restrained and takes a \u20132 circumstance penalty to its Fortitude DC against the nosferatu's Drink Blood ability until the end of the nosferatu's next turn.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightened 2",
-                    "aonid": 19,
-                    "game-obj": "Conditions",
-                    "name": "frightened 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, and the target is frightened 2.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Nosferatu')].sections[?(@.name=='Nosferatu Overlord Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "diseases",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "diseases",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric exsanguination",
+                "aonid": 353,
+                "game-obj": "Spells",
+                "name": "vampiric exsanguination",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "immobilized",
+                "aonid": 24,
+                "game-obj": "Conditions",
+                "name": "immobilized",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 2",
+                "aonid": 19,
+                "game-obj": "Conditions",
+                "name": "frightened 2",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1429,153 +786,61 @@
         ],
         "name": "Nosferatu Overlord Abilities",
         "subtype": "monster_family",
-        "text": "A truly primeval nosferatu can gain extraordinary powers over their foes. Creatures must have lived for millennia and be 14th level or higher to become a nosferatu overlord.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Fast Healing",
-                  "aonid": 15,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Fast Healing",
-                  "type": "link"
-                },
-                "name": "Fast Healing",
-                "subtype": "ability",
-                "text": "A nosferatu thrall gains fast healing 5 from being sustained by their master's blood.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 15,
-                  "game-id": "fe1c17e78f6d3164529bc07d7374d9c9",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Fast Healing",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with this ability regains the given number of Hit Points each round at the beginning of its turn.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mental",
-                    "aonid": 106,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Weaknesses",
-                "subtype": "ability",
-                "text": "The strain of being controlled wears on the nosferatu thrall's mind, giving them weakness 10 to mental damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "controlled",
-                    "aonid": 6,
-                    "game-obj": "Conditions",
-                    "name": "controlled",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteract",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mindbound",
-                "subtype": "ability",
-                "text": "A nosferatu master exerts a fierce hold over their thrall's mind. If any creature other than the thrall's master targets them with an effect that would give them the controlled condition, the thrall's master rolls a counteract check against it using their Dominate DC - 10 as the counteract check modifier.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The thrall throws themself in front of their master, taking half the damage of the attack (before applying any weaknesses or resistances). The thrall's master takes the remaining damage, applying any weaknesses or resistances as normal.",
-                "name": "Mortal Shield",
-                "subtype": "ability",
-                "trigger": "The thrall's master would take damage from a Strike or spell attack and is in an adjacent square",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The thrall Strides up to their Speed toward their master.",
-                "name": "Rally",
-                "subtype": "ability",
-                "trigger": "The thrall ends their turn more than 30 feet away from their master",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Nosferatu')].sections[?(@.name=='Nosferatu Thrall Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Fast Healing",
+                "aonid": 15,
+                "game-obj": "MonsterAbilities",
+                "name": "Fast Healing",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "controlled",
+                "aonid": 6,
+                "game-obj": "Conditions",
+                "name": "controlled",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1585,7 +850,6 @@
         ],
         "name": "Nosferatu Thrall Abilities",
         "subtype": "monster_family",
-        "text": "Any creature under a nosferatu's thrall gains the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -1606,6 +870,1618 @@
       ],
       "name": "Creating a Nosferatu",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "sleep",
+                  "aonid": 145,
+                  "game-obj": "Traits",
+                  "name": "sleep",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, sleep",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Nosferatu Vulnerabilities",
+              "subtype": "ability",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Plagued Coffin Restoration",
+              "subtype": "ability",
+              "text": "Unlike other undead, a nosferatu isn't destroyed at 0 HP. Instead, they disperse into an immense number of individual rats heading in every direction in an attempt to return to their coffin. If even a single rat reaches the coffin, the nosferatu can recover. A nosferatu regains their strength through resting in earth taken from the grave of a creature who died of plague. If their body rests in their earth-filled coffin for 1 hour, the nosferatu gains 1 HP, after which their fast healing begins to function normally. If the coffin doesn't contain this plagued grave dirt, they instead need to rest in their coffin for 1 day before they gain 1 HP and regain their fast healing.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "negative",
+                    "aonid": 118,
+                    "game-obj": "Traits",
+                    "name": "negative",
+                    "type": "link"
+                  },
+                  "name": "negative",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "2d10",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 8,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "swarm",
+                  "aonid": 239,
+                  "game-obj": "Traits",
+                  "name": "swarm",
+                  "type": "link"
+                },
+                {
+                  "alt": "high DC for the creature's level",
+                  "aonid": 1020,
+                  "game-obj": "Rules",
+                  "name": "high DC for the creature's level",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. Each enemy in the swarm's space takes 2d10 piercing damage and must attempt a basic Reflex save with a high DC for the creature's level. A creature that fails its save is exposed to plague of ancients (see below).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 8,
+                "game-id": "7564ef41c1e467932029913cee1f7b20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 46,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 5,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  },
+                  {
+                    "edition": "legacy",
+                    "game-id": "e15261ef9d67eae23579ccf106d27c86",
+                    "game-obj": "Traits",
+                    "name": "Transmutation",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 637",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 637",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 637,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "Effects and magic items with this trait are associated with the transmutation school of magic, typically changing something\u2019s form.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The nosferatu gives a single command to one of their thralls, which the thrall follows to the best of its ability during its next turn.",
+              "name": "Command Thrall",
+              "requirement": "One of the nosferatu's thralls is present and can hear the nosferatu",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "auditory",
+                    "aonid": 16,
+                    "game-obj": "Traits",
+                    "name": "auditory",
+                    "type": "link"
+                  },
+                  "name": "auditory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "frequency": "three times per day",
+              "links": [
+                {
+                  "alt": "telekinetic haul",
+                  "aonid": 332,
+                  "game-obj": "Spells",
+                  "name": "telekinetic haul",
+                  "type": "link"
+                }
+              ],
+              "name": "Divine Innate Spells",
+              "subtype": "ability",
+              "text": "The nosferatu can cast *telekinetic haul* (heightened to half their level rounded up) three times per day as a divine innate spell. They use a high DC for their level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "affliction",
+              "links": [
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "enfeebled 2",
+                  "aonid": 13,
+                  "game-obj": "Conditions",
+                  "name": "enfeebled 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "doomed 1",
+                  "aonid": 9,
+                  "game-obj": "Conditions",
+                  "name": "doomed 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                }
+              ],
+              "name": "Plague of Ancients",
+              "onset": "1 day",
+              "saving_throw": [
+                {
+                  "modifiers": [
+                    {
+                      "name": "use a high DC for the nosferatu's level",
+                      "subtype": "modifier",
+                      "type": "stat_block_section"
+                    }
+                  ],
+                  "save_type": "Fort",
+                  "subtype": "save_dc",
+                  "text": "Fortitude (use a high DC for the nosferatu's level)",
+                  "type": "stat_block_section"
+                }
+              ],
+              "stages": [
+                {
+                  "name": "Stage 1",
+                  "subtype": "affliction_stage",
+                  "text": "drained 1 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 2",
+                  "subtype": "affliction_stage",
+                  "text": "drained 2 and enfeebled 2 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 3",
+                  "subtype": "affliction_stage",
+                  "text": "doomed 1, drained 3, and enfeebled 3 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 4",
+                  "subtype": "affliction_stage",
+                  "text": "doomed 2, drained 3, and enfeebled 3 (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 5",
+                  "subtype": "affliction_stage",
+                  "text": "unconscious (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 6",
+                  "subtype": "affliction_stage",
+                  "text": "death",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "virulent",
+                    "aonid": 162,
+                    "game-obj": "Traits",
+                    "name": "virulent",
+                    "type": "link"
+                  },
+                  "name": "virulent",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "dominate",
+                  "aonid": 87,
+                  "game-obj": "Spells",
+                  "name": "dominate",
+                  "type": "link"
+                },
+                {
+                  "alt": "visual",
+                  "aonid": 163,
+                  "game-obj": "Traits",
+                  "name": "visual",
+                  "type": "link"
+                }
+              ],
+              "name": "Dominate",
+              "subtype": "ability",
+              "text": "The nosferatu can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses a high DC for the nosferatu's level, and a creature that succeeds is temporarily immune to that nosferatu's Dominate for 24 hours. Fully destroying the nosferatu ends the domination, but merely reducing the nosferatu to 0 HP is insufficient to break the spell.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "visual",
+                    "aonid": 163,
+                    "game-obj": "Traits",
+                    "name": "visual",
+                    "type": "link"
+                  },
+                  "name": "visual",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The nosferatu sinks their fangs into the targeted creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the nosferatu regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the nosferatu, but increases the creature's drained condition value by 1. A nosferatu can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.",
+              "links": [
+                {
+                  "alt": "Athletics",
+                  "aonid": 3,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                },
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Drink Blood",
+              "requirement": "The nosferatu's last action was a successful fangs Strike",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "human",
+              "aonid": 90,
+              "game-obj": "Traits",
+              "name": "human",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 91,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 145,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "negative",
+              "aonid": 118,
+              "game-obj": "Traits",
+              "name": "negative",
+              "type": "link"
+            },
+            {
+              "alt": "Change Shape",
+              "aonid": 8,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "swarm",
+              "aonid": 239,
+              "game-obj": "Traits",
+              "name": "swarm",
+              "type": "link"
+            },
+            {
+              "alt": "high DC for the creature's level",
+              "aonid": 1020,
+              "game-obj": "Rules",
+              "name": "high DC for the creature's level",
+              "type": "link"
+            },
+            {
+              "alt": "auditory",
+              "aonid": 16,
+              "game-obj": "Traits",
+              "name": "auditory",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "telekinetic haul",
+              "aonid": 332,
+              "game-obj": "Spells",
+              "name": "telekinetic haul",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "virulent",
+              "aonid": 162,
+              "game-obj": "Traits",
+              "name": "virulent",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "enfeebled 2",
+              "aonid": 13,
+              "game-obj": "Conditions",
+              "name": "enfeebled 2",
+              "type": "link"
+            },
+            {
+              "alt": "doomed 1",
+              "aonid": 9,
+              "game-obj": "Conditions",
+              "name": "doomed 1",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "dominate",
+              "aonid": 87,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "Medicine",
+              "aonid": 9,
+              "game-obj": "Skills",
+              "name": "Medicine",
+              "type": "link"
+            }
+          ],
+          "name": "Basic Nosferatu Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 282",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 282",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 282,
+              "type": "source"
+            }
+          ],
+          "text": "If the base creature becoming a nosferatu has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the nosferatu's theme.  \n  \n All nosferatus gain the following abilities.  \n  \n**Darkvision**  \n  \n**Negative Healing**  \n  \n**Immunities** death effects, disease, paralyzed, poison, sleep  \n  \n**Nosferatu Vulnerabilities**  \n  \n**Plagued Coffin Restoration** (divine, necromancy, negative) Unlike other undead, a nosferatu isn't destroyed at 0 HP. Instead, they disperse into an immense number of individual rats heading in every direction in an attempt to return to their coffin. If even a single rat reaches the coffin, the nosferatu can recover. A nosferatu regains their strength through resting in earth taken from the grave of a creature who died of plague. If their body rests in their earth-filled coffin for 1 hour, the nosferatu gains 1 HP, after which their fast healing begins to function normally. If the coffin doesn't contain this plagued grave dirt, they instead need to rest in their coffin for 1 day before they gain 1 HP and regain their fast healing.   \n  \n**Change Shape** [#] (concentrate, divine, polymorph, transmutation) The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. Each enemy in the swarm's space takes 2d10 piercing damage and must attempt a basic Reflex save with a high DC for the creature's level. A creature that fails its save is exposed to plague of ancients (see below).   \n  \n**Command Thrall** [-] (auditory, divine, mental) **Requirements** One of the nosferatu's thralls is present and can hear the nosferatu; **Effect** The nosferatu gives a single command to one of their thralls, which the thrall follows to the best of its ability during its next turn.   \n  \n**Divine Innate Spells** The nosferatu can cast *telekinetic haul* (heightened to half their level rounded up) three times per day as a divine innate spell. They use a high DC for their level.   \n  \n**Plague of Ancients** (disease, virulent) **Saving Throw** Fortitude (use a high DC for the nosferatu's level); **Onset** 1 day; **Stage 1** drained 1 (1 day); **Stage 2** drained 2 and enfeebled 2 (1 day); **Stage 3** doomed 1, drained 3, and enfeebled 3 (1 day); **Stage 4** doomed 2, drained 3, and enfeebled 3 (1 day); **Stage 5** unconscious (1 day); **Stage 6** death   \n  \n**Dominate** [##] (divine, enchantment, incapacitation, mental, visual) The nosferatu can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses a high DC for the nosferatu's level, and a creature that succeeds is temporarily immune to that nosferatu's Dominate for 24 hours. Fully destroying the nosferatu ends the domination, but merely reducing the nosferatu to 0 HP is insufficient to break the spell.   \n  \n**Drink Blood** [#] (divine, necromancy) **Requirements** The nosferatu's last action was a successful fangs Strike; **Effect** The nosferatu sinks their fangs into the targeted creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the nosferatu regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the nosferatu, but increases the creature's drained condition value by 1. A nosferatu can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.  \n The target creature's drained condition value decreases by 1 per week. A blood transfusion, which requires a successful DC 20 Medicine check and sufficient blood or a blood donor, reduces the drained value by 1 after 10 minutes.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "sickened 1",
+                  "aonid": 34,
+                  "game-obj": "Conditions",
+                  "name": "sickened 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "diseases",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "diseases",
+                  "type": "link"
+                }
+              ],
+              "name": "Air of Sickness",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "A creature entering or starting its turn in the aura must attempt a Fortitude save with a moderate DC for the nosferatu's level. On a failure, the creature is sickened 1 and takes a \u20132 status penalty to saves made to resist diseases and remove the sickened condition for 1 hour.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "frequency": "twice per day",
+              "links": [
+                {
+                  "alt": "vampiric exsanguination",
+                  "aonid": 353,
+                  "game-obj": "Spells",
+                  "name": "vampiric exsanguination",
+                  "type": "link"
+                }
+              ],
+              "name": "Divine Innate Spells",
+              "subtype": "ability",
+              "text": "As nosferatu, but they can also cast *vampiric exsanguination* twice per day as a divine innate spell.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The nosferatu drags the target of the Strike close and freezes its mind in terror. The target must attempt a Will save with a moderate DC for the nosferatu's level.",
+              "name": "Paralytic Fear",
+              "requirement": "The nosferatu overlord's last action was a successful claw Strike",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 60,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fear",
+                    "aonid": 68,
+                    "game-obj": "Traits",
+                    "name": "fear",
+                    "type": "link"
+                  },
+                  "name": "fear",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Critical Success",
+              "subtype": "ability",
+              "text": "The target is unaffected.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "immobilized",
+                  "aonid": 24,
+                  "game-obj": "Conditions",
+                  "name": "immobilized",
+                  "type": "link"
+                }
+              ],
+              "name": "Success",
+              "subtype": "ability",
+              "text": "The target is immobilized by fear until the end of the nosferatu's next turn.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "restrained",
+                  "aonid": 33,
+                  "game-obj": "Conditions",
+                  "name": "restrained",
+                  "type": "link"
+                }
+              ],
+              "name": "Failure",
+              "subtype": "ability",
+              "text": "The target is restrained and takes a \u20132 circumstance penalty to its Fortitude DC against the nosferatu's Drink Blood ability until the end of the nosferatu's next turn.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "frightened 2",
+                  "aonid": 19,
+                  "game-obj": "Conditions",
+                  "name": "frightened 2",
+                  "type": "link"
+                }
+              ],
+              "name": "Critical Failure",
+              "subtype": "ability",
+              "text": "As failure, and the target is frightened 2.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 1",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            },
+            {
+              "alt": "diseases",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "diseases",
+              "type": "link"
+            },
+            {
+              "alt": "vampiric exsanguination",
+              "aonid": 353,
+              "game-obj": "Spells",
+              "name": "vampiric exsanguination",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 60,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 68,
+              "game-obj": "Traits",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "immobilized",
+              "aonid": 24,
+              "game-obj": "Conditions",
+              "name": "immobilized",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 33,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "frightened 2",
+              "aonid": 19,
+              "game-obj": "Conditions",
+              "name": "frightened 2",
+              "type": "link"
+            }
+          ],
+          "name": "Nosferatu Overlord Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 282",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 282",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 282,
+              "type": "source"
+            }
+          ],
+          "text": "A truly primeval nosferatu can gain extraordinary powers over their foes. Creatures must have lived for millennia and be 14th level or higher to become a nosferatu overlord.  \n  \n**Air of Sickness** (aura) 30 feet. A creature entering or starting its turn in the aura must attempt a Fortitude save with a moderate DC for the nosferatu's level. On a failure, the creature is sickened 1 and takes a \u20132 status penalty to saves made to resist diseases and remove the sickened condition for 1 hour.  \n  \n**Divine Innate Spells** As nosferatu, but they can also cast *vampiric exsanguination* twice per day as a divine innate spell.  \n  \n**Paralytic Fear** [-] (divine, emotion, fear, incapacitation, mental) **Requirements** The nosferatu overlord's last action was a successful claw Strike; **Effect** The nosferatu drags the target of the Strike close and freezes its mind in terror. The target must attempt a Will save with a moderate DC for the nosferatu's level.   \n**Critical Success** The target is unaffected.   \n**Success** The target is immobilized by fear until the end of the nosferatu's next turn.   \n**Failure** The target is restrained and takes a \u20132 circumstance penalty to its Fortitude DC against the nosferatu's Drink Blood ability until the end of the nosferatu's next turn.   \n**Critical Failure** As failure, and the target is frightened 2.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Fast Healing",
+                "aonid": 15,
+                "game-obj": "MonsterAbilities",
+                "name": "Fast Healing",
+                "type": "link"
+              },
+              "name": "Fast Healing",
+              "subtype": "ability",
+              "text": "A nosferatu thrall gains fast healing 5 from being sustained by their master's blood.",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 15,
+                "game-id": "fe1c17e78f6d3164529bc07d7374d9c9",
+                "game-obj": "MonsterAbilities",
+                "name": "Fast Healing",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with this ability regains the given number of Hit Points each round at the beginning of its turn.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "mental",
+                  "aonid": 106,
+                  "game-obj": "Traits",
+                  "name": "mental",
+                  "type": "link"
+                }
+              ],
+              "name": "Weaknesses",
+              "subtype": "ability",
+              "text": "The strain of being controlled wears on the nosferatu thrall's mind, giving them weakness 10 to mental damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "controlled",
+                  "aonid": 6,
+                  "game-obj": "Conditions",
+                  "name": "controlled",
+                  "type": "link"
+                },
+                {
+                  "alt": "counteract",
+                  "aonid": 371,
+                  "game-obj": "Rules",
+                  "name": "counteract",
+                  "type": "link"
+                }
+              ],
+              "name": "Mindbound",
+              "subtype": "ability",
+              "text": "A nosferatu master exerts a fierce hold over their thrall's mind. If any creature other than the thrall's master targets them with an effect that would give them the controlled condition, the thrall's master rolls a counteract check against it using their Dominate DC - 10 as the counteract check modifier.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The thrall throws themself in front of their master, taking half the damage of the attack (before applying any weaknesses or resistances). The thrall's master takes the remaining damage, applying any weaknesses or resistances as normal.",
+              "name": "Mortal Shield",
+              "subtype": "ability",
+              "trigger": "The thrall's master would take damage from a Strike or spell attack and is in an adjacent square",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The thrall Strides up to their Speed toward their master.",
+              "name": "Rally",
+              "subtype": "ability",
+              "trigger": "The thrall ends their turn more than 30 feet away from their master",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Fast Healing",
+              "aonid": 15,
+              "game-obj": "MonsterAbilities",
+              "name": "Fast Healing",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "controlled",
+              "aonid": 6,
+              "game-obj": "Conditions",
+              "name": "controlled",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            }
+          ],
+          "name": "Nosferatu Thrall Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Bestiary 3 pg. 282",
+                "aonid": 66,
+                "game-obj": "Sources",
+                "name": "Bestiary 3 pg. 282",
+                "type": "link"
+              },
+              "name": "Bestiary 3",
+              "page": 282,
+              "type": "source"
+            }
+          ],
+          "text": "Any creature under a nosferatu's thrall gains the following abilities.   \n  \n**Fast Healing** A nosferatu thrall gains fast healing 5 from being sustained by their master's blood.   \n  \n**Weaknesses** The strain of being controlled wears on the nosferatu thrall's mind, giving them weakness 10 to mental damage.   \n  \n**Mindbound** (divine, enchantment) A nosferatu master exerts a fierce hold over their thrall's mind. If any creature other than the thrall's master targets them with an effect that would give them the controlled condition, the thrall's master rolls a counteract check against it using their Dominate DC - 10 as the counteract check modifier.   \n  \n**Mortal Shield** [@] **Trigger** The thrall's master would take damage from a Strike or spell attack and is in an adjacent square; **Effect** The thrall throws themself in front of their master, taking half the damage of the attack (before applying any weaknesses or resistances). The thrall's master takes the remaining damage, applying any weaknesses or resistances as normal.   \n  \n**Rally** [@] **Trigger** The thrall ends their turn more than 30 feet away from their master; **Effect** The thrall Strides up to their Speed toward their master.",
+          "type": "section"
+        },
         {
           "name": "Among the Living",
           "sources": [

--- a/monster_families/book_of_the_dead/deathless_acolyte.json
+++ b/monster_families/book_of_the_dead/deathless_acolyte.json
@@ -29,116 +29,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Alignment",
-                "subtype": "ability",
-                "text": "match the acolyte's deity",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Aura",
-                "subtype": "ability",
-                "text": "replace the acolyte's aura with an alternate one (see below) if it's more appropriate",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 5,
-                  "game-id": "ec271c184c25cc70ec0d7ff4755ca248",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "frightful presence",
-                      "aonid": 17,
-                      "game-obj": "MonsterAbilities",
-                      "name": "frightful presence",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Aura",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 342",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 342",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 342,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster's aura automatically affects everything within a specified emanation around that monster. The monster doesn't need to spend actions on the aura; rather, the aura's effects are applied at specific times, such as when a creature ends its turn in the aura or when creatures enter the aura.  \n  \n If an aura does nothing but deal damage, its entry lists only the radius, damage, and saving throw. Such auras deal this damage to a creature when the creature enters the aura and when a creature starts its turn in the aura. A creature can take damage from the aura only once per round.  \n  \n The GM might determine that a monster's aura doesn't affect its own allies. For example, a creature might be immune to a monster's frightful presence if they have been around each other for a long time.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Chastise Heretic and Denounce Heretic",
-                "subtype": "ability",
-                "text": "apply to anyone who doesn't follow the acolyte's deity",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "goblin pox",
-                    "aonid": 139,
-                    "game-obj": "Spells",
-                    "name": "goblin pox",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "false life",
-                    "aonid": 108,
-                    "game-obj": "Spells",
-                    "name": "false life",
-                    "type": "link"
-                  }
-                ],
-                "name": "Spells",
-                "subtype": "ability",
-                "text": "replace *goblin pox* and *false life* with spells from the acolyte's deity's spells",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Domain Spells",
-                "subtype": "ability",
-                "text": "use the domain spells from one of the deity's domains",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "scythe",
-                    "aonid": 39,
-                    "game-obj": "Weapons",
-                    "name": "scythe",
-                    "type": "link"
-                  }
-                ],
-                "name": "Weapon",
-                "subtype": "ability",
-                "text": "replace the scythe with the deity's favored weapon",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Deathless Deities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -148,6 +43,27 @@
                 "aonid": 19,
                 "game-obj": "Deities",
                 "name": "Urgathoa",
+                "type": "link"
+              },
+              {
+                "alt": "goblin pox",
+                "aonid": 139,
+                "game-obj": "Spells",
+                "name": "goblin pox",
+                "type": "link"
+              },
+              {
+                "alt": "false life",
+                "aonid": 108,
+                "game-obj": "Spells",
+                "name": "false life",
+                "type": "link"
+              },
+              {
+                "alt": "scythe",
+                "aonid": 39,
+                "game-obj": "Weapons",
+                "name": "scythe",
                 "type": "link"
               }
             ],
@@ -162,137 +78,11 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_category": "automatic",
-                    "ability_type": "ability",
-                    "name": "Aura",
-                    "subtype": "ability",
-                    "text": "field of bloodshed",
-                    "type": "stat_block_section",
-                    "universal_monster_ability": {
-                      "ability_type": "universal_monster_ability",
-                      "aonid": 5,
-                      "game-id": "ec271c184c25cc70ec0d7ff4755ca248",
-                      "game-obj": "MonsterAbilities",
-                      "links": [
-                        {
-                          "alt": "frightful presence",
-                          "aonid": 17,
-                          "game-obj": "MonsterAbilities",
-                          "name": "frightful presence",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Aura",
-                      "sources": [
-                        {
-                          "link": {
-                            "alt": "Bestiary pg. 342",
-                            "aonid": 2,
-                            "game-obj": "Sources",
-                            "name": "Bestiary pg. 342",
-                            "type": "link"
-                          },
-                          "name": "Bestiary",
-                          "page": 342,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "A monster's aura automatically affects everything within a specified emanation around that monster. The monster doesn't need to spend actions on the aura; rather, the aura's effects are applied at specific times, such as when a creature ends its turn in the aura or when creatures enter the aura.  \n  \n If an aura does nothing but deal damage, its entry lists only the radius, damage, and saving throw. Such auras deal this damage to a creature when the creature enters the aura and when a creature starts its turn in the aura. A creature can take damage from the aura only once per round.  \n  \n The GM might determine that a monster's aura doesn't affect its own allies. For example, a creature might be immune to a monster's frightful presence if they have been around each other for a long time.",
-                      "type": "ability"
-                    }
-                  },
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "athletic rush",
-                        "aonid": 402,
-                        "game-obj": "Spells",
-                        "name": "athletic rush",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "enduring might",
-                        "aonid": 419,
-                        "game-obj": "Spells",
-                        "name": "enduring might",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Domain Spells",
-                    "subtype": "ability",
-                    "text": "*athletic rush*, *enduring might* (hierophant only)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "goblin pox",
-                        "aonid": 139,
-                        "game-obj": "Spells",
-                        "name": "goblin pox",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "true strike",
-                        "aonid": 345,
-                        "game-obj": "Spells",
-                        "name": "true strike",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "false life",
-                        "aonid": 108,
-                        "game-obj": "Spells",
-                        "name": "false life",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "enlarge",
-                        "aonid": 102,
-                        "game-obj": "Spells",
-                        "name": "enlarge",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Spells",
-                    "subtype": "ability",
-                    "text": "replace *goblin pox* with *true strike* and *false life* with *enlarge*",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "offensive",
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "greatsword",
-                        "aonid": 24,
-                        "game-obj": "Weapons",
-                        "name": "greatsword",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "versatile P",
-                        "aonid": 200,
-                        "game-obj": "Traits",
-                        "name": "versatile P",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Weapon",
-                    "subtype": "ability",
-                    "text": "greatsword (1d12 slashing, versatile P)",
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Deathless Deities')].sections[?(@.name=='Example Deity: Gorum (CN)')].abilities",
                     "target": "$.defense.automatic_abilities"
                   }
                 ],
@@ -303,6 +93,62 @@
                     "game-obj": "Deities",
                     "name": "Gorum",
                     "type": "link"
+                  },
+                  {
+                    "alt": "athletic rush",
+                    "aonid": 402,
+                    "game-obj": "Spells",
+                    "name": "athletic rush",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "enduring might",
+                    "aonid": 419,
+                    "game-obj": "Spells",
+                    "name": "enduring might",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "goblin pox",
+                    "aonid": 139,
+                    "game-obj": "Spells",
+                    "name": "goblin pox",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "true strike",
+                    "aonid": 345,
+                    "game-obj": "Spells",
+                    "name": "true strike",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "false life",
+                    "aonid": 108,
+                    "game-obj": "Spells",
+                    "name": "false life",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "enlarge",
+                    "aonid": 102,
+                    "game-obj": "Spells",
+                    "name": "enlarge",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "greatsword",
+                    "aonid": 24,
+                    "game-obj": "Weapons",
+                    "name": "greatsword",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "versatile P",
+                    "aonid": 200,
+                    "game-obj": "Traits",
+                    "name": "versatile P",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -312,89 +158,40 @@
             ],
             "name": "Example Deity: Gorum (CN)",
             "subtype": "monster_family",
-            "text": "The mortality rate among priests of Gorum is exceptionally robust, as are the ranks of his deathless acolytes.",
             "type": "stat_block_section"
           },
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_category": "automatic",
-                    "ability_type": "ability",
-                    "name": "Field of Bloodshed",
-                    "range": {
-                      "modifiers": [
-                        {
-                          "name": "hierophant 40",
-                          "subtype": "modifier",
-                          "type": "stat_block_section"
-                        }
-                      ],
-                      "range": 20,
-                      "subtype": "range",
-                      "text": "20 feet (hierophant 40)",
-                      "type": "stat_block_section",
-                      "unit": "feet"
-                    },
-                    "saving_throw": [
-                      {
-                        "dc": 5,
-                        "save_type": "Flat Check",
-                        "subtype": "save_dc",
-                        "text": "DC 5 flat check",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "ability",
-                    "text": "All creatures within the aura gain a +2 status bonus to damage with weapon Strikes. Creatures within the aura who attempt to Cast a Spell that doesn't deal damage must succeed at a DC 5 flat check or the spell fails, and the slot or Focus Point is wasted.",
-                    "traits": [
-                      {
-                        "link": {
-                          "alt": "abjuration",
-                          "aonid": 2,
-                          "game-obj": "Traits",
-                          "name": "abjuration",
-                          "type": "link"
-                        },
-                        "name": "abjuration",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "link": {
-                          "alt": "aura",
-                          "aonid": 5,
-                          "game-obj": "MonsterAbilities",
-                          "name": "aura",
-                          "type": "link"
-                        },
-                        "name": "aura",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "link": {
-                          "alt": "divine",
-                          "aonid": 48,
-                          "game-obj": "Traits",
-                          "name": "divine",
-                          "type": "link"
-                        },
-                        "name": "divine",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Deathless Deities')].sections[?(@.name=='Alternate Aura')].abilities",
                     "target": "$.defense.automatic_abilities"
+                  }
+                ],
+                "links": [
+                  {
+                    "alt": "abjuration",
+                    "aonid": 2,
+                    "game-obj": "Traits",
+                    "name": "abjuration",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "aura",
+                    "aonid": 5,
+                    "game-obj": "MonsterAbilities",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -407,7 +204,6 @@
             "type": "stat_block_section"
           }
         ],
-        "text": "Urgathoa isn't the only deity who has deathless acolytes. Other deities of death and war have their own deathless servitors. Included below are adjustments that can be quickly applied to the above stat blocks to modify them for other deities. Make the following adjustments and see the sample deity entry below.",
         "type": "stat_block_section"
       }
     ],
@@ -415,6 +211,553 @@
   },
   "name": "Deathless Acolyte",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Alignment",
+          "subtype": "ability",
+          "text": "match the acolyte's deity",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Aura",
+          "subtype": "ability",
+          "text": "replace the acolyte's aura with an alternate one (see below) if it's more appropriate",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 5,
+            "game-id": "ec271c184c25cc70ec0d7ff4755ca248",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "frightful presence",
+                "aonid": 17,
+                "game-obj": "MonsterAbilities",
+                "name": "frightful presence",
+                "type": "link"
+              }
+            ],
+            "name": "Aura",
+            "sources": [
+              {
+                "link": {
+                  "alt": "Bestiary pg. 342",
+                  "aonid": 2,
+                  "game-obj": "Sources",
+                  "name": "Bestiary pg. 342",
+                  "type": "link"
+                },
+                "name": "Bestiary",
+                "page": 342,
+                "type": "source"
+              }
+            ],
+            "text": "A monster's aura automatically affects everything within a specified emanation around that monster. The monster doesn't need to spend actions on the aura; rather, the aura's effects are applied at specific times, such as when a creature ends its turn in the aura or when creatures enter the aura.  \n  \n If an aura does nothing but deal damage, its entry lists only the radius, damage, and saving throw. Such auras deal this damage to a creature when the creature enters the aura and when a creature starts its turn in the aura. A creature can take damage from the aura only once per round.  \n  \n The GM might determine that a monster's aura doesn't affect its own allies. For example, a creature might be immune to a monster's frightful presence if they have been around each other for a long time.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Chastise Heretic and Denounce Heretic",
+          "subtype": "ability",
+          "text": "apply to anyone who doesn't follow the acolyte's deity",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "goblin pox",
+              "aonid": 139,
+              "game-obj": "Spells",
+              "name": "goblin pox",
+              "type": "link"
+            },
+            {
+              "alt": "false life",
+              "aonid": 108,
+              "game-obj": "Spells",
+              "name": "false life",
+              "type": "link"
+            }
+          ],
+          "name": "Spells",
+          "subtype": "ability",
+          "text": "replace *goblin pox* and *false life* with spells from the acolyte's deity's spells",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Domain Spells",
+          "subtype": "ability",
+          "text": "use the domain spells from one of the deity's domains",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "scythe",
+              "aonid": 39,
+              "game-obj": "Weapons",
+              "name": "scythe",
+              "type": "link"
+            }
+          ],
+          "name": "Weapon",
+          "subtype": "ability",
+          "text": "replace the scythe with the deity's favored weapon",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Urgathoa",
+          "aonid": 19,
+          "game-obj": "Deities",
+          "name": "Urgathoa",
+          "type": "link"
+        },
+        {
+          "alt": "goblin pox",
+          "aonid": 139,
+          "game-obj": "Spells",
+          "name": "goblin pox",
+          "type": "link"
+        },
+        {
+          "alt": "false life",
+          "aonid": 108,
+          "game-obj": "Spells",
+          "name": "false life",
+          "type": "link"
+        },
+        {
+          "alt": "scythe",
+          "aonid": 39,
+          "game-obj": "Weapons",
+          "name": "scythe",
+          "type": "link"
+        }
+      ],
+      "name": "Deathless Deities",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Aura",
+              "subtype": "ability",
+              "text": "field of bloodshed",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 5,
+                "game-id": "ec271c184c25cc70ec0d7ff4755ca248",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "frightful presence",
+                    "aonid": 17,
+                    "game-obj": "MonsterAbilities",
+                    "name": "frightful presence",
+                    "type": "link"
+                  }
+                ],
+                "name": "Aura",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 342",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 342",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 342,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster's aura automatically affects everything within a specified emanation around that monster. The monster doesn't need to spend actions on the aura; rather, the aura's effects are applied at specific times, such as when a creature ends its turn in the aura or when creatures enter the aura.  \n  \n If an aura does nothing but deal damage, its entry lists only the radius, damage, and saving throw. Such auras deal this damage to a creature when the creature enters the aura and when a creature starts its turn in the aura. A creature can take damage from the aura only once per round.  \n  \n The GM might determine that a monster's aura doesn't affect its own allies. For example, a creature might be immune to a monster's frightful presence if they have been around each other for a long time.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "athletic rush",
+                  "aonid": 402,
+                  "game-obj": "Spells",
+                  "name": "athletic rush",
+                  "type": "link"
+                },
+                {
+                  "alt": "enduring might",
+                  "aonid": 419,
+                  "game-obj": "Spells",
+                  "name": "enduring might",
+                  "type": "link"
+                }
+              ],
+              "name": "Domain Spells",
+              "subtype": "ability",
+              "text": "*athletic rush*, *enduring might* (hierophant only)",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "goblin pox",
+                  "aonid": 139,
+                  "game-obj": "Spells",
+                  "name": "goblin pox",
+                  "type": "link"
+                },
+                {
+                  "alt": "true strike",
+                  "aonid": 345,
+                  "game-obj": "Spells",
+                  "name": "true strike",
+                  "type": "link"
+                },
+                {
+                  "alt": "false life",
+                  "aonid": 108,
+                  "game-obj": "Spells",
+                  "name": "false life",
+                  "type": "link"
+                },
+                {
+                  "alt": "enlarge",
+                  "aonid": 102,
+                  "game-obj": "Spells",
+                  "name": "enlarge",
+                  "type": "link"
+                }
+              ],
+              "name": "Spells",
+              "subtype": "ability",
+              "text": "replace *goblin pox* with *true strike* and *false life* with *enlarge*",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "greatsword",
+                  "aonid": 24,
+                  "game-obj": "Weapons",
+                  "name": "greatsword",
+                  "type": "link"
+                },
+                {
+                  "alt": "versatile P",
+                  "aonid": 200,
+                  "game-obj": "Traits",
+                  "name": "versatile P",
+                  "type": "link"
+                }
+              ],
+              "name": "Weapon",
+              "subtype": "ability",
+              "text": "greatsword (1d12 slashing, versatile P)",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Gorum",
+              "aonid": 7,
+              "game-obj": "Deities",
+              "name": "Gorum",
+              "type": "link"
+            },
+            {
+              "alt": "athletic rush",
+              "aonid": 402,
+              "game-obj": "Spells",
+              "name": "athletic rush",
+              "type": "link"
+            },
+            {
+              "alt": "enduring might",
+              "aonid": 419,
+              "game-obj": "Spells",
+              "name": "enduring might",
+              "type": "link"
+            },
+            {
+              "alt": "goblin pox",
+              "aonid": 139,
+              "game-obj": "Spells",
+              "name": "goblin pox",
+              "type": "link"
+            },
+            {
+              "alt": "true strike",
+              "aonid": 345,
+              "game-obj": "Spells",
+              "name": "true strike",
+              "type": "link"
+            },
+            {
+              "alt": "false life",
+              "aonid": 108,
+              "game-obj": "Spells",
+              "name": "false life",
+              "type": "link"
+            },
+            {
+              "alt": "enlarge",
+              "aonid": 102,
+              "game-obj": "Spells",
+              "name": "enlarge",
+              "type": "link"
+            },
+            {
+              "alt": "greatsword",
+              "aonid": 24,
+              "game-obj": "Weapons",
+              "name": "greatsword",
+              "type": "link"
+            },
+            {
+              "alt": "versatile P",
+              "aonid": 200,
+              "game-obj": "Traits",
+              "name": "versatile P",
+              "type": "link"
+            }
+          ],
+          "name": "Example Deity: Gorum (CN)",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 88",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 88",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "The mortality rate among priests of Gorum is exceptionally robust, as are the ranks of his deathless acolytes.  \n  \n**Aura** field of bloodshed  \n  \n**Domain Spells** *athletic rush*, *enduring might* (hierophant only)  \n  \n**Spells** replace *goblin pox* with *true strike* and *false life* with *enlarge*  \n  \n**Weapon** greatsword (1d12 slashing, versatile P)",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Field of Bloodshed",
+              "range": {
+                "modifiers": [
+                  {
+                    "name": "hierophant 40",
+                    "subtype": "modifier",
+                    "type": "stat_block_section"
+                  }
+                ],
+                "range": 20,
+                "subtype": "range",
+                "text": "20 feet (hierophant 40)",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "saving_throw": [
+                {
+                  "dc": 5,
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 5 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "All creatures within the aura gain a +2 status bonus to damage with weapon Strikes. Creatures within the aura who attempt to Cast a Spell that doesn't deal damage must succeed at a DC 5 flat check or the spell fails, and the slot or Focus Point is wasted.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "abjuration",
+                    "aonid": 2,
+                    "game-obj": "Traits",
+                    "name": "abjuration",
+                    "type": "link"
+                  },
+                  "name": "abjuration",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 5,
+                    "game-obj": "MonsterAbilities",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "abjuration",
+              "aonid": 2,
+              "game-obj": "Traits",
+              "name": "abjuration",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 5,
+              "game-obj": "MonsterAbilities",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            }
+          ],
+          "name": "Alternate Aura",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 88",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 88",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "**Field of Bloodshed** (abjuration, aura, divine) 20 feet (hierophant 40). All creatures within the aura gain a +2 status bonus to damage with weapon Strikes. Creatures within the aura who attempt to Cast a Spell that doesn't deal damage must succeed at a DC 5 flat check or the spell fails, and the slot or Focus Point is wasted.",
+          "type": "section"
+        },
+        {
+          "name": "Eternal Servitude",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 88",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 88",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "Most priests and clerics don't aspire to become a deathless acolyte. Undergoing the transformation in the first place is usually an indicator the acolyte failed to achieve an important task set by their deity in life. Being forced to complete in undeath what one failed to achieve potentially means missing one's eternal reward to devote their existence to an undefined and potentially indefinite period of servitude.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Urgathoa's",
+              "aonid": 19,
+              "game-obj": "Deities",
+              "name": "Urgathoa's",
+              "type": "link"
+            }
+          ],
+          "name": "She-Who-Feasts",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 88",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 88",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "There are some among the deathless who I must watch carefully. Urgathoa's priests are hedonistic and boringly predictable, but on at least two occasions, I have encountered the rumored handiwork of one of her deathless hierophants: a being called She-Who-Feasts. I have yet to unravel the creature's purpose, but she seems drawn to flash points of great political strife, working behind the scenes to foment discord before fading back into the margins of history.",
+          "type": "section"
+        },
+        {
+          "name": "War's Toll",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 88",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 88",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "In the wake of the War of Immortals, deathless acolytes of all types have grown in number, especially deathless zealots, as both deities and their followers fell in battle without completing divine mandates. Curiously, deathless zealots of slain deities retain their power and continue to roam, still striving to carry out missions granted to them by their lost patrons.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Book of the Dead pg. 88",
+            "aonid": 118,
+            "game-obj": "Sources",
+            "name": "Book of the Dead pg. 88",
+            "type": "link"
+          },
+          "name": "Book of the Dead",
+          "page": 88,
+          "type": "source"
+        }
+      ],
+      "text": "Urgathoa isn't the only deity who has deathless acolytes. Other deities of death and war have their own deathless servitors. Included below are adjustments that can be quickly applied to the above stat blocks to modify them for other deities. Make the following adjustments and see the sample deity entry below.  \n  \n**Alignment** match the acolyte's deity  \n  \n**Aura** replace the acolyte's aura with an alternate one (see below) if it's more appropriate  \n  \n**Chastise Heretic and Denounce Heretic** apply to anyone who doesn't follow the acolyte's deity  \n  \n**Spells** replace *goblin pox* and *false life* with spells from the acolyte's deity's spells  \n  \n**Domain Spells** use the domain spells from one of the deity's domains  \n  \n**Weapon** replace the scythe with the deity's favored weapon",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/book_of_the_dead/siabrae.json
+++ b/monster_families/book_of_the_dead/siabrae.json
@@ -117,508 +117,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Tremorsense",
-                  "aonid": 40,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Tremorsense",
-                  "type": "link"
-                },
-                "name": "Tremorsense",
-                "subtype": "ability",
-                "text": "(imprecise) 60 feet",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 40,
-                  "game-id": "0ee039798743b8879736178247f002d2",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Tremorsense",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 344",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 344",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 344,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "Tremorsense allows a monster to feel the vibrations through a solid surface caused by movement. It is an imprecise sense with a limited range (listed in the ability). Tremorsense functions only if the monster is on the same surface as the subject, and only if the subject is moving along (or burrowing through) the surface.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Rejuvenation",
-                "saving_throw": [
-                  {
-                    "dc": 10,
-                    "modifiers": [
-                      {
-                        "name": "they automatically succeed if they're standing on blighted or diseased terrain, and automatically fail if they're standing on sacred ground",
-                        "subtype": "modifier",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "save_type": "Flat Check",
-                    "subtype": "save_dc",
-                    "text": "DC 10 flat check",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "When a siabrae is destroyed, they can attempt a DC 10 flat check (they automatically succeed if they're standing on blighted or diseased terrain, and automatically fail if they're standing on sacred ground). If the flat check succeeds, the siabrae's body crumbles to dust and absorbs into the earth. After 1d10 days, the siabrae's body reforms from a mass of unworked stone large enough to create a new body; this stone is in a random location within 1d10 miles of where the siabrae was destroyed. The siabrae emerges from the stone with a peal of thunder, though without any of their gear.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, unconscious",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fire",
-                    "aonid": 72,
-                    "game-obj": "Traits",
-                    "name": "fire",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magic",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "fire 20, physical 15 (except magic bludgeoning)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Speed",
-                "subtype": "ability",
-                "text": "The siabrae gains a burrow Speed equal to their land Speed and the earth glide ability (see below).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "animal",
-                    "aonid": 9,
-                    "game-obj": "Traits",
-                    "name": "animal",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blight Mastery",
-                "subtype": "ability",
-                "text": "Any of the siabrae's spells or effects that would normally be restricted to affecting animal can also affect undead animals. Furthermore, any animals the siabrae takes the form of or summons appear to be diseased, malnourished, or even dead and rotting. (This doesn't affect their statistics.)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Burrow",
-                    "aonid": 93,
-                    "game-obj": "Actions",
-                    "name": "Burrow",
-                    "type": "link"
-                  }
-                ],
-                "name": "Earth Glide",
-                "subtype": "ability",
-                "text": "The siabrae can Burrow through any earthen matter, including rock. When it does so, the siabrae moves at its full burrow Speed, leaving no tunnels or signs of its passing.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 2",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "animal",
-                    "aonid": 9,
-                    "game-obj": "Traits",
-                    "name": "animal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fey",
-                    "aonid": 69,
-                    "game-obj": "Traits",
-                    "name": "fey",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "plant",
-                    "aonid": 125,
-                    "game-obj": "Traits",
-                    "name": "plant",
-                    "type": "link"
-                  }
-                ],
-                "name": "Miasma",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "DC equal to the siabrae's spell DC \u2013 4. A creature that enters the aura or begins its turn there becomes sickened 2 on a failure (or sickened 4 on a critical failure). An animal, fey, or plant that rolls a failure gets a critical failure instead. Regardless of the result of the saving throw, the creature is temporarily immune to the siabrae's miasma for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d6+2",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Stone Antlers",
-                "subtype": "ability",
-                "text": "The siabrae grows a pair of stony antlers or horns from its head, which give it an antler attack that deals 1d6+2 bludgeoning damage for every 3 levels and inflicts stony shards. If the siabrae wishes, they can keep these antlers while polymorphed, using the normal statistics of the stone antler attack.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "clumsy 2",
-                    "aonid": 3,
-                    "game-obj": "Conditions",
-                    "name": "clumsy 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "petrified",
-                    "aonid": 30,
-                    "game-obj": "Conditions",
-                    "name": "petrified",
-                    "type": "link"
-                  }
-                ],
-                "name": "Stony Shards",
-                "subtype": "ability",
-                "text": "Tiny shards break off the siabrae's antlers when they attack, lodging in the target's wounds and inflicting a terrible curse. A creature damaged by a siabrae's stone antlers Strike must succeed at a Fortitude save against the siabrae's spell DC \u2013 4 or become clumsy 2 for 1d4 rounds on a failure. If the creature critically fails, or fails while already clumsy 2 or greater, the creature is petrified.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 38,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "earth",
-                      "aonid": 55,
-                      "game-obj": "Traits",
-                      "name": "earth",
-                      "type": "link"
-                    },
-                    "name": "earth",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Siabrae')].sections[?(@.name=='Siabrae Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -636,6 +139,202 @@
                 "game-obj": "Traits",
                 "name": "undead",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Tremorsense",
+                "aonid": 40,
+                "game-obj": "MonsterAbilities",
+                "name": "Tremorsense",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 72,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "magic",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magic",
+                "type": "link"
+              },
+              {
+                "alt": "animal",
+                "aonid": 9,
+                "game-obj": "Traits",
+                "name": "animal",
+                "type": "link"
+              },
+              {
+                "alt": "Burrow",
+                "aonid": 93,
+                "game-obj": "Actions",
+                "name": "Burrow",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 2",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 2",
+                "type": "link"
+              },
+              {
+                "alt": "animal",
+                "aonid": 9,
+                "game-obj": "Traits",
+                "name": "animal",
+                "type": "link"
+              },
+              {
+                "alt": "fey",
+                "aonid": 69,
+                "game-obj": "Traits",
+                "name": "fey",
+                "type": "link"
+              },
+              {
+                "alt": "plant",
+                "aonid": 125,
+                "game-obj": "Traits",
+                "name": "plant",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "earth",
+                "aonid": 55,
+                "game-obj": "Traits",
+                "name": "earth",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "clumsy 2",
+                "aonid": 3,
+                "game-obj": "Conditions",
+                "name": "clumsy 2",
+                "type": "link"
+              },
+              {
+                "alt": "petrified",
+                "aonid": 30,
+                "game-obj": "Conditions",
+                "name": "petrified",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -645,7 +344,6 @@
         ],
         "name": "Siabrae Abilities",
         "subtype": "monster_family",
-        "text": "A siabrae gains the earth and undead traits and becomes evil. Siabraes lose all abilities that specifically come from being a living creature of their original kind.  \n  \n A siabrae gains the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -666,6 +364,734 @@
       ],
       "name": "Creating a Siabrae",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Tremorsense",
+                "aonid": 40,
+                "game-obj": "MonsterAbilities",
+                "name": "Tremorsense",
+                "type": "link"
+              },
+              "name": "Tremorsense",
+              "subtype": "ability",
+              "text": "(imprecise) 60 feet",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 40,
+                "game-id": "0ee039798743b8879736178247f002d2",
+                "game-obj": "MonsterAbilities",
+                "name": "Tremorsense",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 344",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 344",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 344,
+                    "type": "source"
+                  }
+                ],
+                "text": "Tremorsense allows a monster to feel the vibrations through a solid surface caused by movement. It is an imprecise sense with a limited range (listed in the ability). Tremorsense functions only if the monster is on the same surface as the subject, and only if the subject is moving along (or burrowing through) the surface.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Rejuvenation",
+              "saving_throw": [
+                {
+                  "dc": 10,
+                  "modifiers": [
+                    {
+                      "name": "they automatically succeed if they're standing on blighted or diseased terrain, and automatically fail if they're standing on sacred ground",
+                      "subtype": "modifier",
+                      "type": "stat_block_section"
+                    }
+                  ],
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 10 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "When a siabrae is destroyed, they can attempt a DC 10 flat check (they automatically succeed if they're standing on blighted or diseased terrain, and automatically fail if they're standing on sacred ground). If the flat check succeeds, the siabrae's body crumbles to dust and absorbs into the earth. After 1d10 days, the siabrae's body reforms from a mass of unworked stone large enough to create a new body; this stone is in a random location within 1d10 miles of where the siabrae was destroyed. The siabrae emerges from the stone with a peal of thunder, though without any of their gear.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, unconscious",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "fire",
+                  "aonid": 72,
+                  "game-obj": "Traits",
+                  "name": "fire",
+                  "type": "link"
+                },
+                {
+                  "alt": "magic",
+                  "aonid": 103,
+                  "game-obj": "Traits",
+                  "name": "magic",
+                  "type": "link"
+                }
+              ],
+              "name": "Resistances",
+              "subtype": "ability",
+              "text": "fire 20, physical 15 (except magic bludgeoning)",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Speed",
+              "subtype": "ability",
+              "text": "The siabrae gains a burrow Speed equal to their land Speed and the earth glide ability (see below).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "animal",
+                  "aonid": 9,
+                  "game-obj": "Traits",
+                  "name": "animal",
+                  "type": "link"
+                }
+              ],
+              "name": "Blight Mastery",
+              "subtype": "ability",
+              "text": "Any of the siabrae's spells or effects that would normally be restricted to affecting animal can also affect undead animals. Furthermore, any animals the siabrae takes the form of or summons appear to be diseased, malnourished, or even dead and rotting. (This doesn't affect their statistics.)",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Burrow",
+                  "aonid": 93,
+                  "game-obj": "Actions",
+                  "name": "Burrow",
+                  "type": "link"
+                }
+              ],
+              "name": "Earth Glide",
+              "subtype": "ability",
+              "text": "The siabrae can Burrow through any earthen matter, including rock. When it does so, the siabrae moves at its full burrow Speed, leaving no tunnels or signs of its passing.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "sickened 2",
+                  "aonid": 34,
+                  "game-obj": "Conditions",
+                  "name": "sickened 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "animal",
+                  "aonid": 9,
+                  "game-obj": "Traits",
+                  "name": "animal",
+                  "type": "link"
+                },
+                {
+                  "alt": "fey",
+                  "aonid": 69,
+                  "game-obj": "Traits",
+                  "name": "fey",
+                  "type": "link"
+                },
+                {
+                  "alt": "plant",
+                  "aonid": 125,
+                  "game-obj": "Traits",
+                  "name": "plant",
+                  "type": "link"
+                }
+              ],
+              "name": "Miasma",
+              "range": {
+                "range": 20,
+                "subtype": "range",
+                "text": "20 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "DC equal to the siabrae's spell DC \u2013 4. A creature that enters the aura or begins its turn there becomes sickened 2 on a failure (or sickened 4 on a critical failure). An animal, fey, or plant that rolls a failure gets a critical failure instead. Regardless of the result of the saving throw, the creature is temporarily immune to the siabrae's miasma for 1 minute.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "bludgeoning",
+                  "formula": "1d6+2",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Stone Antlers",
+              "subtype": "ability",
+              "text": "The siabrae grows a pair of stony antlers or horns from its head, which give it an antler attack that deals 1d6+2 bludgeoning damage for every 3 levels and inflicts stony shards. If the siabrae wishes, they can keep these antlers while polymorphed, using the normal statistics of the stone antler attack.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "clumsy 2",
+                  "aonid": 3,
+                  "game-obj": "Conditions",
+                  "name": "clumsy 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "petrified",
+                  "aonid": 30,
+                  "game-obj": "Conditions",
+                  "name": "petrified",
+                  "type": "link"
+                }
+              ],
+              "name": "Stony Shards",
+              "subtype": "ability",
+              "text": "Tiny shards break off the siabrae's antlers when they attack, lodging in the target's wounds and inflicting a terrible curse. A creature damaged by a siabrae's stone antlers Strike must succeed at a Fortitude save against the siabrae's spell DC \u2013 4 or become clumsy 2 for 1d4 rounds on a failure. If the creature critically fails, or fails while already clumsy 2 or greater, the creature is petrified.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "curse",
+                    "aonid": 38,
+                    "game-obj": "Traits",
+                    "name": "curse",
+                    "type": "link"
+                  },
+                  "name": "curse",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "earth",
+                    "aonid": 55,
+                    "game-obj": "Traits",
+                    "name": "earth",
+                    "type": "link"
+                  },
+                  "name": "earth",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "earth",
+              "aonid": 10,
+              "game-obj": "Domains",
+              "name": "earth",
+              "type": "link"
+            },
+            {
+              "alt": "undead",
+              "aonid": 160,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Tremorsense",
+              "aonid": 40,
+              "game-obj": "MonsterAbilities",
+              "name": "Tremorsense",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "fire",
+              "aonid": 72,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "magic",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magic",
+              "type": "link"
+            },
+            {
+              "alt": "animal",
+              "aonid": 9,
+              "game-obj": "Traits",
+              "name": "animal",
+              "type": "link"
+            },
+            {
+              "alt": "Burrow",
+              "aonid": 93,
+              "game-obj": "Actions",
+              "name": "Burrow",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 2",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 2",
+              "type": "link"
+            },
+            {
+              "alt": "animal",
+              "aonid": 9,
+              "game-obj": "Traits",
+              "name": "animal",
+              "type": "link"
+            },
+            {
+              "alt": "fey",
+              "aonid": 69,
+              "game-obj": "Traits",
+              "name": "fey",
+              "type": "link"
+            },
+            {
+              "alt": "plant",
+              "aonid": 125,
+              "game-obj": "Traits",
+              "name": "plant",
+              "type": "link"
+            },
+            {
+              "alt": "curse",
+              "aonid": 38,
+              "game-obj": "Traits",
+              "name": "curse",
+              "type": "link"
+            },
+            {
+              "alt": "earth",
+              "aonid": 55,
+              "game-obj": "Traits",
+              "name": "earth",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "clumsy 2",
+              "aonid": 3,
+              "game-obj": "Conditions",
+              "name": "clumsy 2",
+              "type": "link"
+            },
+            {
+              "alt": "petrified",
+              "aonid": 30,
+              "game-obj": "Conditions",
+              "name": "petrified",
+              "type": "link"
+            }
+          ],
+          "name": "Siabrae Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 144",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 144",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 144,
+              "type": "source"
+            }
+          ],
+          "text": "A siabrae gains the earth and undead traits and becomes evil. Siabraes lose all abilities that specifically come from being a living creature of their original kind.  \n  \n A siabrae gains the following abilities.  \n  \n**Darkvision**  \n**Tremorsense** (imprecise) 60 feet  \n**Negative Healing**  \n**Rejuvenation** (primal, necromancy) When a siabrae is destroyed, they can attempt a DC 10 flat check (they automatically succeed if they're standing on blighted or diseased terrain, and automatically fail if they're standing on sacred ground). If the flat check succeeds, the siabrae's body crumbles to dust and absorbs into the earth. After 1d10 days, the siabrae's body reforms from a mass of unworked stone large enough to create a new body; this stone is in a random location within 1d10 miles of where the siabrae was destroyed. The siabrae emerges from the stone with a peal of thunder, though without any of their gear.  \n**Immunities** death effects, disease, paralyzed, poison, unconscious  \n**Resistances** fire 20, physical 15 (except magic bludgeoning)  \n**Speed** The siabrae gains a burrow Speed equal to their land Speed and the earth glide ability (see below).  \n**Blight Mastery** Any of the siabrae's spells or effects that would normally be restricted to affecting animal can also affect undead animals. Furthermore, any animals the siabrae takes the form of or summons appear to be diseased, malnourished, or even dead and rotting. (This doesn't affect their statistics.)  \n**Earth Glide** The siabrae can Burrow through any earthen matter, including rock. When it does so, the siabrae moves at its full burrow Speed, leaving no tunnels or signs of its passing.  \n**Miasma** (aura, disease, primal) 20 feet. DC equal to the siabrae's spell DC \u2013 4. A creature that enters the aura or begins its turn there becomes sickened 2 on a failure (or sickened 4 on a critical failure). An animal, fey, or plant that rolls a failure gets a critical failure instead. Regardless of the result of the saving throw, the creature is temporarily immune to the siabrae's miasma for 1 minute.  \n**Stone Antlers** The siabrae grows a pair of stony antlers or horns from its head, which give it an antler attack that deals 1d6+2 bludgeoning damage for every 3 levels and inflicts stony shards. If the siabrae wishes, they can keep these antlers while polymorphed, using the normal statistics of the stone antler attack.  \n**Stony Shards** (curse, earth, incapacitation, necromancy, primal) Tiny shards break off the siabrae's antlers when they attack, lodging in the target's wounds and inflicting a terrible curse. A creature damaged by a siabrae's stone antlers Strike must succeed at a Fortitude save against the siabrae's spell DC \u2013 4 or become clumsy 2 for 1d4 rounds on a failure. If the creature critically fails, or fails while already clumsy 2 or greater, the creature is petrified.",
+          "type": "section"
+        },
         {
           "links": [
             {

--- a/monster_families/book_of_the_dead/vampire_jiang-shi.json
+++ b/monster_families/book_of_the_dead/vampire_jiang-shi.json
@@ -322,454 +322,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "precise",
-                    "aonid": 411,
-                    "game-obj": "Rules",
-                    "name": "precise",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Drowning and Suffocation",
-                    "aonid": 468,
-                    "game-obj": "Rules",
-                    "name": "Drowning and Suffocation",
-                    "type": "link"
-                  }
-                ],
-                "name": "Breathsense",
-                "subtype": "ability",
-                "text": "60 feet (precise). A jiang-shi can't perceive living creatures beyond 5 feet except with their breathsense. A living creature within the listed range who holds its breath is invisible to the jiang-shi for as long as it hold its breath. To hold its breath in this way, a creature must have one hand free to fully plug its nose or cover its mouth. (Refer to Drowning and Suffocation for the full rules on holding breath.)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 145,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "prone",
-                    "aonid": 31,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, sleep, prone",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "darkwood",
-                    "aonid": 273,
-                    "game-obj": "Equipment",
-                    "name": "darkwood",
-                    "type": "link"
-                  }
-                ],
-                "name": "One More Breath",
-                "subtype": "ability",
-                "text": "Unlike other undead, a jiang-shi isn't destroyed at 0 HP. Instead, they fall unconscious and awaken in 1 minute with 1 Hit Point. Scattering at least 1 Bulk of glutinous rice or hen eggs on an unconscious jiang-shi destroys them permanently. If the jiang-shi was reduced to 0 HP by an attack from a weapon made of darkwood, they're destroyed immediately",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "negative",
-                      "aonid": 118,
-                      "game-obj": "Traits",
-                      "name": "negative",
-                      "type": "link"
-                    },
-                    "name": "negative",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Jiang-shi Vulnerabilities",
-                "subtype": "ability",
-                "text": "All jiang-shi possess the following vulnerabilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Steal",
-                    "aonid": 68,
-                    "game-obj": "Actions",
-                    "name": "Steal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fast healing",
-                    "aonid": 15,
-                    "game-obj": "MonsterAbilities",
-                    "name": "fast healing",
-                    "type": "link"
-                  }
-                ],
-                "name": "Warped Fulu",
-                "subtype": "ability",
-                "text": "The jiang-shi has corrupted the fulu attached to their brow. The jiang-shi is immune to spells cast from a magic item without expending a spell slot, such as from a scroll or wand. A creature can Steal a jiang-shi's fulu to remove it, rolling against the jiang-shi's Perception DC. This immediately ends the jiang-shi's immunity to these effects. If a creature then destroys a jiang-shi's removed fulu with an Interact action, the jiang-shi also loses their fast healing ability. A jiang-shi can create a replacement fulu by spending 1 uninterrupted hour inscribing a strip of paper (or similar) with a writing instrument.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "prone",
-                    "aonid": 31,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Drop Prone",
-                    "aonid": 78,
-                    "game-obj": "Actions",
-                    "name": "Drop Prone",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Leap",
-                    "aonid": 81,
-                    "game-obj": "Actions",
-                    "name": "Leap",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "move",
-                    "aonid": 114,
-                    "game-obj": "Traits",
-                    "name": "move",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Attacks of Opportunity",
-                    "aonid": 8,
-                    "game-obj": "Actions",
-                    "name": "Attacks of Opportunity",
-                    "type": "link"
-                  }
-                ],
-                "name": "Rigor Mortis",
-                "subtype": "ability",
-                "text": "The jiang-shi ignores difficult terrain and effects that would render it prone. A jiang-shi can't take the Drop Prone action. When a jiang-shi Leap, it doesn't trigger reactions that are normally triggered by move actions, such as Attacks of Opportunity.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Strike Damage",
-                    "aonid": 1018,
-                    "game-obj": "Rules",
-                    "name": "Strike Damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the base creature had hands, its fingernails thicken and grow to terrible proportions, granting it an unarmed claw Strike that deals slashing damage, has the agile trait, and can Grab. Use the moderate damage for the creature's level on the Strike Damage table.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The jiang-shi drains the victim's life energy, or qi, through their breath. This requires an Athletics check against the  victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the jiang-shi regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Draining qi from a creature that's already drained doesn't restore any HP to the jiang-shi but increases the victim's drained condition value by 1. If the victim has the ability to cast ki spells, it can spend 1 Focus Point to avoid becoming drained. This protects it only from the current attack, not from subsequent attempts to Drain Qi.",
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 20,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 33,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drain Qi",
-                "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the jiang-shi's reach",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Jiang-Shi')].sections[?(@.name=='Basic Jiang-Shi Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -787,6 +344,237 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "precise",
+                "aonid": 411,
+                "game-obj": "Rules",
+                "name": "precise",
+                "type": "link"
+              },
+              {
+                "alt": "Drowning and Suffocation",
+                "aonid": 468,
+                "game-obj": "Rules",
+                "name": "Drowning and Suffocation",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 145,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "prone",
+                "aonid": 31,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "negative",
+                "aonid": 118,
+                "game-obj": "Traits",
+                "name": "negative",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "darkwood",
+                "aonid": 273,
+                "game-obj": "Equipment",
+                "name": "darkwood",
+                "type": "link"
+              },
+              {
+                "alt": "Steal",
+                "aonid": 68,
+                "game-obj": "Actions",
+                "name": "Steal",
+                "type": "link"
+              },
+              {
+                "alt": "fast healing",
+                "aonid": 15,
+                "game-obj": "MonsterAbilities",
+                "name": "fast healing",
+                "type": "link"
+              },
+              {
+                "alt": "prone",
+                "aonid": 31,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "Drop Prone",
+                "aonid": 78,
+                "game-obj": "Actions",
+                "name": "Drop Prone",
+                "type": "link"
+              },
+              {
+                "alt": "Leap",
+                "aonid": 81,
+                "game-obj": "Actions",
+                "name": "Leap",
+                "type": "link"
+              },
+              {
+                "alt": "move",
+                "aonid": 114,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
+              },
+              {
+                "alt": "Attacks of Opportunity",
+                "aonid": 8,
+                "game-obj": "Actions",
+                "name": "Attacks of Opportunity",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "Strike Damage",
+                "aonid": 1018,
+                "game-obj": "Rules",
+                "name": "Strike Damage",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -796,121 +584,68 @@
         ],
         "name": "Basic Jiang-Shi Abilities",
         "subtype": "monster_family",
-        "text": "If the base creature becoming a jiang-shi has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the jiang-shi's theme. All jiang-shi gain the following abilities.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "darkwood",
-                    "aonid": 273,
-                    "game-obj": "Equipment",
-                    "name": "darkwood",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "The jiang-shi resists all physical damage (except magical darkwood).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "darkvision",
-                    "aonid": 12,
-                    "game-obj": "MonsterAbilities",
-                    "name": "darkvision",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Drop Prone",
-                    "aonid": 78,
-                    "game-obj": "Actions",
-                    "name": "Drop Prone",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dark Enlightenment",
-                "subtype": "ability",
-                "text": "The jiang-shi is no longer limited to seeing living creatures with only their breathsense, and they no longer have the Revulsion vulnerability. They can perceive living creatures normally with either darkvision or breathsense, and they can take the Drop Prone action.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Leaps",
-                    "aonid": 81,
-                    "game-obj": "Actions",
-                    "name": "Leaps",
-                    "type": "link"
-                  }
-                ],
-                "name": "Distant Steps",
-                "subtype": "ability",
-                "text": "When the jiang-shi Leaps, they can add 10 feet to the horizontal and/or vertical distance they move without affecting the Leap DC. The jiang-shi can stand and walk on water and other solid or liquid surfaces that wouldn't normally support their weight.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "quickened",
-                    "aonid": 32,
-                    "game-obj": "Conditions",
-                    "name": "quickened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Tumult of the Blood",
-                "subtype": "ability",
-                "text": "The third time a jiang-shi successfully Drains Qi within a single minute, they become quickened for 1 minute. They can use their extra action only to Strike or Stride.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Jiang-Shi')].sections[?(@.name=='Jiang-Shi Minister Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "darkwood",
+                "aonid": 273,
+                "game-obj": "Equipment",
+                "name": "darkwood",
+                "type": "link"
+              },
+              {
+                "alt": "darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Drop Prone",
+                "aonid": 78,
+                "game-obj": "Actions",
+                "name": "Drop Prone",
+                "type": "link"
+              },
+              {
+                "alt": "Leaps",
+                "aonid": 81,
+                "game-obj": "Actions",
+                "name": "Leaps",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "quickened",
+                "aonid": 32,
+                "game-obj": "Conditions",
+                "name": "quickened",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -920,7 +655,6 @@
         ],
         "name": "Jiang-Shi Minister Abilities",
         "subtype": "monster_family",
-        "text": "Those rare jiang-shi who have devoured at least a thousand victims' qi have shed many of their frailties and become able to create jiang-shi from their slain victims. These imperious undead address themselves as \u201cministers\u201d or by other grandiose titles, and they mock lesser jiang-shi as mere \u201cprovincials.\u201d  \n  \n Ministers gain additional jiang-shi abilities, as detailed below. A creature below level 13 is not significant enough to become a minister\u2014you should instead simply make such a creature into a regular jiang-shi or rebuild the creature so that it's at least level 13 before becoming a minister.",
         "type": "stat_block_section"
       }
     ],
@@ -932,6 +666,888 @@
     {
       "name": "Creating a Jiang-Shi",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "precise",
+                  "aonid": 411,
+                  "game-obj": "Rules",
+                  "name": "precise",
+                  "type": "link"
+                },
+                {
+                  "alt": "Drowning and Suffocation",
+                  "aonid": 468,
+                  "game-obj": "Rules",
+                  "name": "Drowning and Suffocation",
+                  "type": "link"
+                }
+              ],
+              "name": "Breathsense",
+              "subtype": "ability",
+              "text": "60 feet (precise). A jiang-shi can't perceive living creatures beyond 5 feet except with their breathsense. A living creature within the listed range who holds its breath is invisible to the jiang-shi for as long as it hold its breath. To hold its breath in this way, a creature must have one hand free to fully plug its nose or cover its mouth. (Refer to Drowning and Suffocation for the full rules on holding breath.)",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "sleep",
+                  "aonid": 145,
+                  "game-obj": "Traits",
+                  "name": "sleep",
+                  "type": "link"
+                },
+                {
+                  "alt": "prone",
+                  "aonid": 31,
+                  "game-obj": "Conditions",
+                  "name": "prone",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, sleep, prone",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                },
+                {
+                  "alt": "darkwood",
+                  "aonid": 273,
+                  "game-obj": "Equipment",
+                  "name": "darkwood",
+                  "type": "link"
+                }
+              ],
+              "name": "One More Breath",
+              "subtype": "ability",
+              "text": "Unlike other undead, a jiang-shi isn't destroyed at 0 HP. Instead, they fall unconscious and awaken in 1 minute with 1 Hit Point. Scattering at least 1 Bulk of glutinous rice or hen eggs on an unconscious jiang-shi destroys them permanently. If the jiang-shi was reduced to 0 HP by an attack from a weapon made of darkwood, they're destroyed immediately",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "negative",
+                    "aonid": 118,
+                    "game-obj": "Traits",
+                    "name": "negative",
+                    "type": "link"
+                  },
+                  "name": "negative",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Jiang-shi Vulnerabilities",
+              "subtype": "ability",
+              "text": "All jiang-shi possess the following vulnerabilities.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Steal",
+                  "aonid": 68,
+                  "game-obj": "Actions",
+                  "name": "Steal",
+                  "type": "link"
+                },
+                {
+                  "alt": "fast healing",
+                  "aonid": 15,
+                  "game-obj": "MonsterAbilities",
+                  "name": "fast healing",
+                  "type": "link"
+                }
+              ],
+              "name": "Warped Fulu",
+              "subtype": "ability",
+              "text": "The jiang-shi has corrupted the fulu attached to their brow. The jiang-shi is immune to spells cast from a magic item without expending a spell slot, such as from a scroll or wand. A creature can Steal a jiang-shi's fulu to remove it, rolling against the jiang-shi's Perception DC. This immediately ends the jiang-shi's immunity to these effects. If a creature then destroys a jiang-shi's removed fulu with an Interact action, the jiang-shi also loses their fast healing ability. A jiang-shi can create a replacement fulu by spending 1 uninterrupted hour inscribing a strip of paper (or similar) with a writing instrument.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "prone",
+                  "aonid": 31,
+                  "game-obj": "Conditions",
+                  "name": "prone",
+                  "type": "link"
+                },
+                {
+                  "alt": "Drop Prone",
+                  "aonid": 78,
+                  "game-obj": "Actions",
+                  "name": "Drop Prone",
+                  "type": "link"
+                },
+                {
+                  "alt": "Leap",
+                  "aonid": 81,
+                  "game-obj": "Actions",
+                  "name": "Leap",
+                  "type": "link"
+                },
+                {
+                  "alt": "move",
+                  "aonid": 114,
+                  "game-obj": "Traits",
+                  "name": "move",
+                  "type": "link"
+                },
+                {
+                  "alt": "Attacks of Opportunity",
+                  "aonid": 8,
+                  "game-obj": "Actions",
+                  "name": "Attacks of Opportunity",
+                  "type": "link"
+                }
+              ],
+              "name": "Rigor Mortis",
+              "subtype": "ability",
+              "text": "The jiang-shi ignores difficult terrain and effects that would render it prone. A jiang-shi can't take the Drop Prone action. When a jiang-shi Leap, it doesn't trigger reactions that are normally triggered by move actions, such as Attacks of Opportunity.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 170,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                },
+                {
+                  "alt": "Grab",
+                  "aonid": 18,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Grab",
+                  "type": "link"
+                },
+                {
+                  "alt": "Strike Damage",
+                  "aonid": 1018,
+                  "game-obj": "Rules",
+                  "name": "Strike Damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Claws",
+              "subtype": "ability",
+              "text": "If the base creature had hands, its fingernails thicken and grow to terrible proportions, granting it an unarmed claw Strike that deals slashing damage, has the agile trait, and can Grab. Use the moderate damage for the creature's level on the Strike Damage table.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The jiang-shi drains the victim's life energy, or qi, through their breath. This requires an Athletics check against the  victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the jiang-shi regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Draining qi from a creature that's already drained doesn't restore any HP to the jiang-shi but increases the victim's drained condition value by 1. If the victim has the ability to cast ki spells, it can spend 1 Focus Point to avoid becoming drained. This protects it only from the current attack, not from subsequent attempts to Drain Qi.",
+              "links": [
+                {
+                  "alt": "grabbed",
+                  "aonid": 20,
+                  "game-obj": "Conditions",
+                  "name": "grabbed",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "restrained",
+                  "aonid": 33,
+                  "game-obj": "Conditions",
+                  "name": "restrained",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                },
+                {
+                  "alt": "Athletics",
+                  "aonid": 3,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                },
+                {
+                  "alt": "drained 1",
+                  "aonid": 10,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Drain Qi",
+              "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the jiang-shi's reach",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "human",
+              "aonid": 90,
+              "game-obj": "Traits",
+              "name": "human",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 91,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "precise",
+              "aonid": 411,
+              "game-obj": "Rules",
+              "name": "precise",
+              "type": "link"
+            },
+            {
+              "alt": "Drowning and Suffocation",
+              "aonid": 468,
+              "game-obj": "Rules",
+              "name": "Drowning and Suffocation",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 145,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            },
+            {
+              "alt": "prone",
+              "aonid": 31,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "negative",
+              "aonid": 118,
+              "game-obj": "Traits",
+              "name": "negative",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "darkwood",
+              "aonid": 273,
+              "game-obj": "Equipment",
+              "name": "darkwood",
+              "type": "link"
+            },
+            {
+              "alt": "Steal",
+              "aonid": 68,
+              "game-obj": "Actions",
+              "name": "Steal",
+              "type": "link"
+            },
+            {
+              "alt": "fast healing",
+              "aonid": 15,
+              "game-obj": "MonsterAbilities",
+              "name": "fast healing",
+              "type": "link"
+            },
+            {
+              "alt": "prone",
+              "aonid": 31,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            },
+            {
+              "alt": "Drop Prone",
+              "aonid": 78,
+              "game-obj": "Actions",
+              "name": "Drop Prone",
+              "type": "link"
+            },
+            {
+              "alt": "Leap",
+              "aonid": 81,
+              "game-obj": "Actions",
+              "name": "Leap",
+              "type": "link"
+            },
+            {
+              "alt": "move",
+              "aonid": 114,
+              "game-obj": "Traits",
+              "name": "move",
+              "type": "link"
+            },
+            {
+              "alt": "Attacks of Opportunity",
+              "aonid": 8,
+              "game-obj": "Actions",
+              "name": "Attacks of Opportunity",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            },
+            {
+              "alt": "Strike Damage",
+              "aonid": 1018,
+              "game-obj": "Rules",
+              "name": "Strike Damage",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "grabbed",
+              "aonid": 20,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 33,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Basic Jiang-Shi Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 157",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 157",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 157,
+              "type": "source"
+            }
+          ],
+          "text": "If the base creature becoming a jiang-shi has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the jiang-shi's theme. All jiang-shi gain the following abilities.   \n  \n**Darkvision**   \n  \n**Breathsense** 60 feet (precise). A jiang-shi can't perceive living creatures beyond 5 feet except with their breathsense. A living creature within the listed range who holds its breath is invisible to the jiang-shi for as long as it hold its breath. To hold its breath in this way, a creature must have one hand free to fully plug its nose or cover its mouth. (Refer to Drowning and Suffocation for the full rules on holding breath.)   \n  \n**Negative Healing**   \n  \n**Immunities** death effects, disease, paralyzed, poison, sleep, prone   \n  \n**One More Breath** (divine, necromancy, negative); Unlike other undead, a jiang-shi isn't destroyed at 0 HP. Instead, they fall unconscious and awaken in 1 minute with 1 Hit Point. Scattering at least 1 Bulk of glutinous rice or hen eggs on an unconscious jiang-shi destroys them permanently. If the jiang-shi was reduced to 0 HP by an attack from a weapon made of darkwood, they're destroyed immediately   \n  \n**Jiang-shi Vulnerabilities** All jiang-shi possess the following vulnerabilities.**Warped Fulu** The jiang-shi has corrupted the fulu attached to their brow. The jiang-shi is immune to spells cast from a magic item without expending a spell slot, such as from a scroll or wand. A creature can Steal a jiang-shi's fulu to remove it, rolling against the jiang-shi's Perception DC. This immediately ends the jiang-shi's immunity to these effects. If a creature then destroys a jiang-shi's removed fulu with an Interact action, the jiang-shi also loses their fast healing ability. A jiang-shi can create a replacement fulu by spending 1 uninterrupted hour inscribing a strip of paper (or similar) with a writing instrument.   \n  \n**Rigor Mortis** The jiang-shi ignores difficult terrain and effects that would render it prone. A jiang-shi can't take the Drop Prone action. When a jiang-shi Leap, it doesn't trigger reactions that are normally triggered by move actions, such as Attacks of Opportunity.   \n  \n**Claws** If the base creature had hands, its fingernails thicken and grow to terrible proportions, granting it an unarmed claw Strike that deals slashing damage, has the agile trait, and can Grab. Use the moderate damage for the creature's level on the Strike Damage table.   \n  \n**Drain Qi** [#] (divine, necromancy) **Requirement** A grabbed, paralyzed, restrained, unconscious, or willing creature is within the jiang-shi's reach; **Effect** The jiang-shi drains the victim's life energy, or qi, through their breath. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the jiang-shi regains HP equal to 10% of its maximum HP, gaining any excess HP as temporary Hit Points. Draining qi from a creature that's already drained doesn't restore any HP to the jiang-shi but increases the victim's drained condition value by 1. If the victim has the ability to cast ki spells, it can spend 1 Focus Point to avoid becoming drained. This protects it only from the current attack, not from subsequent attempts to Drain Qi.  \n A victim's drained condition value decreases by 1 every week. If the creature restricts their diet to glutinous rice for at least 1 day and spends 10 minutes dancing, jogging, or otherwise engaging in vigorous physical activity by succeeding at a DC 25 Athletics check, it reduces its drained condition by 1.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "darkwood",
+                  "aonid": 273,
+                  "game-obj": "Equipment",
+                  "name": "darkwood",
+                  "type": "link"
+                }
+              ],
+              "name": "Resistances",
+              "subtype": "ability",
+              "text": "The jiang-shi resists all physical damage (except magical darkwood).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "darkvision",
+                  "aonid": 12,
+                  "game-obj": "MonsterAbilities",
+                  "name": "darkvision",
+                  "type": "link"
+                },
+                {
+                  "alt": "Drop Prone",
+                  "aonid": 78,
+                  "game-obj": "Actions",
+                  "name": "Drop Prone",
+                  "type": "link"
+                }
+              ],
+              "name": "Dark Enlightenment",
+              "subtype": "ability",
+              "text": "The jiang-shi is no longer limited to seeing living creatures with only their breathsense, and they no longer have the Revulsion vulnerability. They can perceive living creatures normally with either darkvision or breathsense, and they can take the Drop Prone action.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Leaps",
+                  "aonid": 81,
+                  "game-obj": "Actions",
+                  "name": "Leaps",
+                  "type": "link"
+                }
+              ],
+              "name": "Distant Steps",
+              "subtype": "ability",
+              "text": "When the jiang-shi Leaps, they can add 10 feet to the horizontal and/or vertical distance they move without affecting the Leap DC. The jiang-shi can stand and walk on water and other solid or liquid surfaces that wouldn't normally support their weight.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "quickened",
+                  "aonid": 32,
+                  "game-obj": "Conditions",
+                  "name": "quickened",
+                  "type": "link"
+                }
+              ],
+              "name": "Tumult of the Blood",
+              "subtype": "ability",
+              "text": "The third time a jiang-shi successfully Drains Qi within a single minute, they become quickened for 1 minute. They can use their extra action only to Strike or Stride.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "darkwood",
+              "aonid": 273,
+              "game-obj": "Equipment",
+              "name": "darkwood",
+              "type": "link"
+            },
+            {
+              "alt": "darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Drop Prone",
+              "aonid": 78,
+              "game-obj": "Actions",
+              "name": "Drop Prone",
+              "type": "link"
+            },
+            {
+              "alt": "Leaps",
+              "aonid": 81,
+              "game-obj": "Actions",
+              "name": "Leaps",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "quickened",
+              "aonid": 32,
+              "game-obj": "Conditions",
+              "name": "quickened",
+              "type": "link"
+            }
+          ],
+          "name": "Jiang-Shi Minister Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 157",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 157",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 157,
+              "type": "source"
+            }
+          ],
+          "text": "Those rare jiang-shi who have devoured at least a thousand victims' qi have shed many of their frailties and become able to create jiang-shi from their slain victims. These imperious undead address themselves as \u201cministers\u201d or by other grandiose titles, and they mock lesser jiang-shi as mere \u201cprovincials.\u201d  \n  \n Ministers gain additional jiang-shi abilities, as detailed below. A creature below level 13 is not significant enough to become a minister\u2014you should instead simply make such a creature into a regular jiang-shi or rebuild the creature so that it's at least level 13 before becoming a minister.   \n  \n**Resistances** The jiang-shi resists all physical damage (except magical darkwood).   \n  \n**Dark Enlightenment** The jiang-shi is no longer limited to seeing living creatures with only their breathsense, and they no longer have the Revulsion vulnerability. They can perceive living creatures normally with either darkvision or breathsense, and they can take the Drop Prone action.   \n  \n**Distant Steps** When the jiang-shi Leaps, they can add 10 feet to the horizontal and/or vertical distance they move without affecting the Leap DC. The jiang-shi can stand and walk on water and other solid or liquid surfaces that wouldn't normally support their weight.   \n  \n**Tumult of the Blood** (divine, necromancy); The third time a jiang-shi successfully Drains Qi within a single minute, they become quickened for 1 minute. They can use their extra action only to Strike or Stride.",
+          "type": "section"
+        },
         {
           "name": "Dreamers of the Dark",
           "sources": [

--- a/monster_families/book_of_the_dead/vampire_vetalarana.json
+++ b/monster_families/book_of_the_dead/vampire_vetalarana.json
@@ -309,386 +309,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mindless",
-                    "aonid": 108,
-                    "game-obj": "Traits",
-                    "name": "mindless",
-                    "type": "link"
-                  }
-                ],
-                "name": "Thoughtsense",
-                "range": {
-                  "range": 100,
-                  "subtype": "range",
-                  "text": "within 100 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The vetalarana senses all non-mindless creatures within 100 feet as a precise sense.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divination",
-                      "aonid": 47,
-                      "game-obj": "Traits",
-                      "name": "divination",
-                      "type": "link"
-                    },
-                    "name": "divination",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 145,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Vetalarana Vulnerabilities",
-                "subtype": "ability",
-                "text": "All vetalaranas possess the following weaknesses.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "controlled",
-                    "aonid": 6,
-                    "game-obj": "Conditions",
-                    "name": "controlled",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mental Rebirth",
-                "range": {
-                  "range": 1,
-                  "subtype": "range",
-                  "text": "within 1 mile",
-                  "type": "stat_block_section",
-                  "unit": "miles"
-                },
-                "subtype": "ability",
-                "text": "Unlike most other undead, a vetalarana isn't destroyed when they reach 0 HP. Instead, their body is destroyed, crumbling to ash, and their mind is immediately transferred into a creature they rendered comatose through Drain Thoughts. This creature must be within 1 mile; if no such creature is in range, the vetalarana is destroyed. The creature becomes controlled by the vetalarana and loses the stupefied and unconscious conditions. If the creature controlled by a vetalarana in this way is killed, the vetalarana's mind transfers to another creature within 1 mile who they rendered comatose through Drain Thoughts.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 38,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Climb Speed",
-                "subtype": "ability",
-                "text": "A vetalarana gains a climb Speed equal to their land Speed.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Strike Damage",
-                    "aonid": 1018,
-                    "game-obj": "Rules",
-                    "name": "Strike Damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the base creature had hands, its fingernails thicken and grow to terrible proportions, granting it an unarmed claw Strike that deals slashing damage, has the agile trait, and can Grab. Use the moderate damage for the creature's level on the Strike Damage table.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The vetalarana seizes a creature and consumes its memories. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is stupefied 1, and the vetalarana regains HP equal to 10% of the vetalarana's maximum HP, gaining any excess as temporary Hit Points. Draining Thoughts from a creature that is already stupefied doesn't restore any HP to the vetalarana but increases the victim's stupefied value by 1. Additionally, the vetalarana views one of the victim's memories.",
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 20,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 33,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drain Thoughts",
-                "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vetalarana's reach",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divination",
-                      "aonid": 47,
-                      "game-obj": "Traits",
-                      "name": "divination",
-                      "type": "link"
-                    },
-                    "name": "divination",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Vetalarana')].sections[?(@.name=='Basic Vetalarana Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -706,6 +331,195 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "mindless",
+                "aonid": 108,
+                "game-obj": "Traits",
+                "name": "mindless",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 145,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "controlled",
+                "aonid": 6,
+                "game-obj": "Conditions",
+                "name": "controlled",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "Strike Damage",
+                "aonid": 1018,
+                "game-obj": "Rules",
+                "name": "Strike Damage",
+                "type": "link"
+              },
+              {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -715,288 +529,159 @@
         ],
         "name": "Basic Vetalarana Abilities",
         "subtype": "monster_family",
-        "text": "All vetalaranas gain the following abilities. If the base creature has any abilities that specifically come from being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vetalarana's theme.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mental",
-                    "aonid": 106,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magical",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "cold iron",
-                    "aonid": 375,
-                    "game-obj": "Equipment",
-                    "name": "cold iron",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "The vetalarana manipulator resists mental damage and all physical damage (except magical cold iron).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "effect": "The vetalarana manipulator spends 10 minutes to take psychic control of the creatures they've rendered comatose with Drain Thoughts. This has the effects of the *possession* spell, but lasts for up to 6 hours, has a range of 1 mile, and the vetalarana can control a number of comatose victims at a time equal to half the vetalarana's level. A comatose victim can't resist this possession and automatically gets a critical failure on its saving throw against Control Comatose.",
-                "frequency": "once per day",
-                "links": [
-                  {
-                    "alt": "possession",
-                    "aonid": 225,
-                    "game-obj": "Spells",
-                    "name": "possession",
-                    "type": "link"
-                  }
-                ],
-                "name": "Control Comatose",
-                "range": {
-                  "range": 1,
-                  "subtype": "range",
-                  "text": "range of 1 mile",
-                  "type": "stat_block_section",
-                  "unit": "miles"
-                },
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "exploration",
-                      "aonid": 66,
-                      "game-obj": "Traits",
-                      "name": "exploration",
-                      "type": "link"
-                    },
-                    "name": "exploration",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "possession",
-                      "aonid": 129,
-                      "game-obj": "Traits",
-                      "name": "possession",
-                      "type": "link"
-                    },
-                    "name": "possession",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "modify memory",
-                    "aonid": 200,
-                    "game-obj": "Spells",
-                    "name": "modify memory",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drain Thoughts",
-                "subtype": "ability",
-                "text": "As a basic vetalarana, but the vetalarana manipulator can choose to alter, enhance, or erase the memory they view as a 4th-level *modify memory* spell. If the vetalarana gets a critical success on their Athletics check to Drain Thoughts, the target is stupefied 2 instead of stupefied 1.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divination",
-                      "aonid": 47,
-                      "game-obj": "Traits",
-                      "name": "divination",
-                      "type": "link"
-                    },
-                    "name": "divination",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "tongues",
-                    "aonid": 340,
-                    "game-obj": "Spells",
-                    "name": "tongues",
-                    "type": "link"
-                  }
-                ],
-                "name": "Occult Innate Spells",
-                "subtype": "ability",
-                "text": "A vetalarana manipulator has *tongues* as a constant occult innate spell.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Spell DC and Spell Attack Bonus",
-                    "aonid": 1020,
-                    "game-obj": "Rules",
-                    "name": "Spell DC and Spell Attack Bonus",
-                    "type": "link"
-                  }
-                ],
-                "name": "Paralyzing Claws",
-                "subtype": "ability",
-                "text": "Any living creature hit by a vetalarana manipulator's claw Strike must succeed at a Fortitude save or become paralyzed. The target can attempt a new save at the end of each of its turns to end the effect, and the DC cumulatively decreases by 1 on each such save. Use the moderate DC for the creature's level on the Spell DC and Spell Attack Bonus table.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Vetalarana')].sections[?(@.name=='Vetalarana Manipulator Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "cold iron",
+                "aonid": 375,
+                "game-obj": "Equipment",
+                "name": "cold iron",
+                "type": "link"
+              },
+              {
+                "alt": "exploration",
+                "aonid": 66,
+                "game-obj": "Traits",
+                "name": "exploration",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 129,
+                "game-obj": "Traits",
+                "name": "possession",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 225,
+                "game-obj": "Spells",
+                "name": "possession",
+                "type": "link"
+              },
+              {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "modify memory",
+                "aonid": 200,
+                "game-obj": "Spells",
+                "name": "modify memory",
+                "type": "link"
+              },
+              {
+                "alt": "tongues",
+                "aonid": 340,
+                "game-obj": "Spells",
+                "name": "tongues",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "Spell DC and Spell Attack Bonus",
+                "aonid": 1020,
+                "game-obj": "Rules",
+                "name": "Spell DC and Spell Attack Bonus",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1006,7 +691,6 @@
         ],
         "name": "Vetalarana Manipulator Abilities",
         "subtype": "monster_family",
-        "text": "Extremely powerful vetalaranas who've tasted the thoughts of hundreds of people or more become empowered by the memories and experiences they've consumed, overcoming their revulsions. They gain greater control over their comatose victims, can manipulate memories, and even paralyze with a touch. These vetalaranas are known as \u201cmanipulators,\u201d although those with psychic powers of their own often prefer the terms \u201cdoyen\u201d or \u201cthoughtseer.\u201d   \n  \nVetalarana manipulators gain additional abilities, as detailed below. A creature below 10th level isn't powerful enough to become a vetalarana manipulator; instead, make such a creature into a regular vetalarana or rebuild the creature so that it's at least 10th level before making it a vetalarana manipulator.",
         "type": "stat_block_section"
       }
     ],
@@ -1018,6 +702,1036 @@
     {
       "name": "Creating a Vetalarana",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "mindless",
+                  "aonid": 108,
+                  "game-obj": "Traits",
+                  "name": "mindless",
+                  "type": "link"
+                }
+              ],
+              "name": "Thoughtsense",
+              "range": {
+                "range": 100,
+                "subtype": "range",
+                "text": "within 100 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The vetalarana senses all non-mindless creatures within 100 feet as a precise sense.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divination",
+                    "aonid": 47,
+                    "game-obj": "Traits",
+                    "name": "divination",
+                    "type": "link"
+                  },
+                  "name": "divination",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "sleep",
+                  "aonid": 145,
+                  "game-obj": "Traits",
+                  "name": "sleep",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, sleep",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Vetalarana Vulnerabilities",
+              "subtype": "ability",
+              "text": "All vetalaranas possess the following weaknesses.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "controlled",
+                  "aonid": 6,
+                  "game-obj": "Conditions",
+                  "name": "controlled",
+                  "type": "link"
+                },
+                {
+                  "alt": "stupefied",
+                  "aonid": 37,
+                  "game-obj": "Conditions",
+                  "name": "stupefied",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                }
+              ],
+              "name": "Mental Rebirth",
+              "range": {
+                "range": 1,
+                "subtype": "range",
+                "text": "within 1 mile",
+                "type": "stat_block_section",
+                "unit": "miles"
+              },
+              "subtype": "ability",
+              "text": "Unlike most other undead, a vetalarana isn't destroyed when they reach 0 HP. Instead, their body is destroyed, crumbling to ash, and their mind is immediately transferred into a creature they rendered comatose through Drain Thoughts. This creature must be within 1 mile; if no such creature is in range, the vetalarana is destroyed. The creature becomes controlled by the vetalarana and loses the stupefied and unconscious conditions. If the creature controlled by a vetalarana in this way is killed, the vetalarana's mind transfers to another creature within 1 mile who they rendered comatose through Drain Thoughts.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "curse",
+                    "aonid": 38,
+                    "game-obj": "Traits",
+                    "name": "curse",
+                    "type": "link"
+                  },
+                  "name": "curse",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "name": "Climb Speed",
+              "subtype": "ability",
+              "text": "A vetalarana gains a climb Speed equal to their land Speed.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 170,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                },
+                {
+                  "alt": "Grab",
+                  "aonid": 18,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Grab",
+                  "type": "link"
+                },
+                {
+                  "alt": "Strike Damage",
+                  "aonid": 1018,
+                  "game-obj": "Rules",
+                  "name": "Strike Damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Claws",
+              "subtype": "ability",
+              "text": "If the base creature had hands, its fingernails thicken and grow to terrible proportions, granting it an unarmed claw Strike that deals slashing damage, has the agile trait, and can Grab. Use the moderate damage for the creature's level on the Strike Damage table.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The vetalarana seizes a creature and consumes its memories. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is stupefied 1, and the vetalarana regains HP equal to 10% of the vetalarana's maximum HP, gaining any excess as temporary Hit Points. Draining Thoughts from a creature that is already stupefied doesn't restore any HP to the vetalarana but increases the victim's stupefied value by 1. Additionally, the vetalarana views one of the victim's memories.",
+              "links": [
+                {
+                  "alt": "grabbed",
+                  "aonid": 20,
+                  "game-obj": "Conditions",
+                  "name": "grabbed",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "restrained",
+                  "aonid": 33,
+                  "game-obj": "Conditions",
+                  "name": "restrained",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                },
+                {
+                  "alt": "Athletics",
+                  "aonid": 3,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                }
+              ],
+              "name": "Drain Thoughts",
+              "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vetalarana's reach",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divination",
+                    "aonid": 47,
+                    "game-obj": "Traits",
+                    "name": "divination",
+                    "type": "link"
+                  },
+                  "name": "divination",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "human",
+              "aonid": 90,
+              "game-obj": "Traits",
+              "name": "human",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 91,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "divination",
+              "aonid": 47,
+              "game-obj": "Traits",
+              "name": "divination",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "mindless",
+              "aonid": 108,
+              "game-obj": "Traits",
+              "name": "mindless",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 145,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            },
+            {
+              "alt": "curse",
+              "aonid": 38,
+              "game-obj": "Traits",
+              "name": "curse",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "controlled",
+              "aonid": 6,
+              "game-obj": "Conditions",
+              "name": "controlled",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            },
+            {
+              "alt": "Strike Damage",
+              "aonid": 1018,
+              "game-obj": "Rules",
+              "name": "Strike Damage",
+              "type": "link"
+            },
+            {
+              "alt": "divination",
+              "aonid": 47,
+              "game-obj": "Traits",
+              "name": "divination",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "grabbed",
+              "aonid": 20,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 33,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            }
+          ],
+          "name": "Basic Vetalarana Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 160",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 160",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 160,
+              "type": "source"
+            }
+          ],
+          "text": "All vetalaranas gain the following abilities. If the base creature has any abilities that specifically come from being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vetalarana's theme.   \n  \n**Thoughtsense** (divination, mental, occult) The vetalarana senses all non-mindless creatures within 100 feet as a precise sense.  \n  \n**Negative Healing**  \n  \n**Immunities** death effects, disease, paralyzed, poison, sleep  \n  \n**Vetalarana Vulnerabilities** All vetalaranas possess the following weaknesses. **Mental Rebirth** (curse, incapacitation, mental, necromancy, occult) Unlike most other undead, a vetalarana isn't destroyed when they reach 0 HP. Instead, their body is destroyed, crumbling to ash, and their mind is immediately transferred into a creature they rendered comatose through Drain Thoughts. This creature must be within 1 mile; if no such creature is in range, the vetalarana is destroyed. The creature becomes controlled by the vetalarana and loses the stupefied and unconscious conditions. If the creature controlled by a vetalarana in this way is killed, the vetalarana's mind transfers to another creature within 1 mile who they rendered comatose through Drain Thoughts.  \n After 1d6 days of being controlled, the controlled creature dies, and its body transforms into that of the vetalarana who rendered it comatose.  \n  \n**Climb Speed** A vetalarana gains a climb Speed equal to their land Speed.  \n  \n**Claws** If the base creature had hands, its fingernails thicken and grow to terrible proportions, granting it an unarmed claw Strike that deals slashing damage, has the agile trait, and can Grab. Use the moderate damage for the creature's level on the Strike Damage table.  \n  \n**Drain Thoughts** [#] (divination, mental, occult) **Requirements** A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vetalarana's reach; **Effect** The vetalarana seizes a creature and consumes its memories. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is stupefied 1, and the vetalarana regains HP equal to 10% of the vetalarana's maximum HP, gaining any excess as temporary Hit Points. Draining Thoughts from a creature that is already stupefied doesn't restore any HP to the vetalarana but increases the victim's stupefied value by 1. Additionally, the vetalarana views one of the victim's memories.  \n A victim's stupefied condition value decreases by 1 every week.  \n A victim that becomes stupefied 5 in this way is rendered comatose, becoming permanently unconscious. As long as the vetalarana lives, a comatose victim can't regain consciousness, and its stupefied condition doesn't decrease.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "mental",
+                  "aonid": 106,
+                  "game-obj": "Traits",
+                  "name": "mental",
+                  "type": "link"
+                },
+                {
+                  "alt": "magical",
+                  "aonid": 103,
+                  "game-obj": "Traits",
+                  "name": "magical",
+                  "type": "link"
+                },
+                {
+                  "alt": "cold iron",
+                  "aonid": 375,
+                  "game-obj": "Equipment",
+                  "name": "cold iron",
+                  "type": "link"
+                }
+              ],
+              "name": "Resistances",
+              "subtype": "ability",
+              "text": "The vetalarana manipulator resists mental damage and all physical damage (except magical cold iron).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "effect": "The vetalarana manipulator spends 10 minutes to take psychic control of the creatures they've rendered comatose with Drain Thoughts. This has the effects of the *possession* spell, but lasts for up to 6 hours, has a range of 1 mile, and the vetalarana can control a number of comatose victims at a time equal to half the vetalarana's level. A comatose victim can't resist this possession and automatically gets a critical failure on its saving throw against Control Comatose.",
+              "frequency": "once per day",
+              "links": [
+                {
+                  "alt": "possession",
+                  "aonid": 225,
+                  "game-obj": "Spells",
+                  "name": "possession",
+                  "type": "link"
+                }
+              ],
+              "name": "Control Comatose",
+              "range": {
+                "range": 1,
+                "subtype": "range",
+                "text": "range of 1 mile",
+                "type": "stat_block_section",
+                "unit": "miles"
+              },
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "exploration",
+                    "aonid": 66,
+                    "game-obj": "Traits",
+                    "name": "exploration",
+                    "type": "link"
+                  },
+                  "name": "exploration",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "possession",
+                    "aonid": 129,
+                    "game-obj": "Traits",
+                    "name": "possession",
+                    "type": "link"
+                  },
+                  "name": "possession",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "modify memory",
+                  "aonid": 200,
+                  "game-obj": "Spells",
+                  "name": "modify memory",
+                  "type": "link"
+                }
+              ],
+              "name": "Drain Thoughts",
+              "subtype": "ability",
+              "text": "As a basic vetalarana, but the vetalarana manipulator can choose to alter, enhance, or erase the memory they view as a 4th-level *modify memory* spell. If the vetalarana gets a critical success on their Athletics check to Drain Thoughts, the target is stupefied 2 instead of stupefied 1.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divination",
+                    "aonid": 47,
+                    "game-obj": "Traits",
+                    "name": "divination",
+                    "type": "link"
+                  },
+                  "name": "divination",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "tongues",
+                  "aonid": 340,
+                  "game-obj": "Spells",
+                  "name": "tongues",
+                  "type": "link"
+                }
+              ],
+              "name": "Occult Innate Spells",
+              "subtype": "ability",
+              "text": "A vetalarana manipulator has *tongues* as a constant occult innate spell.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "Spell DC and Spell Attack Bonus",
+                  "aonid": 1020,
+                  "game-obj": "Rules",
+                  "name": "Spell DC and Spell Attack Bonus",
+                  "type": "link"
+                }
+              ],
+              "name": "Paralyzing Claws",
+              "subtype": "ability",
+              "text": "Any living creature hit by a vetalarana manipulator's claw Strike must succeed at a Fortitude save or become paralyzed. The target can attempt a new save at the end of each of its turns to end the effect, and the DC cumulatively decreases by 1 on each such save. Use the moderate DC for the creature's level on the Spell DC and Spell Attack Bonus table.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "incapacitation",
+                    "aonid": 93,
+                    "game-obj": "Traits",
+                    "name": "incapacitation",
+                    "type": "link"
+                  },
+                  "name": "incapacitation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "occult",
+                    "aonid": 120,
+                    "game-obj": "Traits",
+                    "name": "occult",
+                    "type": "link"
+                  },
+                  "name": "occult",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "magical",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            },
+            {
+              "alt": "cold iron",
+              "aonid": 375,
+              "game-obj": "Equipment",
+              "name": "cold iron",
+              "type": "link"
+            },
+            {
+              "alt": "exploration",
+              "aonid": 66,
+              "game-obj": "Traits",
+              "name": "exploration",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "possession",
+              "aonid": 129,
+              "game-obj": "Traits",
+              "name": "possession",
+              "type": "link"
+            },
+            {
+              "alt": "possession",
+              "aonid": 225,
+              "game-obj": "Spells",
+              "name": "possession",
+              "type": "link"
+            },
+            {
+              "alt": "divination",
+              "aonid": 47,
+              "game-obj": "Traits",
+              "name": "divination",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "modify memory",
+              "aonid": 200,
+              "game-obj": "Spells",
+              "name": "modify memory",
+              "type": "link"
+            },
+            {
+              "alt": "tongues",
+              "aonid": 340,
+              "game-obj": "Spells",
+              "name": "tongues",
+              "type": "link"
+            },
+            {
+              "alt": "incapacitation",
+              "aonid": 93,
+              "game-obj": "Traits",
+              "name": "incapacitation",
+              "type": "link"
+            },
+            {
+              "alt": "occult",
+              "aonid": 120,
+              "game-obj": "Traits",
+              "name": "occult",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "Spell DC and Spell Attack Bonus",
+              "aonid": 1020,
+              "game-obj": "Rules",
+              "name": "Spell DC and Spell Attack Bonus",
+              "type": "link"
+            }
+          ],
+          "name": "Vetalarana Manipulator Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Book of the Dead pg. 160",
+                "aonid": 118,
+                "game-obj": "Sources",
+                "name": "Book of the Dead pg. 160",
+                "type": "link"
+              },
+              "name": "Book of the Dead",
+              "page": 160,
+              "type": "source"
+            }
+          ],
+          "text": "Extremely powerful vetalaranas who've tasted the thoughts of hundreds of people or more become empowered by the memories and experiences they've consumed, overcoming their revulsions. They gain greater control over their comatose victims, can manipulate memories, and even paralyze with a touch. These vetalaranas are known as \u201cmanipulators,\u201d although those with psychic powers of their own often prefer the terms \u201cdoyen\u201d or \u201cthoughtseer.\u201d   \n  \nVetalarana manipulators gain additional abilities, as detailed below. A creature below 10th level isn't powerful enough to become a vetalarana manipulator; instead, make such a creature into a regular vetalarana or rebuild the creature so that it's at least 10th level before making it a vetalarana manipulator.  \n  \n**Resistances** The vetalarana manipulator resists mental damage and all physical damage (except magical cold iron).  \n  \n**Control Comatose** (exploration, incapacitation, mental, necromancy, occult, possession) **Frequency** once per day; **Effect** The vetalarana manipulator spends 10 minutes to take psychic control of the creatures they've rendered comatose with Drain Thoughts. This has the effects of the *possession* spell, but lasts for up to 6 hours, has a range of 1 mile, and the vetalarana can control a number of comatose victims at a time equal to half the vetalarana's level. A comatose victim can't resist this possession and automatically gets a critical failure on its saving throw against Control Comatose.  \n As long as a comatose victim is controlled by a vetalarana manipulator in this way, the victim's stupefied and unconscious conditions are temporarily suppressed.  \n  \n**Drain Thoughts** [#] (divination, mental, occult) As a basic vetalarana, but the vetalarana manipulator can choose to alter, enhance, or erase the memory they view as a 4th-level *modify memory* spell. If the vetalarana gets a critical success on their Athletics check to Drain Thoughts, the target is stupefied 2 instead of stupefied 1.  \n  \n**Occult Innate Spells** A vetalarana manipulator has *tongues* as a constant occult innate spell.  \n  \n**Paralyzing Claws** (incapacitation, occult, necromancy) Any living creature hit by a vetalarana manipulator's claw Strike must succeed at a Fortitude save or become paralyzed. The target can attempt a new save at the end of each of its turns to end the effect, and the DC cumulatively decreases by 1 on each such save. Use the moderate DC for the creature's level on the Spell DC and Spell Attack Bonus table.",
+          "type": "section"
+        },
         {
           "name": "Mistaken Identity",
           "sources": [

--- a/monster_families/draconic_codex/dragon_barrage.json
+++ b/monster_families/draconic_codex/dragon_barrage.json
@@ -59,247 +59,97 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "force barrage",
-                            "aonid": 1536,
-                            "game-obj": "Spells",
-                            "name": "force barrage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "lightning bolt",
-                            "aonid": 1586,
-                            "game-obj": "Spells",
-                            "name": "lightning bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "lightning bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of wind",
-                            "aonid": 1753,
-                            "game-obj": "Spells",
-                            "name": "wall of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blazing bolt",
-                            "aonid": 1450,
-                            "game-obj": "Spells",
-                            "name": "blazing bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blazing bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic maneuver",
-                            "aonid": 1717,
-                            "game-obj": "Spells",
-                            "name": "telekinetic maneuver",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic maneuver",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dizzying colors",
-                            "aonid": 1500,
-                            "game-obj": "Spells",
-                            "name": "dizzying colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dizzying colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pummeling rubble",
-                            "aonid": 1642,
-                            "game-obj": "Spells",
-                            "name": "pummeling rubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pummeling rubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 1509,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 1718,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Barrage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "force barrage",
+                "aonid": 1536,
+                "game-obj": "Spells",
+                "name": "force barrage",
+                "type": "link"
+              },
+              {
+                "alt": "lightning bolt",
+                "aonid": 1586,
+                "game-obj": "Spells",
+                "name": "lightning bolt",
+                "type": "link"
+              },
+              {
+                "alt": "wall of wind",
+                "aonid": 1753,
+                "game-obj": "Spells",
+                "name": "wall of wind",
+                "type": "link"
+              },
+              {
+                "alt": "blazing bolt",
+                "aonid": 1450,
+                "game-obj": "Spells",
+                "name": "blazing bolt",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic maneuver",
+                "aonid": 1717,
+                "game-obj": "Spells",
+                "name": "telekinetic maneuver",
+                "type": "link"
+              },
+              {
+                "alt": "dizzying colors",
+                "aonid": 1500,
+                "game-obj": "Spells",
+                "name": "dizzying colors",
+                "type": "link"
+              },
+              {
+                "alt": "pummeling rubble",
+                "aonid": 1642,
+                "game-obj": "Spells",
+                "name": "pummeling rubble",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 1509,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 1718,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -315,196 +165,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young barrage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 32,
-                  "subtype": "save_dc",
-                  "text": "DC 32",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disintegrate",
-                            "aonid": 1492,
-                            "game-obj": "Spells",
-                            "name": "disintegrate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disintegrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of force",
-                            "aonid": 1749,
-                            "game-obj": "Spells",
-                            "name": "wall of force",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of force",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "impaling spike",
-                            "aonid": 1571,
-                            "game-obj": "Spells",
-                            "name": "impaling spike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "impaling spike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic haul",
-                            "aonid": 1716,
-                            "game-obj": "Spells",
-                            "name": "telekinetic haul",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic haul",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "creation",
-                            "aonid": 1477,
-                            "game-obj": "Spells",
-                            "name": "creation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "creation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "flicker",
-                            "aonid": 1532,
-                            "game-obj": "Spells",
-                            "name": "flicker",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "flicker",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Barrage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disintegrate",
+                "aonid": 1492,
+                "game-obj": "Spells",
+                "name": "disintegrate",
+                "type": "link"
+              },
+              {
+                "alt": "wall of force",
+                "aonid": 1749,
+                "game-obj": "Spells",
+                "name": "wall of force",
+                "type": "link"
+              },
+              {
+                "alt": "impaling spike",
+                "aonid": 1571,
+                "game-obj": "Spells",
+                "name": "impaling spike",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic haul",
+                "aonid": 1716,
+                "game-obj": "Spells",
+                "name": "telekinetic haul",
+                "type": "link"
+              },
+              {
+                "alt": "creation",
+                "aonid": 1477,
+                "game-obj": "Spells",
+                "name": "creation",
+                "type": "link"
+              },
+              {
+                "alt": "flicker",
+                "aonid": 1532,
+                "game-obj": "Spells",
+                "name": "flicker",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -520,196 +229,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult barrage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "quandary",
-                            "aonid": 1644,
-                            "game-obj": "Spells",
-                            "name": "quandary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "quandary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "duplicate foe",
-                            "aonid": 1505,
-                            "game-obj": "Spells",
-                            "name": "duplicate foe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "duplicate foe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Barrage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "quandary",
+                "aonid": 1644,
+                "game-obj": "Spells",
+                "name": "quandary",
+                "type": "link"
+              },
+              {
+                "alt": "duplicate foe",
+                "aonid": 1505,
+                "game-obj": "Spells",
+                "name": "duplicate foe",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -725,63 +293,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As ancient barrage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "containment",
-                            "aonid": 1981,
-                            "game-obj": "Spells",
-                            "name": "containment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "containment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 1640,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Barrage Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "containment",
+                "aonid": 1981,
+                "game-obj": "Spells",
+                "name": "containment",
+                "type": "link"
+              },
+              {
+                "alt": "project image",
+                "aonid": 1640,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -796,48 +328,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -848,263 +343,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1114,7 +393,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1140,6 +418,958 @@
         }
       ],
       "text": "Barrage dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "force barrage",
+          "aonid": 1536,
+          "game-obj": "Spells",
+          "name": "force barrage",
+          "type": "link"
+        },
+        {
+          "alt": "lightning bolt",
+          "aonid": 1586,
+          "game-obj": "Spells",
+          "name": "lightning bolt",
+          "type": "link"
+        },
+        {
+          "alt": "wall of wind",
+          "aonid": 1753,
+          "game-obj": "Spells",
+          "name": "wall of wind",
+          "type": "link"
+        },
+        {
+          "alt": "blazing bolt",
+          "aonid": 1450,
+          "game-obj": "Spells",
+          "name": "blazing bolt",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic maneuver",
+          "aonid": 1717,
+          "game-obj": "Spells",
+          "name": "telekinetic maneuver",
+          "type": "link"
+        },
+        {
+          "alt": "dizzying colors",
+          "aonid": 1500,
+          "game-obj": "Spells",
+          "name": "dizzying colors",
+          "type": "link"
+        },
+        {
+          "alt": "pummeling rubble",
+          "aonid": 1642,
+          "game-obj": "Spells",
+          "name": "pummeling rubble",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 1509,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 1718,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Young Barrage Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 105",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 105",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 105,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "force barrage",
+                      "aonid": 1536,
+                      "game-obj": "Spells",
+                      "name": "force barrage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "lightning bolt",
+                      "aonid": 1586,
+                      "game-obj": "Spells",
+                      "name": "lightning bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "lightning bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of wind",
+                      "aonid": 1753,
+                      "game-obj": "Spells",
+                      "name": "wall of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blazing bolt",
+                      "aonid": 1450,
+                      "game-obj": "Spells",
+                      "name": "blazing bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blazing bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic maneuver",
+                      "aonid": 1717,
+                      "game-obj": "Spells",
+                      "name": "telekinetic maneuver",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic maneuver",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dizzying colors",
+                      "aonid": 1500,
+                      "game-obj": "Spells",
+                      "name": "dizzying colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dizzying colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pummeling rubble",
+                      "aonid": 1642,
+                      "game-obj": "Spells",
+                      "name": "pummeling rubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pummeling rubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 1509,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 1718,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 26, attack +18; **3rd** *force barrage*, *lightning bolt*, *wall of wind*; **2nd** *blazing bolt*, *force barrage*, *telekinetic maneuver*; **1st** *dizzying colors*, *force barrage*, *pummeling rubble*; **Cantrips (3rd)** *detect magic*, *electric arc*, *figment*, *shield*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "disintegrate",
+          "aonid": 1492,
+          "game-obj": "Spells",
+          "name": "disintegrate",
+          "type": "link"
+        },
+        {
+          "alt": "wall of force",
+          "aonid": 1749,
+          "game-obj": "Spells",
+          "name": "wall of force",
+          "type": "link"
+        },
+        {
+          "alt": "impaling spike",
+          "aonid": 1571,
+          "game-obj": "Spells",
+          "name": "impaling spike",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic haul",
+          "aonid": 1716,
+          "game-obj": "Spells",
+          "name": "telekinetic haul",
+          "type": "link"
+        },
+        {
+          "alt": "creation",
+          "aonid": 1477,
+          "game-obj": "Spells",
+          "name": "creation",
+          "type": "link"
+        },
+        {
+          "alt": "flicker",
+          "aonid": 1532,
+          "game-obj": "Spells",
+          "name": "flicker",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Barrage Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 105",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 105",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 105,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young barrage dragon"
+          ],
+          "saving_throw": {
+            "dc": 32,
+            "subtype": "save_dc",
+            "text": "DC 32",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disintegrate",
+                      "aonid": 1492,
+                      "game-obj": "Spells",
+                      "name": "disintegrate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disintegrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of force",
+                      "aonid": 1749,
+                      "game-obj": "Spells",
+                      "name": "wall of force",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of force",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "impaling spike",
+                      "aonid": 1571,
+                      "game-obj": "Spells",
+                      "name": "impaling spike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "impaling spike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic haul",
+                      "aonid": 1716,
+                      "game-obj": "Spells",
+                      "name": "telekinetic haul",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic haul",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "creation",
+                      "aonid": 1477,
+                      "game-obj": "Spells",
+                      "name": "creation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "creation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "flicker",
+                      "aonid": 1532,
+                      "game-obj": "Spells",
+                      "name": "flicker",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "flicker",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 32, attack +24; As young barrage dragon, plus **6th** *disintegrate*, *force barrage*, *wall of force*; **5th** *force barrage*, *impaling spike*, *telekinetic haul*; **4th** *creation*, *flicker*, *force barrage*; **Cantrips (6th)** *detect magic*, *electric arc*, *figment*, *shield*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "quandary",
+          "aonid": 1644,
+          "game-obj": "Spells",
+          "name": "quandary",
+          "type": "link"
+        },
+        {
+          "alt": "duplicate foe",
+          "aonid": 1505,
+          "game-obj": "Spells",
+          "name": "duplicate foe",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Barrage Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 105",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 105",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 105,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult barrage dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "quandary",
+                      "aonid": 1644,
+                      "game-obj": "Spells",
+                      "name": "quandary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "quandary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "duplicate foe",
+                      "aonid": 1505,
+                      "game-obj": "Spells",
+                      "name": "duplicate foe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "duplicate foe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 38, attack +30; As adult barrage dragon, plus **9th** *detonate magic*, *force barrage*, *implosion*; **8th** *force barrage*, *hidden mind*, *quandary*; **7th** *duplicate foe*, *energy aegis*, *force barrage*; **Cantrips (9th)** *detect magic*, *electric arc*, *figment*, *shield*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "containment",
+          "aonid": 1981,
+          "game-obj": "Spells",
+          "name": "containment",
+          "type": "link"
+        },
+        {
+          "alt": "project image",
+          "aonid": 1640,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        }
+      ],
+      "name": "Barrage Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 105",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 105",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 105,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As ancient barrage dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "containment",
+                      "aonid": 1981,
+                      "game-obj": "Spells",
+                      "name": "containment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "containment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 1640,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 42, attack +34; As ancient barrage dragon, plus **9th** *containment*, *project image*",
       "type": "section"
     },
     {
@@ -1454,6 +1684,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 105",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 105",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 105,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1601,6 +1887,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 105",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 105",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 105,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_bog.json
+++ b/monster_families/draconic_codex/dragon_bog.json
@@ -65,318 +65,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 25,
-                  "subtype": "save_dc",
-                  "text": "DC 25",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 17,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hydraulic torrent",
-                            "aonid": 1562,
-                            "game-obj": "Spells",
-                            "name": "hydraulic torrent",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "misty memory",
-                            "aonid": 1392,
-                            "game-obj": "Spells",
-                            "name": "misty memory",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "misty memory",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vapor form",
-                            "aonid": 1738,
-                            "game-obj": "Spells",
-                            "name": "vapor form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vapor form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "aqueous orb",
-                            "aonid": 1443,
-                            "game-obj": "Spells",
-                            "name": "aqueous orb",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "aqueous orb",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 1506,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of thorns",
-                            "aonid": 1752,
-                            "game-obj": "Spells",
-                            "name": "wall of thorns",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of thorns",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sudden blight",
-                            "aonid": 2033,
-                            "game-obj": "Spells",
-                            "name": "sudden blight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sudden blight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vomit swarm",
-                            "aonid": 2041,
-                            "game-obj": "Spells",
-                            "name": "vomit swarm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vomit swarm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mud pit",
-                            "aonid": 2009,
-                            "game-obj": "Spells",
-                            "name": "mud pit",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mud pit",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vanishing tracks",
-                            "aonid": 1737,
-                            "game-obj": "Spells",
-                            "name": "vanishing tracks",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vanishing tracks",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "caustic blast",
-                            "aonid": 1461,
-                            "game-obj": "Spells",
-                            "name": "caustic blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangle vine",
-                            "aonid": 1713,
-                            "game-obj": "Spells",
-                            "name": "tangle vine",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tremor signs",
-                            "aonid": 1342,
-                            "game-obj": "Spells",
-                            "name": "tremor signs",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Bog Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "hydraulic torrent",
+                "aonid": 1562,
+                "game-obj": "Spells",
+                "name": "hydraulic torrent",
+                "type": "link"
+              },
+              {
+                "alt": "misty memory",
+                "aonid": 1392,
+                "game-obj": "Spells",
+                "name": "misty memory",
+                "type": "link"
+              },
+              {
+                "alt": "vapor form",
+                "aonid": 1738,
+                "game-obj": "Spells",
+                "name": "vapor form",
+                "type": "link"
+              },
+              {
+                "alt": "aqueous orb",
+                "aonid": 1443,
+                "game-obj": "Spells",
+                "name": "aqueous orb",
+                "type": "link"
+              },
+              {
+                "alt": "earthbind",
+                "aonid": 1506,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "wall of thorns",
+                "aonid": 1752,
+                "game-obj": "Spells",
+                "name": "wall of thorns",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "sudden blight",
+                "aonid": 2033,
+                "game-obj": "Spells",
+                "name": "sudden blight",
+                "type": "link"
+              },
+              {
+                "alt": "vomit swarm",
+                "aonid": 2041,
+                "game-obj": "Spells",
+                "name": "vomit swarm",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mud pit",
+                "aonid": 2009,
+                "game-obj": "Spells",
+                "name": "mud pit",
+                "type": "link"
+              },
+              {
+                "alt": "vanishing tracks",
+                "aonid": 1737,
+                "game-obj": "Spells",
+                "name": "vanishing tracks",
+                "type": "link"
+              },
+              {
+                "alt": "caustic blast",
+                "aonid": 1461,
+                "game-obj": "Spells",
+                "name": "caustic blast",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "tangle vine",
+                "aonid": 1713,
+                "game-obj": "Spells",
+                "name": "tangle vine",
+                "type": "link"
+              },
+              {
+                "alt": "tremor signs",
+                "aonid": 1342,
+                "game-obj": "Spells",
+                "name": "tremor signs",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -392,170 +206,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young bog dragon"
-                ],
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blinding fury",
-                            "aonid": 1968,
-                            "game-obj": "Spells",
-                            "name": "blinding fury",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blinding fury",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangling creepers",
-                            "aonid": 1714,
-                            "game-obj": "Spells",
-                            "name": "tangling creepers",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangling creepers",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tree of seasons",
-                            "aonid": 1725,
-                            "game-obj": "Spells",
-                            "name": "tree of seasons",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tree of seasons",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "control water",
-                            "aonid": 1473,
-                            "game-obj": "Spells",
-                            "name": "control water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "control water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "corrosive muck",
-                            "aonid": 1982,
-                            "game-obj": "Spells",
-                            "name": "corrosive muck",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "corrosive muck",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Bog Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "blinding fury",
+                "aonid": 1968,
+                "game-obj": "Spells",
+                "name": "blinding fury",
+                "type": "link"
+              },
+              {
+                "alt": "tangling creepers",
+                "aonid": 1714,
+                "game-obj": "Spells",
+                "name": "tangling creepers",
+                "type": "link"
+              },
+              {
+                "alt": "tree of seasons",
+                "aonid": 1725,
+                "game-obj": "Spells",
+                "name": "tree of seasons",
+                "type": "link"
+              },
+              {
+                "alt": "control water",
+                "aonid": 1473,
+                "game-obj": "Spells",
+                "name": "control water",
+                "type": "link"
+              },
+              {
+                "alt": "corrosive muck",
+                "aonid": 1982,
+                "game-obj": "Spells",
+                "name": "corrosive muck",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -571,170 +270,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult bog dragon"
-                ],
-                "saving_throw": {
-                  "dc": 37,
-                  "subtype": "save_dc",
-                  "text": "DC 37",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 29,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid grip",
-                            "aonid": 1436,
-                            "game-obj": "Spells",
-                            "name": "acid grip",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid grip",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthquake",
-                            "aonid": 1507,
-                            "game-obj": "Spells",
-                            "name": "earthquake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthquake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "execute",
-                            "aonid": 1519,
-                            "game-obj": "Spells",
-                            "name": "execute",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "execute",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Bog Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "acid grip",
+                "aonid": 1436,
+                "game-obj": "Spells",
+                "name": "acid grip",
+                "type": "link"
+              },
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "earthquake",
+                "aonid": 1507,
+                "game-obj": "Spells",
+                "name": "earthquake",
+                "type": "link"
+              },
+              {
+                "alt": "execute",
+                "aonid": 1519,
+                "game-obj": "Spells",
+                "name": "execute",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -750,117 +334,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient bog dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "harm",
-                            "aonid": 1552,
-                            "game-obj": "Spells",
-                            "name": "harm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "harm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wrathful storm",
-                            "aonid": 1759,
-                            "game-obj": "Spells",
-                            "name": "wrathful storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wrathful storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Bog Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "harm",
+                "aonid": 1552,
+                "game-obj": "Spells",
+                "name": "harm",
+                "type": "link"
+              },
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
+              },
+              {
+                "alt": "wrathful storm",
+                "aonid": 1759,
+                "game-obj": "Spells",
+                "name": "wrathful storm",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -875,48 +376,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -927,263 +391,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1193,7 +441,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1219,6 +466,1073 @@
         }
       ],
       "text": "Bog dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "hydraulic torrent",
+          "aonid": 1562,
+          "game-obj": "Spells",
+          "name": "hydraulic torrent",
+          "type": "link"
+        },
+        {
+          "alt": "misty memory",
+          "aonid": 1392,
+          "game-obj": "Spells",
+          "name": "misty memory",
+          "type": "link"
+        },
+        {
+          "alt": "vapor form",
+          "aonid": 1738,
+          "game-obj": "Spells",
+          "name": "vapor form",
+          "type": "link"
+        },
+        {
+          "alt": "aqueous orb",
+          "aonid": 1443,
+          "game-obj": "Spells",
+          "name": "aqueous orb",
+          "type": "link"
+        },
+        {
+          "alt": "earthbind",
+          "aonid": 1506,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "wall of thorns",
+          "aonid": 1752,
+          "game-obj": "Spells",
+          "name": "wall of thorns",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "sudden blight",
+          "aonid": 2033,
+          "game-obj": "Spells",
+          "name": "sudden blight",
+          "type": "link"
+        },
+        {
+          "alt": "vomit swarm",
+          "aonid": 2041,
+          "game-obj": "Spells",
+          "name": "vomit swarm",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mud pit",
+          "aonid": 2009,
+          "game-obj": "Spells",
+          "name": "mud pit",
+          "type": "link"
+        },
+        {
+          "alt": "vanishing tracks",
+          "aonid": 1737,
+          "game-obj": "Spells",
+          "name": "vanishing tracks",
+          "type": "link"
+        },
+        {
+          "alt": "caustic blast",
+          "aonid": 1461,
+          "game-obj": "Spells",
+          "name": "caustic blast",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "tangle vine",
+          "aonid": 1713,
+          "game-obj": "Spells",
+          "name": "tangle vine",
+          "type": "link"
+        },
+        {
+          "alt": "tremor signs",
+          "aonid": 1342,
+          "game-obj": "Spells",
+          "name": "tremor signs",
+          "type": "link"
+        }
+      ],
+      "name": "Young Bog Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 109",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 109",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 109,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 25,
+            "subtype": "save_dc",
+            "text": "DC 25",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 17,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hydraulic torrent",
+                      "aonid": 1562,
+                      "game-obj": "Spells",
+                      "name": "hydraulic torrent",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "misty memory",
+                      "aonid": 1392,
+                      "game-obj": "Spells",
+                      "name": "misty memory",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "misty memory",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vapor form",
+                      "aonid": 1738,
+                      "game-obj": "Spells",
+                      "name": "vapor form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vapor form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "aqueous orb",
+                      "aonid": 1443,
+                      "game-obj": "Spells",
+                      "name": "aqueous orb",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "aqueous orb",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 1506,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of thorns",
+                      "aonid": 1752,
+                      "game-obj": "Spells",
+                      "name": "wall of thorns",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of thorns",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sudden blight",
+                      "aonid": 2033,
+                      "game-obj": "Spells",
+                      "name": "sudden blight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sudden blight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vomit swarm",
+                      "aonid": 2041,
+                      "game-obj": "Spells",
+                      "name": "vomit swarm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vomit swarm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mud pit",
+                      "aonid": 2009,
+                      "game-obj": "Spells",
+                      "name": "mud pit",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mud pit",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vanishing tracks",
+                      "aonid": 1737,
+                      "game-obj": "Spells",
+                      "name": "vanishing tracks",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vanishing tracks",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "caustic blast",
+                      "aonid": 1461,
+                      "game-obj": "Spells",
+                      "name": "caustic blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangle vine",
+                      "aonid": 1713,
+                      "game-obj": "Spells",
+                      "name": "tangle vine",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tremor signs",
+                      "aonid": 1342,
+                      "game-obj": "Spells",
+                      "name": "tremor signs",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 25, attack +17; **4th** *hydraulic torrent*, *misty memory*, *vapor form*; **3rd** *aqueous orb*, *earthbind*, *wall of thorns*; **2nd** *mist*, *sudden blight*, *vomit swarm*; **1st** *fear*, *mud pit*, *vanishing tracks*; **Cantrips (4th)** *caustic blast*, *detect magic*, *know the way*, *tangle vine*, *tremor signs*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "blinding fury",
+          "aonid": 1968,
+          "game-obj": "Spells",
+          "name": "blinding fury",
+          "type": "link"
+        },
+        {
+          "alt": "tangling creepers",
+          "aonid": 1714,
+          "game-obj": "Spells",
+          "name": "tangling creepers",
+          "type": "link"
+        },
+        {
+          "alt": "tree of seasons",
+          "aonid": 1725,
+          "game-obj": "Spells",
+          "name": "tree of seasons",
+          "type": "link"
+        },
+        {
+          "alt": "control water",
+          "aonid": 1473,
+          "game-obj": "Spells",
+          "name": "control water",
+          "type": "link"
+        },
+        {
+          "alt": "corrosive muck",
+          "aonid": 1982,
+          "game-obj": "Spells",
+          "name": "corrosive muck",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Bog Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 109",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 109",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 109,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young bog dragon"
+          ],
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blinding fury",
+                      "aonid": 1968,
+                      "game-obj": "Spells",
+                      "name": "blinding fury",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blinding fury",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangling creepers",
+                      "aonid": 1714,
+                      "game-obj": "Spells",
+                      "name": "tangling creepers",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangling creepers",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tree of seasons",
+                      "aonid": 1725,
+                      "game-obj": "Spells",
+                      "name": "tree of seasons",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tree of seasons",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "control water",
+                      "aonid": 1473,
+                      "game-obj": "Spells",
+                      "name": "control water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "control water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "corrosive muck",
+                      "aonid": 1982,
+                      "game-obj": "Spells",
+                      "name": "corrosive muck",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "corrosive muck",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 30, attack +22; As young bog dragon, plus **6th** *blinding fury*, *tangling creepers*, *tree of seasons*; **5th** *control water*, *corrosive muck*, *toxic cloud*; **Cantrips (6th)** *caustic blast*, *detect magic*, *know the way*, *tangle vine*, *tremor signs*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "acid grip",
+          "aonid": 1436,
+          "game-obj": "Spells",
+          "name": "acid grip",
+          "type": "link"
+        },
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "earthquake",
+          "aonid": 1507,
+          "game-obj": "Spells",
+          "name": "earthquake",
+          "type": "link"
+        },
+        {
+          "alt": "execute",
+          "aonid": 1519,
+          "game-obj": "Spells",
+          "name": "execute",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Bog Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 109",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 109",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 109,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult bog dragon"
+          ],
+          "saving_throw": {
+            "dc": 37,
+            "subtype": "save_dc",
+            "text": "DC 37",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 29,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid grip",
+                      "aonid": 1436,
+                      "game-obj": "Spells",
+                      "name": "acid grip",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid grip",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthquake",
+                      "aonid": 1507,
+                      "game-obj": "Spells",
+                      "name": "earthquake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthquake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "execute",
+                      "aonid": 1519,
+                      "game-obj": "Spells",
+                      "name": "execute",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "execute",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 37, attack +29; As adult bog dragon, plus 8th *acid grip*, *desiccate*, *earthquake*; **7th** *execute*, *mask of terror*, *regenerate*; **Cantrips (8th)** *caustic blast*, *detect magic*, *know the way*, *tangle vine*, *tremor signs*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "harm",
+          "aonid": 1552,
+          "game-obj": "Spells",
+          "name": "harm",
+          "type": "link"
+        },
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        },
+        {
+          "alt": "wrathful storm",
+          "aonid": 1759,
+          "game-obj": "Spells",
+          "name": "wrathful storm",
+          "type": "link"
+        }
+      ],
+      "name": "Bog Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 109",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 109",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 109,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient bog dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "harm",
+                      "aonid": 1552,
+                      "game-obj": "Spells",
+                      "name": "harm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "harm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wrathful storm",
+                      "aonid": 1759,
+                      "game-obj": "Spells",
+                      "name": "wrathful storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wrathful storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +33; As ancient bog dragon, plus **9th** *harm*, *massacre*, *wrathful storm*; **Cantrips (9th)** *caustic blast*, *detect magic*, *know the way*, *tangle vine*, *tremor signs*",
       "type": "section"
     },
     {
@@ -1533,6 +1847,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 109",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 109",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 109,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1680,6 +2050,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 109",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 109",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 109,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_brine.json
+++ b/monster_families/draconic_codex/dragon_brine.json
@@ -74,318 +74,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "crashing wave",
-                            "aonid": 1984,
-                            "game-obj": "Spells",
-                            "name": "crashing wave",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "crashing wave",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hydraulic torrent",
-                            "aonid": 1562,
-                            "game-obj": "Spells",
-                            "name": "hydraulic torrent",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "aqueous orb",
-                            "aonid": 1443,
-                            "game-obj": "Spells",
-                            "name": "aqueous orb",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "aqueous orb",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "feet to fins",
-                            "aonid": 1525,
-                            "game-obj": "Spells",
-                            "name": "feet to fins",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "feet to fins",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "acid grip",
-                            "aonid": 1436,
-                            "game-obj": "Spells",
-                            "name": "acid grip",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "acid grip",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "darkness",
-                            "aonid": 1480,
-                            "game-obj": "Spells",
-                            "name": "darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water breathing",
-                            "aonid": 1755,
-                            "game-obj": "Spells",
-                            "name": "water breathing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water breathing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "air bubble",
-                            "aonid": 1438,
-                            "game-obj": "Spells",
-                            "name": "air bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "air bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create water",
-                            "aonid": 1476,
-                            "game-obj": "Spells",
-                            "name": "create water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hydraulic push",
-                            "aonid": 1561,
-                            "game-obj": "Spells",
-                            "name": "hydraulic push",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hydraulic push",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "caustic blast",
-                            "aonid": 1461,
-                            "game-obj": "Spells",
-                            "name": "caustic blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spout",
-                            "aonid": 2031,
-                            "game-obj": "Spells",
-                            "name": "spout",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Brine Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "crashing wave",
+                "aonid": 1984,
+                "game-obj": "Spells",
+                "name": "crashing wave",
+                "type": "link"
+              },
+              {
+                "alt": "hydraulic torrent",
+                "aonid": 1562,
+                "game-obj": "Spells",
+                "name": "hydraulic torrent",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "aqueous orb",
+                "aonid": 1443,
+                "game-obj": "Spells",
+                "name": "aqueous orb",
+                "type": "link"
+              },
+              {
+                "alt": "feet to fins",
+                "aonid": 1525,
+                "game-obj": "Spells",
+                "name": "feet to fins",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "acid grip",
+                "aonid": 1436,
+                "game-obj": "Spells",
+                "name": "acid grip",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "water breathing",
+                "aonid": 1755,
+                "game-obj": "Spells",
+                "name": "water breathing",
+                "type": "link"
+              },
+              {
+                "alt": "air bubble",
+                "aonid": 1438,
+                "game-obj": "Spells",
+                "name": "air bubble",
+                "type": "link"
+              },
+              {
+                "alt": "create water",
+                "aonid": 1476,
+                "game-obj": "Spells",
+                "name": "create water",
+                "type": "link"
+              },
+              {
+                "alt": "hydraulic push",
+                "aonid": 1561,
+                "game-obj": "Spells",
+                "name": "hydraulic push",
+                "type": "link"
+              },
+              {
+                "alt": "caustic blast",
+                "aonid": 1461,
+                "game-obj": "Spells",
+                "name": "caustic blast",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "spout",
+                "aonid": 2031,
+                "game-obj": "Spells",
+                "name": "spout",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -401,152 +215,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young brine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 32,
-                  "subtype": "save_dc",
-                  "text": "DC 32",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "acid grip",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "control water",
-                            "aonid": 1473,
-                            "game-obj": "Spells",
-                            "name": "control water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "control water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "corrosive muck",
-                            "aonid": 1982,
-                            "game-obj": "Spells",
-                            "name": "corrosive muck",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "corrosive muck",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mariner\u2019s curse",
-                            "aonid": 1593,
-                            "game-obj": "Spells",
-                            "name": "mariner\u2019s curse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mariner\u2019s curse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Brine Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "control water",
+                "aonid": 1473,
+                "game-obj": "Spells",
+                "name": "control water",
+                "type": "link"
+              },
+              {
+                "alt": "corrosive muck",
+                "aonid": 1982,
+                "game-obj": "Spells",
+                "name": "corrosive muck",
+                "type": "link"
+              },
+              {
+                "alt": "mariner\u2019s curse",
+                "aonid": 1593,
+                "game-obj": "Spells",
+                "name": "mariner\u2019s curse",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -562,161 +265,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult brine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "migration",
-                            "aonid": 1600,
-                            "game-obj": "Spells",
-                            "name": "migration",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "migration",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "eclipse burst",
-                            "aonid": 1508,
-                            "game-obj": "Spells",
-                            "name": "eclipse burst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "eclipse burst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Brine Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "migration",
+                "aonid": 1600,
+                "game-obj": "Spells",
+                "name": "migration",
+                "type": "link"
+              },
+              {
+                "alt": "eclipse burst",
+                "aonid": 1508,
+                "game-obj": "Spells",
+                "name": "eclipse burst",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -732,117 +322,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient brine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wrathful storm",
-                            "aonid": 1759,
-                            "game-obj": "Spells",
-                            "name": "wrathful storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wrathful storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Brine Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "wrathful storm",
+                "aonid": 1759,
+                "game-obj": "Spells",
+                "name": "wrathful storm",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -857,48 +364,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -909,263 +379,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1175,7 +429,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1201,6 +454,1025 @@
         }
       ],
       "text": "Brine dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "crashing wave",
+          "aonid": 1984,
+          "game-obj": "Spells",
+          "name": "crashing wave",
+          "type": "link"
+        },
+        {
+          "alt": "hydraulic torrent",
+          "aonid": 1562,
+          "game-obj": "Spells",
+          "name": "hydraulic torrent",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "aqueous orb",
+          "aonid": 1443,
+          "game-obj": "Spells",
+          "name": "aqueous orb",
+          "type": "link"
+        },
+        {
+          "alt": "feet to fins",
+          "aonid": 1525,
+          "game-obj": "Spells",
+          "name": "feet to fins",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "acid grip",
+          "aonid": 1436,
+          "game-obj": "Spells",
+          "name": "acid grip",
+          "type": "link"
+        },
+        {
+          "alt": "darkness",
+          "aonid": 1480,
+          "game-obj": "Spells",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "water breathing",
+          "aonid": 1755,
+          "game-obj": "Spells",
+          "name": "water breathing",
+          "type": "link"
+        },
+        {
+          "alt": "air bubble",
+          "aonid": 1438,
+          "game-obj": "Spells",
+          "name": "air bubble",
+          "type": "link"
+        },
+        {
+          "alt": "create water",
+          "aonid": 1476,
+          "game-obj": "Spells",
+          "name": "create water",
+          "type": "link"
+        },
+        {
+          "alt": "hydraulic push",
+          "aonid": 1561,
+          "game-obj": "Spells",
+          "name": "hydraulic push",
+          "type": "link"
+        },
+        {
+          "alt": "caustic blast",
+          "aonid": 1461,
+          "game-obj": "Spells",
+          "name": "caustic blast",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "spout",
+          "aonid": 2031,
+          "game-obj": "Spells",
+          "name": "spout",
+          "type": "link"
+        }
+      ],
+      "name": "Young Brine Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 113",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 113",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 113,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "crashing wave",
+                      "aonid": 1984,
+                      "game-obj": "Spells",
+                      "name": "crashing wave",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "crashing wave",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hydraulic torrent",
+                      "aonid": 1562,
+                      "game-obj": "Spells",
+                      "name": "hydraulic torrent",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "aqueous orb",
+                      "aonid": 1443,
+                      "game-obj": "Spells",
+                      "name": "aqueous orb",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "aqueous orb",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "feet to fins",
+                      "aonid": 1525,
+                      "game-obj": "Spells",
+                      "name": "feet to fins",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "feet to fins",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "acid grip",
+                      "aonid": 1436,
+                      "game-obj": "Spells",
+                      "name": "acid grip",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "acid grip",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "darkness",
+                      "aonid": 1480,
+                      "game-obj": "Spells",
+                      "name": "darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water breathing",
+                      "aonid": 1755,
+                      "game-obj": "Spells",
+                      "name": "water breathing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water breathing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "air bubble",
+                      "aonid": 1438,
+                      "game-obj": "Spells",
+                      "name": "air bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "air bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create water",
+                      "aonid": 1476,
+                      "game-obj": "Spells",
+                      "name": "create water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hydraulic push",
+                      "aonid": 1561,
+                      "game-obj": "Spells",
+                      "name": "hydraulic push",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hydraulic push",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "caustic blast",
+                      "aonid": 1461,
+                      "game-obj": "Spells",
+                      "name": "caustic blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spout",
+                      "aonid": 2031,
+                      "game-obj": "Spells",
+                      "name": "spout",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 26, attack +18; **4th** *crashing wave*, *hydraulic torrent*, *unfettered movement*; **3rd** *aqueous orb*, *feet to fins*, *slow*; **2nd** *acid grip*, *darkness*, *water breathing*; **1st** *air bubble*, *create water*, *hydraulic push*; **Cantrips (3rd)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *spout*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "control water",
+          "aonid": 1473,
+          "game-obj": "Spells",
+          "name": "control water",
+          "type": "link"
+        },
+        {
+          "alt": "corrosive muck",
+          "aonid": 1982,
+          "game-obj": "Spells",
+          "name": "corrosive muck",
+          "type": "link"
+        },
+        {
+          "alt": "mariner\u2019s curse",
+          "aonid": 1593,
+          "game-obj": "Spells",
+          "name": "mariner\u2019s curse",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Brine Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 113",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 113",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 113,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young brine dragon"
+          ],
+          "saving_throw": {
+            "dc": 32,
+            "subtype": "save_dc",
+            "text": "DC 32",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "acid grip",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "control water",
+                      "aonid": 1473,
+                      "game-obj": "Spells",
+                      "name": "control water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "control water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "corrosive muck",
+                      "aonid": 1982,
+                      "game-obj": "Spells",
+                      "name": "corrosive muck",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "corrosive muck",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mariner\u2019s curse",
+                      "aonid": 1593,
+                      "game-obj": "Spells",
+                      "name": "mariner\u2019s curse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mariner\u2019s curse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 32, attack +24; As young brine dragon, plus **6th** *acid grip*, *hydraulic torrent*, *truesight*; **5th** *control water*, *corrosive muck*, *mariner\u2019s curse*; **Cantrips (6th)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *spout*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "migration",
+          "aonid": 1600,
+          "game-obj": "Spells",
+          "name": "migration",
+          "type": "link"
+        },
+        {
+          "alt": "eclipse burst",
+          "aonid": 1508,
+          "game-obj": "Spells",
+          "name": "eclipse burst",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Brine Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 113",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 113",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 113,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult brine dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "migration",
+                      "aonid": 1600,
+                      "game-obj": "Spells",
+                      "name": "migration",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "migration",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "eclipse burst",
+                      "aonid": 1508,
+                      "game-obj": "Spells",
+                      "name": "eclipse burst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "eclipse burst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 38, attack +30; As adult brine dragon, plus **8th** *desiccate*, *hydraulic torrent*, *migration*; **7th** *eclipse burst*, *energy aegis*, *regenerate*; **Cantrips (8th)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *spout*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "wrathful storm",
+          "aonid": 1759,
+          "game-obj": "Spells",
+          "name": "wrathful storm",
+          "type": "link"
+        }
+      ],
+      "name": "Brine Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 113",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 113",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 113,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient brine dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wrathful storm",
+                      "aonid": 1759,
+                      "game-obj": "Spells",
+                      "name": "wrathful storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wrathful storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 42, attack +34; As ancient brine dragon, plus **9th** *detonate magic*, *implosion*, *wrathful storm*; **Cantrips (9th)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *spout*",
       "type": "section"
     },
     {
@@ -1515,6 +1787,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 113",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 113",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 113,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1662,6 +1990,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 113",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 113",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 113,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_cloud.json
+++ b/monster_families/draconic_codex/dragon_cloud.json
@@ -65,309 +65,125 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "lightning bolt",
-                            "aonid": 1586,
-                            "game-obj": "Spells",
-                            "name": "lightning bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "lightning bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mirage",
-                            "aonid": 1604,
-                            "game-obj": "Spells",
-                            "name": "mirage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mirage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vapor form",
-                            "aonid": 1738,
-                            "game-obj": "Spells",
-                            "name": "vapor form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vapor form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "lightning bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 1560,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resist energy",
-                            "aonid": 1651,
-                            "game-obj": "Spells",
-                            "name": "resist energy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resist energy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sure footing",
-                            "aonid": 1708,
-                            "game-obj": "Spells",
-                            "name": "sure footing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sure footing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tailwind",
-                            "aonid": 1711,
-                            "game-obj": "Spells",
-                            "name": "tailwind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tailwind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "thunderstrike",
-                            "aonid": 1721,
-                            "game-obj": "Spells",
-                            "name": "thunderstrike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "thunderstrike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ventriloquism",
-                            "aonid": 1740,
-                            "game-obj": "Spells",
-                            "name": "ventriloquism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ventriloquism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 1509,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "frostbite",
-                            "aonid": 1539,
-                            "game-obj": "Spells",
-                            "name": "frostbite",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Cloud Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "lightning bolt",
+                "aonid": 1586,
+                "game-obj": "Spells",
+                "name": "lightning bolt",
+                "type": "link"
+              },
+              {
+                "alt": "mirage",
+                "aonid": 1604,
+                "game-obj": "Spells",
+                "name": "mirage",
+                "type": "link"
+              },
+              {
+                "alt": "vapor form",
+                "aonid": 1738,
+                "game-obj": "Spells",
+                "name": "vapor form",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 1560,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "resist energy",
+                "aonid": 1651,
+                "game-obj": "Spells",
+                "name": "resist energy",
+                "type": "link"
+              },
+              {
+                "alt": "sure footing",
+                "aonid": 1708,
+                "game-obj": "Spells",
+                "name": "sure footing",
+                "type": "link"
+              },
+              {
+                "alt": "tailwind",
+                "aonid": 1711,
+                "game-obj": "Spells",
+                "name": "tailwind",
+                "type": "link"
+              },
+              {
+                "alt": "thunderstrike",
+                "aonid": 1721,
+                "game-obj": "Spells",
+                "name": "thunderstrike",
+                "type": "link"
+              },
+              {
+                "alt": "ventriloquism",
+                "aonid": 1740,
+                "game-obj": "Spells",
+                "name": "ventriloquism",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 1509,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "frostbite",
+                "aonid": 1539,
+                "game-obj": "Spells",
+                "name": "frostbite",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -383,161 +199,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young cloud dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chain lightning",
-                            "aonid": 1462,
-                            "game-obj": "Spells",
-                            "name": "chain lightning",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chain lightning",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cursed metamorphosis",
-                            "aonid": 1479,
-                            "game-obj": "Spells",
-                            "name": "cursed metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cursed metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "howling blizzard",
-                            "aonid": 1559,
-                            "game-obj": "Spells",
-                            "name": "howling blizzard",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "howling blizzard",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "lightning bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Cloud Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "chain lightning",
+                "aonid": 1462,
+                "game-obj": "Spells",
+                "name": "chain lightning",
+                "type": "link"
+              },
+              {
+                "alt": "cursed metamorphosis",
+                "aonid": 1479,
+                "game-obj": "Spells",
+                "name": "cursed metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "howling blizzard",
+                "aonid": 1559,
+                "game-obj": "Spells",
+                "name": "howling blizzard",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -553,223 +256,76 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult cloud dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "metamorphosis",
-                            "aonid": 1599,
-                            "game-obj": "Spells",
-                            "name": "metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wrathful storm",
-                            "aonid": 1759,
-                            "game-obj": "Spells",
-                            "name": "wrathful storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wrathful storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "arctic rift",
-                            "aonid": 1444,
-                            "game-obj": "Spells",
-                            "name": "arctic rift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "arctic rift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "punishing winds",
-                            "aonid": 1643,
-                            "game-obj": "Spells",
-                            "name": "punishing winds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "punishing winds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "eclipse burst",
-                            "aonid": 1508,
-                            "game-obj": "Spells",
-                            "name": "eclipse burst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "eclipse burst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Cloud Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "metamorphosis",
+                "aonid": 1599,
+                "game-obj": "Spells",
+                "name": "metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "wrathful storm",
+                "aonid": 1759,
+                "game-obj": "Spells",
+                "name": "wrathful storm",
+                "type": "link"
+              },
+              {
+                "alt": "arctic rift",
+                "aonid": 1444,
+                "game-obj": "Spells",
+                "name": "arctic rift",
+                "type": "link"
+              },
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "punishing winds",
+                "aonid": 1643,
+                "game-obj": "Spells",
+                "name": "punishing winds",
+                "type": "link"
+              },
+              {
+                "alt": "eclipse burst",
+                "aonid": 1508,
+                "game-obj": "Spells",
+                "name": "eclipse burst",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -785,102 +341,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient cloud dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cataclysm",
-                            "aonid": 1460,
-                            "game-obj": "Spells",
-                            "name": "cataclysm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cataclysm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revival",
-                            "aonid": 1654,
-                            "game-obj": "Spells",
-                            "name": "revival",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revival",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Cloud Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cataclysm",
+                "aonid": 1460,
+                "game-obj": "Spells",
+                "name": "cataclysm",
+                "type": "link"
+              },
+              {
+                "alt": "revival",
+                "aonid": 1654,
+                "game-obj": "Spells",
+                "name": "revival",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -895,48 +376,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -947,263 +391,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1213,7 +441,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1239,6 +466,1093 @@
         }
       ],
       "text": "Cloud dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "lightning bolt",
+          "aonid": 1586,
+          "game-obj": "Spells",
+          "name": "lightning bolt",
+          "type": "link"
+        },
+        {
+          "alt": "mirage",
+          "aonid": 1604,
+          "game-obj": "Spells",
+          "name": "mirage",
+          "type": "link"
+        },
+        {
+          "alt": "vapor form",
+          "aonid": 1738,
+          "game-obj": "Spells",
+          "name": "vapor form",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 1560,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "resist energy",
+          "aonid": 1651,
+          "game-obj": "Spells",
+          "name": "resist energy",
+          "type": "link"
+        },
+        {
+          "alt": "sure footing",
+          "aonid": 1708,
+          "game-obj": "Spells",
+          "name": "sure footing",
+          "type": "link"
+        },
+        {
+          "alt": "tailwind",
+          "aonid": 1711,
+          "game-obj": "Spells",
+          "name": "tailwind",
+          "type": "link"
+        },
+        {
+          "alt": "thunderstrike",
+          "aonid": 1721,
+          "game-obj": "Spells",
+          "name": "thunderstrike",
+          "type": "link"
+        },
+        {
+          "alt": "ventriloquism",
+          "aonid": 1740,
+          "game-obj": "Spells",
+          "name": "ventriloquism",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 1509,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "frostbite",
+          "aonid": 1539,
+          "game-obj": "Spells",
+          "name": "frostbite",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Young Cloud Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 117",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 117",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 117,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "lightning bolt",
+                      "aonid": 1586,
+                      "game-obj": "Spells",
+                      "name": "lightning bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "lightning bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mirage",
+                      "aonid": 1604,
+                      "game-obj": "Spells",
+                      "name": "mirage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mirage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vapor form",
+                      "aonid": 1738,
+                      "game-obj": "Spells",
+                      "name": "vapor form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vapor form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "lightning bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 1560,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resist energy",
+                      "aonid": 1651,
+                      "game-obj": "Spells",
+                      "name": "resist energy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resist energy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sure footing",
+                      "aonid": 1708,
+                      "game-obj": "Spells",
+                      "name": "sure footing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sure footing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tailwind",
+                      "aonid": 1711,
+                      "game-obj": "Spells",
+                      "name": "tailwind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tailwind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "thunderstrike",
+                      "aonid": 1721,
+                      "game-obj": "Spells",
+                      "name": "thunderstrike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "thunderstrike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ventriloquism",
+                      "aonid": 1740,
+                      "game-obj": "Spells",
+                      "name": "ventriloquism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ventriloquism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 1509,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "frostbite",
+                      "aonid": 1539,
+                      "game-obj": "Spells",
+                      "name": "frostbite",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 29, attack +21; **4th** *lightning bolt*, *mirage*, *vapor form*; **3rd** *haste*, *lightning bolt*, *slow*; **2nd** *humanoid form*, *resist energy*, *sure footing*; **1st** *tailwind*, *thunderstrike*, *ventriloquism*; **Cantrips (4th)** *detect magic*, *electric arc*, *frostbite*, *prestidigitation*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "chain lightning",
+          "aonid": 1462,
+          "game-obj": "Spells",
+          "name": "chain lightning",
+          "type": "link"
+        },
+        {
+          "alt": "cursed metamorphosis",
+          "aonid": 1479,
+          "game-obj": "Spells",
+          "name": "cursed metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "howling blizzard",
+          "aonid": 1559,
+          "game-obj": "Spells",
+          "name": "howling blizzard",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Cloud Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 117",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 117",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 117,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young cloud dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chain lightning",
+                      "aonid": 1462,
+                      "game-obj": "Spells",
+                      "name": "chain lightning",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chain lightning",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cursed metamorphosis",
+                      "aonid": 1479,
+                      "game-obj": "Spells",
+                      "name": "cursed metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cursed metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "howling blizzard",
+                      "aonid": 1559,
+                      "game-obj": "Spells",
+                      "name": "howling blizzard",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "howling blizzard",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "lightning bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 34, attack +26; As young cloud dragon, plus **6th** *chain lightning*, *cursed metamorphosis*, *truesight*; **5th** *banishment*, *howling blizzard*, *lightning bolt*; **Cantrips (6th)** *detect magic*, *electric arc*, *frostbite*, *prestidigitation*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "metamorphosis",
+          "aonid": 1599,
+          "game-obj": "Spells",
+          "name": "metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "wrathful storm",
+          "aonid": 1759,
+          "game-obj": "Spells",
+          "name": "wrathful storm",
+          "type": "link"
+        },
+        {
+          "alt": "arctic rift",
+          "aonid": 1444,
+          "game-obj": "Spells",
+          "name": "arctic rift",
+          "type": "link"
+        },
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "punishing winds",
+          "aonid": 1643,
+          "game-obj": "Spells",
+          "name": "punishing winds",
+          "type": "link"
+        },
+        {
+          "alt": "eclipse burst",
+          "aonid": 1508,
+          "game-obj": "Spells",
+          "name": "eclipse burst",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Cloud Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 117",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 117",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 117,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult cloud dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "metamorphosis",
+                      "aonid": 1599,
+                      "game-obj": "Spells",
+                      "name": "metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wrathful storm",
+                      "aonid": 1759,
+                      "game-obj": "Spells",
+                      "name": "wrathful storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wrathful storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "arctic rift",
+                      "aonid": 1444,
+                      "game-obj": "Spells",
+                      "name": "arctic rift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "arctic rift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "punishing winds",
+                      "aonid": 1643,
+                      "game-obj": "Spells",
+                      "name": "punishing winds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "punishing winds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "eclipse burst",
+                      "aonid": 1508,
+                      "game-obj": "Spells",
+                      "name": "eclipse burst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "eclipse burst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +33; As adult cloud dragon, plus **9th** *falling stars*, *metamorphosis*, *wrathful storm*; **8th** *arctic rift*, *desiccate*, *punishing winds*; **7th** *eclipse burst*, *energy aegis*, *regenerate*; **Cantrips (9th)** *detect magic*, *electric arc*, *frostbite*, *prestidigitation*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cataclysm",
+          "aonid": 1460,
+          "game-obj": "Spells",
+          "name": "cataclysm",
+          "type": "link"
+        },
+        {
+          "alt": "revival",
+          "aonid": 1654,
+          "game-obj": "Spells",
+          "name": "revival",
+          "type": "link"
+        }
+      ],
+      "name": "Cloud Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 117",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 117",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 117,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient cloud dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cataclysm",
+                      "aonid": 1460,
+                      "game-obj": "Spells",
+                      "name": "cataclysm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cataclysm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revival",
+                      "aonid": 1654,
+                      "game-obj": "Spells",
+                      "name": "revival",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revival",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 45, attack +37; As ancient cloud dragon, plus **10th** *cataclysm*, *revival*; **Cantrips (10th)** *detect magic*, *electric arc*, *frostbite*, *prestidigitation*, *sigil*",
       "type": "section"
     },
     {
@@ -1553,6 +1867,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 117",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 117",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 117,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1700,6 +2070,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 117",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 117",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 117,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_crystal.json
+++ b/monster_families/draconic_codex/dragon_crystal.json
@@ -65,269 +65,125 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "4th mountain resilience",
-                  "shatter"
-                ],
-                "saving_throw": {
-                  "dc": 25,
-                  "subtype": "save_dc",
-                  "text": "DC 25",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 17,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cave fangs",
-                            "aonid": 1329,
-                            "game-obj": "Spells",
-                            "name": "cave fangs",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cave fangs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 1506,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "one with stone",
-                            "aonid": 1619,
-                            "game-obj": "Spells",
-                            "name": "one with stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "one with stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "burrow ward",
-                            "aonid": 1328,
-                            "game-obj": "Spells",
-                            "name": "burrow ward",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "burrow ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "everlight",
-                            "aonid": 1518,
-                            "game-obj": "Spells",
-                            "name": "everlight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "everlight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "expeditious excavation",
-                            "aonid": 2349,
-                            "game-obj": "Spells",
-                            "name": "expeditious excavation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "expeditious excavation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pummeling rubble",
-                            "aonid": 1642,
-                            "game-obj": "Spells",
-                            "name": "pummeling rubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pummeling rubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shattering gem",
-                            "aonid": 2364,
-                            "game-obj": "Spells",
-                            "name": "shattering gem",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shattering gem",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shockwave",
-                            "aonid": 2366,
-                            "game-obj": "Spells",
-                            "name": "shockwave",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shockwave",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "glass shield",
-                            "aonid": 1333,
-                            "game-obj": "Spells",
-                            "name": "glass shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "glass shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scatter scree",
-                            "aonid": 2021,
-                            "game-obj": "Spells",
-                            "name": "scatter scree",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scatter scree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tremor signs",
-                            "aonid": 1342,
-                            "game-obj": "Spells",
-                            "name": "tremor signs",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Crystal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mountain resilience",
+                "aonid": 1610,
+                "game-obj": "Spells",
+                "name": "mountain resilience",
+                "type": "link"
+              },
+              {
+                "alt": "shatter",
+                "aonid": 1670,
+                "game-obj": "Spells",
+                "name": "shatter",
+                "type": "link"
+              },
+              {
+                "alt": "cave fangs",
+                "aonid": 1329,
+                "game-obj": "Spells",
+                "name": "cave fangs",
+                "type": "link"
+              },
+              {
+                "alt": "earthbind",
+                "aonid": 1506,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "one with stone",
+                "aonid": 1619,
+                "game-obj": "Spells",
+                "name": "one with stone",
+                "type": "link"
+              },
+              {
+                "alt": "burrow ward",
+                "aonid": 1328,
+                "game-obj": "Spells",
+                "name": "burrow ward",
+                "type": "link"
+              },
+              {
+                "alt": "everlight",
+                "aonid": 1518,
+                "game-obj": "Spells",
+                "name": "everlight",
+                "type": "link"
+              },
+              {
+                "alt": "expeditious excavation",
+                "aonid": 2349,
+                "game-obj": "Spells",
+                "name": "expeditious excavation",
+                "type": "link"
+              },
+              {
+                "alt": "pummeling rubble",
+                "aonid": 1642,
+                "game-obj": "Spells",
+                "name": "pummeling rubble",
+                "type": "link"
+              },
+              {
+                "alt": "shattering gem",
+                "aonid": 2364,
+                "game-obj": "Spells",
+                "name": "shattering gem",
+                "type": "link"
+              },
+              {
+                "alt": "shockwave",
+                "aonid": 2366,
+                "game-obj": "Spells",
+                "name": "shockwave",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "glass shield",
+                "aonid": 1333,
+                "game-obj": "Spells",
+                "name": "glass shield",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "scatter scree",
+                "aonid": 2021,
+                "game-obj": "Spells",
+                "name": "scatter scree",
+                "type": "link"
+              },
+              {
+                "alt": "tremor signs",
+                "aonid": 1342,
+                "game-obj": "Spells",
+                "name": "tremor signs",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -343,178 +199,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young crystal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "petrify",
-                            "aonid": 1628,
-                            "game-obj": "Spells",
-                            "name": "petrify",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "petrify",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vitrifying blast",
-                            "aonid": 1344,
-                            "game-obj": "Spells",
-                            "name": "vitrifying blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vitrifying blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "creation",
-                            "aonid": 1477,
-                            "game-obj": "Spells",
-                            "name": "creation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "creation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "speak with stones",
-                            "aonid": 1682,
-                            "game-obj": "Spells",
-                            "name": "speak with stones",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "speak with stones",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of stone",
-                            "aonid": 1751,
-                            "game-obj": "Spells",
-                            "name": "wall of stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shape stone",
-                            "aonid": 1667,
-                            "game-obj": "Spells",
-                            "name": "shape stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shape stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "glass shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "scatter scree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Crystal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "petrify",
+                "aonid": 1628,
+                "game-obj": "Spells",
+                "name": "petrify",
+                "type": "link"
+              },
+              {
+                "alt": "vitrifying blast",
+                "aonid": 1344,
+                "game-obj": "Spells",
+                "name": "vitrifying blast",
+                "type": "link"
+              },
+              {
+                "alt": "creation",
+                "aonid": 1477,
+                "game-obj": "Spells",
+                "name": "creation",
+                "type": "link"
+              },
+              {
+                "alt": "speak with stones",
+                "aonid": 1682,
+                "game-obj": "Spells",
+                "name": "speak with stones",
+                "type": "link"
+              },
+              {
+                "alt": "wall of stone",
+                "aonid": 1751,
+                "game-obj": "Spells",
+                "name": "wall of stone",
+                "type": "link"
+              },
+              {
+                "alt": "shape stone",
+                "aonid": 1667,
+                "game-obj": "Spells",
+                "name": "shape stone",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -530,131 +263,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult crystal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 37,
-                  "subtype": "save_dc",
-                  "text": "DC 37",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 29,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "cave fangs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthquake",
-                            "aonid": 1507,
-                            "game-obj": "Spells",
-                            "name": "earthquake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthquake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 1607,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heaving earth",
-                            "aonid": 1335,
-                            "game-obj": "Spells",
-                            "name": "heaving earth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heaving earth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "glass shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "scatter scree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Crystal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "earthquake",
+                "aonid": 1507,
+                "game-obj": "Spells",
+                "name": "earthquake",
+                "type": "link"
+              },
+              {
+                "alt": "moment of renewal",
+                "aonid": 1607,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "heaving earth",
+                "aonid": 1335,
+                "game-obj": "Spells",
+                "name": "heaving earth",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -670,116 +306,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient crystal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "indestructibility",
-                            "aonid": 1573,
-                            "game-obj": "Spells",
-                            "name": "indestructibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "indestructibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "heaving earth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "glass shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "scatter scree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tremor signs",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Crystal Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -794,48 +341,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -846,263 +356,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1112,7 +406,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1138,6 +431,957 @@
         }
       ],
       "text": "Crystal dragon spell casters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "mountain resilience",
+          "aonid": 1610,
+          "game-obj": "Spells",
+          "name": "mountain resilience",
+          "type": "link"
+        },
+        {
+          "alt": "shatter",
+          "aonid": 1670,
+          "game-obj": "Spells",
+          "name": "shatter",
+          "type": "link"
+        },
+        {
+          "alt": "cave fangs",
+          "aonid": 1329,
+          "game-obj": "Spells",
+          "name": "cave fangs",
+          "type": "link"
+        },
+        {
+          "alt": "earthbind",
+          "aonid": 1506,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "one with stone",
+          "aonid": 1619,
+          "game-obj": "Spells",
+          "name": "one with stone",
+          "type": "link"
+        },
+        {
+          "alt": "burrow ward",
+          "aonid": 1328,
+          "game-obj": "Spells",
+          "name": "burrow ward",
+          "type": "link"
+        },
+        {
+          "alt": "everlight",
+          "aonid": 1518,
+          "game-obj": "Spells",
+          "name": "everlight",
+          "type": "link"
+        },
+        {
+          "alt": "expeditious excavation",
+          "aonid": 2349,
+          "game-obj": "Spells",
+          "name": "expeditious excavation",
+          "type": "link"
+        },
+        {
+          "alt": "pummeling rubble",
+          "aonid": 1642,
+          "game-obj": "Spells",
+          "name": "pummeling rubble",
+          "type": "link"
+        },
+        {
+          "alt": "shattering gem",
+          "aonid": 2364,
+          "game-obj": "Spells",
+          "name": "shattering gem",
+          "type": "link"
+        },
+        {
+          "alt": "shockwave",
+          "aonid": 2366,
+          "game-obj": "Spells",
+          "name": "shockwave",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "glass shield",
+          "aonid": 1333,
+          "game-obj": "Spells",
+          "name": "glass shield",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "scatter scree",
+          "aonid": 2021,
+          "game-obj": "Spells",
+          "name": "scatter scree",
+          "type": "link"
+        },
+        {
+          "alt": "tremor signs",
+          "aonid": 1342,
+          "game-obj": "Spells",
+          "name": "tremor signs",
+          "type": "link"
+        }
+      ],
+      "name": "Young Crystal Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 121",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 121",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "4th mountain resilience",
+            "shatter"
+          ],
+          "saving_throw": {
+            "dc": 25,
+            "subtype": "save_dc",
+            "text": "DC 25",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 17,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cave fangs",
+                      "aonid": 1329,
+                      "game-obj": "Spells",
+                      "name": "cave fangs",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cave fangs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 1506,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "one with stone",
+                      "aonid": 1619,
+                      "game-obj": "Spells",
+                      "name": "one with stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "one with stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "burrow ward",
+                      "aonid": 1328,
+                      "game-obj": "Spells",
+                      "name": "burrow ward",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "burrow ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "everlight",
+                      "aonid": 1518,
+                      "game-obj": "Spells",
+                      "name": "everlight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "everlight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "expeditious excavation",
+                      "aonid": 2349,
+                      "game-obj": "Spells",
+                      "name": "expeditious excavation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "expeditious excavation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pummeling rubble",
+                      "aonid": 1642,
+                      "game-obj": "Spells",
+                      "name": "pummeling rubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pummeling rubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shattering gem",
+                      "aonid": 2364,
+                      "game-obj": "Spells",
+                      "name": "shattering gem",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shattering gem",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shockwave",
+                      "aonid": 2366,
+                      "game-obj": "Spells",
+                      "name": "shockwave",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shockwave",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "glass shield",
+                      "aonid": 1333,
+                      "game-obj": "Spells",
+                      "name": "glass shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "glass shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scatter scree",
+                      "aonid": 2021,
+                      "game-obj": "Spells",
+                      "name": "scatter scree",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scatter scree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tremor signs",
+                      "aonid": 1342,
+                      "game-obj": "Spells",
+                      "name": "tremor signs",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 25, attack +17, **4th** *mountain resilience*, *shatter*; **3rd** *cave fangs*, *earthbind*, *one with stone*; **2nd** *burrow ward*, *everlight*, *expeditious excavation*; **1st** *pummeling rubble*, *shattering gem*, *shockwave*; **Cantrips (4th)** *detect magic*, *glass shield*, *light*, *scatter scree*, *tremor signs*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "petrify",
+          "aonid": 1628,
+          "game-obj": "Spells",
+          "name": "petrify",
+          "type": "link"
+        },
+        {
+          "alt": "vitrifying blast",
+          "aonid": 1344,
+          "game-obj": "Spells",
+          "name": "vitrifying blast",
+          "type": "link"
+        },
+        {
+          "alt": "creation",
+          "aonid": 1477,
+          "game-obj": "Spells",
+          "name": "creation",
+          "type": "link"
+        },
+        {
+          "alt": "speak with stones",
+          "aonid": 1682,
+          "game-obj": "Spells",
+          "name": "speak with stones",
+          "type": "link"
+        },
+        {
+          "alt": "wall of stone",
+          "aonid": 1751,
+          "game-obj": "Spells",
+          "name": "wall of stone",
+          "type": "link"
+        },
+        {
+          "alt": "shape stone",
+          "aonid": 1667,
+          "game-obj": "Spells",
+          "name": "shape stone",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Crystal Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 121",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 121",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young crystal dragon"
+          ],
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "petrify",
+                      "aonid": 1628,
+                      "game-obj": "Spells",
+                      "name": "petrify",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "petrify",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vitrifying blast",
+                      "aonid": 1344,
+                      "game-obj": "Spells",
+                      "name": "vitrifying blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vitrifying blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "creation",
+                      "aonid": 1477,
+                      "game-obj": "Spells",
+                      "name": "creation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "creation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "speak with stones",
+                      "aonid": 1682,
+                      "game-obj": "Spells",
+                      "name": "speak with stones",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "speak with stones",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of stone",
+                      "aonid": 1751,
+                      "game-obj": "Spells",
+                      "name": "wall of stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shape stone",
+                      "aonid": 1667,
+                      "game-obj": "Spells",
+                      "name": "shape stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shape stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "glass shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "scatter scree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 30, attack +22; As young crystal dragon, plus **6th** *petrify*, *vitrifying blast*; **5th** *creation*, *speak with stones*, *wall of stone*; **4th** *shape stone*; **Cantrips (6th)** *detect magic*, *glass shield*, *light*, *scatter scree*, *tremor signs*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "earthquake",
+          "aonid": 1507,
+          "game-obj": "Spells",
+          "name": "earthquake",
+          "type": "link"
+        },
+        {
+          "alt": "moment of renewal",
+          "aonid": 1607,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "heaving earth",
+          "aonid": 1335,
+          "game-obj": "Spells",
+          "name": "heaving earth",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Crystal Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 121",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 121",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult crystal dragon"
+          ],
+          "saving_throw": {
+            "dc": 37,
+            "subtype": "save_dc",
+            "text": "DC 37",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 29,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "cave fangs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthquake",
+                      "aonid": 1507,
+                      "game-obj": "Spells",
+                      "name": "earthquake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthquake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 1607,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heaving earth",
+                      "aonid": 1335,
+                      "game-obj": "Spells",
+                      "name": "heaving earth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heaving earth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "glass shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "scatter scree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 37, attack +29; As adult crystal dragon, plus **8th** *cave fangs*, *earthquake*, *moment of renewal*; **7th** *heaving earth*; **Cantrips (8th)** *detect magic*, *glass shield*, *light*, *scatter scree*, *tremor signs*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        }
+      ],
+      "name": "Crystal Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 121",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 121",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient crystal dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "indestructibility",
+                      "aonid": 1573,
+                      "game-obj": "Spells",
+                      "name": "indestructibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "indestructibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "heaving earth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "glass shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "scatter scree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tremor signs",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +33; As ancient crystal dragon, plus **10th** *indestructibility*; **9th** *heaving earth*, *implosion*; **Cantrips (10th)** *detect magic*, *glass shield*, *light*, *scatter scree*, *tremor signs*",
       "type": "section"
     },
     {
@@ -1452,6 +1696,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 121",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 121",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 121,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1599,6 +1899,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 121",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 121",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 121,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_delight.json
+++ b/monster_families/draconic_codex/dragon_delight.json
@@ -68,356 +68,146 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cleanse affliction",
-                            "aonid": 1467,
-                            "game-obj": "Spells",
-                            "name": "cleanse affliction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cleanse affliction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "noise blast",
-                            "aonid": 1616,
-                            "game-obj": "Spells",
-                            "name": "noise blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "noise blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vital beacon",
-                            "aonid": 1743,
-                            "game-obj": "Spells",
-                            "name": "vital beacon",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vital beacon",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cozy cabin",
-                            "aonid": 1474,
-                            "game-obj": "Spells",
-                            "name": "cozy cabin",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cozy cabin",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heroism",
-                            "aonid": 1555,
-                            "game-obj": "Spells",
-                            "name": "heroism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "locate",
-                            "aonid": 1588,
-                            "game-obj": "Spells",
-                            "name": "locate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "locate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "laughing fit",
-                            "aonid": 1583,
-                            "game-obj": "Spells",
-                            "name": "laughing fit",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "laughing fit",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "concordant choir",
-                            "aonid": 1979,
-                            "game-obj": "Spells",
-                            "name": "concordant choir",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "concordant choir",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "item facade",
-                            "aonid": 1579,
-                            "game-obj": "Spells",
-                            "name": "item facade",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "item facade",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ventriloquism",
-                            "aonid": 1740,
-                            "game-obj": "Spells",
-                            "name": "ventriloquism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ventriloquism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bullhorn",
-                            "aonid": 1971,
-                            "game-obj": "Spells",
-                            "name": "bullhorn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 1498,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "summon instrument",
-                            "aonid": 1703,
-                            "game-obj": "Spells",
-                            "name": "summon instrument",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Delight Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "cleanse affliction",
+                "aonid": 1467,
+                "game-obj": "Spells",
+                "name": "cleanse affliction",
+                "type": "link"
+              },
+              {
+                "alt": "noise blast",
+                "aonid": 1616,
+                "game-obj": "Spells",
+                "name": "noise blast",
+                "type": "link"
+              },
+              {
+                "alt": "vital beacon",
+                "aonid": 1743,
+                "game-obj": "Spells",
+                "name": "vital beacon",
+                "type": "link"
+              },
+              {
+                "alt": "cozy cabin",
+                "aonid": 1474,
+                "game-obj": "Spells",
+                "name": "cozy cabin",
+                "type": "link"
+              },
+              {
+                "alt": "heroism",
+                "aonid": 1555,
+                "game-obj": "Spells",
+                "name": "heroism",
+                "type": "link"
+              },
+              {
+                "alt": "locate",
+                "aonid": 1588,
+                "game-obj": "Spells",
+                "name": "locate",
+                "type": "link"
+              },
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "laughing fit",
+                "aonid": 1583,
+                "game-obj": "Spells",
+                "name": "laughing fit",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "concordant choir",
+                "aonid": 1979,
+                "game-obj": "Spells",
+                "name": "concordant choir",
+                "type": "link"
+              },
+              {
+                "alt": "item facade",
+                "aonid": 1579,
+                "game-obj": "Spells",
+                "name": "item facade",
+                "type": "link"
+              },
+              {
+                "alt": "ventriloquism",
+                "aonid": 1740,
+                "game-obj": "Spells",
+                "name": "ventriloquism",
+                "type": "link"
+              },
+              {
+                "alt": "bullhorn",
+                "aonid": 1971,
+                "game-obj": "Spells",
+                "name": "bullhorn",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 1498,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "summon instrument",
+                "aonid": 1703,
+                "game-obj": "Spells",
+                "name": "summon instrument",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -433,184 +223,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young delight dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sunburst",
-                            "aonid": 1707,
-                            "game-obj": "Spells",
-                            "name": "sunburst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sunburst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blessed boundary",
-                            "aonid": 1452,
-                            "game-obj": "Spells",
-                            "name": "blessed boundary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blessed boundary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit blast",
-                            "aonid": 1685,
-                            "game-obj": "Spells",
-                            "name": "spirit blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "breath of life",
-                            "aonid": 1456,
-                            "game-obj": "Spells",
-                            "name": "breath of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "breath of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Delight Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "sunburst",
+                "aonid": 1707,
+                "game-obj": "Spells",
+                "name": "sunburst",
+                "type": "link"
+              },
+              {
+                "alt": "blessed boundary",
+                "aonid": 1452,
+                "game-obj": "Spells",
+                "name": "blessed boundary",
+                "type": "link"
+              },
+              {
+                "alt": "spirit blast",
+                "aonid": 1685,
+                "game-obj": "Spells",
+                "name": "spirit blast",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "breath of life",
+                "aonid": 1456,
+                "game-obj": "Spells",
+                "name": "breath of life",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -626,146 +287,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult delight dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine decree",
-                            "aonid": 1495,
-                            "game-obj": "Spells",
-                            "name": "divine decree",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine decree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count_text": "\u00d72",
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 1607,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Delight Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine decree",
+                "aonid": 1495,
+                "game-obj": "Spells",
+                "name": "divine decree",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "moment of renewal",
+                "aonid": 1607,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -781,87 +337,20 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult delight dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gate",
-                            "aonid": 1540,
-                            "game-obj": "Spells",
-                            "name": "gate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Delight Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "gate",
+                "aonid": 1540,
+                "game-obj": "Spells",
+                "name": "gate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -876,48 +365,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -928,263 +380,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1194,7 +430,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1220,6 +455,1057 @@
         }
       ],
       "text": "Delight dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "cleanse affliction",
+          "aonid": 1467,
+          "game-obj": "Spells",
+          "name": "cleanse affliction",
+          "type": "link"
+        },
+        {
+          "alt": "noise blast",
+          "aonid": 1616,
+          "game-obj": "Spells",
+          "name": "noise blast",
+          "type": "link"
+        },
+        {
+          "alt": "vital beacon",
+          "aonid": 1743,
+          "game-obj": "Spells",
+          "name": "vital beacon",
+          "type": "link"
+        },
+        {
+          "alt": "cozy cabin",
+          "aonid": 1474,
+          "game-obj": "Spells",
+          "name": "cozy cabin",
+          "type": "link"
+        },
+        {
+          "alt": "heroism",
+          "aonid": 1555,
+          "game-obj": "Spells",
+          "name": "heroism",
+          "type": "link"
+        },
+        {
+          "alt": "locate",
+          "aonid": 1588,
+          "game-obj": "Spells",
+          "name": "locate",
+          "type": "link"
+        },
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "laughing fit",
+          "aonid": 1583,
+          "game-obj": "Spells",
+          "name": "laughing fit",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "concordant choir",
+          "aonid": 1979,
+          "game-obj": "Spells",
+          "name": "concordant choir",
+          "type": "link"
+        },
+        {
+          "alt": "item facade",
+          "aonid": 1579,
+          "game-obj": "Spells",
+          "name": "item facade",
+          "type": "link"
+        },
+        {
+          "alt": "ventriloquism",
+          "aonid": 1740,
+          "game-obj": "Spells",
+          "name": "ventriloquism",
+          "type": "link"
+        },
+        {
+          "alt": "bullhorn",
+          "aonid": 1971,
+          "game-obj": "Spells",
+          "name": "bullhorn",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 1498,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "summon instrument",
+          "aonid": 1703,
+          "game-obj": "Spells",
+          "name": "summon instrument",
+          "type": "link"
+        }
+      ],
+      "name": "Young Delight Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 125",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 125",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 125,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cleanse affliction",
+                      "aonid": 1467,
+                      "game-obj": "Spells",
+                      "name": "cleanse affliction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cleanse affliction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "noise blast",
+                      "aonid": 1616,
+                      "game-obj": "Spells",
+                      "name": "noise blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "noise blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vital beacon",
+                      "aonid": 1743,
+                      "game-obj": "Spells",
+                      "name": "vital beacon",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vital beacon",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cozy cabin",
+                      "aonid": 1474,
+                      "game-obj": "Spells",
+                      "name": "cozy cabin",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cozy cabin",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heroism",
+                      "aonid": 1555,
+                      "game-obj": "Spells",
+                      "name": "heroism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "locate",
+                      "aonid": 1588,
+                      "game-obj": "Spells",
+                      "name": "locate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "locate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "laughing fit",
+                      "aonid": 1583,
+                      "game-obj": "Spells",
+                      "name": "laughing fit",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "laughing fit",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "concordant choir",
+                      "aonid": 1979,
+                      "game-obj": "Spells",
+                      "name": "concordant choir",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "concordant choir",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "item facade",
+                      "aonid": 1579,
+                      "game-obj": "Spells",
+                      "name": "item facade",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "item facade",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ventriloquism",
+                      "aonid": 1740,
+                      "game-obj": "Spells",
+                      "name": "ventriloquism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ventriloquism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bullhorn",
+                      "aonid": 1971,
+                      "game-obj": "Spells",
+                      "name": "bullhorn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 1498,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "summon instrument",
+                      "aonid": 1703,
+                      "game-obj": "Spells",
+                      "name": "summon instrument",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 29, attack +21; **5th** *banishment*, *dispel magic*; **4th** *cleanse affliction*, *noise blast*, *vital beacon*; **3rd** *cozy cabin*, *heroism*, *locate*; **2nd** *clear mind*, *laughing fit*, *revealing light*; **1st** *concordant choir*, *item facade*, *ventriloquism*; **Cantrips (5th)** *bullhorn*, *detect magic*, *divine lance*, *prestidigitation*, *summon instrument*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "sunburst",
+          "aonid": 1707,
+          "game-obj": "Spells",
+          "name": "sunburst",
+          "type": "link"
+        },
+        {
+          "alt": "blessed boundary",
+          "aonid": 1452,
+          "game-obj": "Spells",
+          "name": "blessed boundary",
+          "type": "link"
+        },
+        {
+          "alt": "spirit blast",
+          "aonid": 1685,
+          "game-obj": "Spells",
+          "name": "spirit blast",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "breath of life",
+          "aonid": 1456,
+          "game-obj": "Spells",
+          "name": "breath of life",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Delight Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 125",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 125",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 125,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young delight dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sunburst",
+                      "aonid": 1707,
+                      "game-obj": "Spells",
+                      "name": "sunburst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sunburst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blessed boundary",
+                      "aonid": 1452,
+                      "game-obj": "Spells",
+                      "name": "blessed boundary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blessed boundary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit blast",
+                      "aonid": 1685,
+                      "game-obj": "Spells",
+                      "name": "spirit blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "breath of life",
+                      "aonid": 1456,
+                      "game-obj": "Spells",
+                      "name": "breath of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "breath of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 34, attack +26; As young delight dragon plus **7th** *dispel magic*, *regenerate*, *sunburst*; **6th** *blessed boundary*, *spirit blast*, *truesight*; **5th** *breath of life*; **Cantrips (7th)** *bullhorn*, *detect magic*, *divine lance*, *prestidigitation*, *summon instrument*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "divine decree",
+          "aonid": 1495,
+          "game-obj": "Spells",
+          "name": "divine decree",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "moment of renewal",
+          "aonid": 1607,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Delight Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 125",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 125",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 125,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult delight dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine decree",
+                      "aonid": 1495,
+                      "game-obj": "Spells",
+                      "name": "divine decree",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine decree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count_text": "\u00d72",
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 1607,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 41, attack +33; As adult delight dragon plus **9th** *dispel magic*, *divine decree*, *overwhelming presence*; **8th** *moment of renewal* (\u00d72), *pinpoint*; **Cantrips (9th)** *bullhorn*, *detect magic*, *divine lance*, *prestidigitation*, *summon instrument*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "gate",
+          "aonid": 1540,
+          "game-obj": "Spells",
+          "name": "gate",
+          "type": "link"
+        }
+      ],
+      "name": "Delight Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 125",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 125",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 125,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult delight dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gate",
+                      "aonid": 1540,
+                      "game-obj": "Spells",
+                      "name": "gate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 45, attack +37; As adult delight dragon plus **10th** *gate*; **Cantrips (10th)** *bullhorn*, *detect magic*, *divine lance*, *prestidigitation*, *summon instrument*",
       "type": "section"
     },
     {
@@ -1534,6 +1820,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 125",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 125",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 125,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1681,6 +2023,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 125",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 125",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 125,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_executor.json
+++ b/monster_families/draconic_codex/dragon_executor.json
@@ -103,300 +103,118 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine wrath",
-                            "aonid": 1499,
-                            "game-obj": "Spells",
-                            "name": "divine wrath",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine wrath",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spiritual armament",
-                            "aonid": 1687,
-                            "game-obj": "Spells",
-                            "name": "spiritual armament",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spiritual armament",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blindness",
-                            "aonid": 1453,
-                            "game-obj": "Spells",
-                            "name": "blindness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blindness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "holy light",
-                            "aonid": 1557,
-                            "game-obj": "Spells",
-                            "name": "holy light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "holy light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ring of truth",
-                            "aonid": 1656,
-                            "game-obj": "Spells",
-                            "name": "ring of truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ring of truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "deafness",
-                            "aonid": 1483,
-                            "game-obj": "Spells",
-                            "name": "deafness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "deafness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spiritual armament",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bless",
-                            "aonid": 1451,
-                            "game-obj": "Spells",
-                            "name": "bless",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bless",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "infuse vitality",
-                            "aonid": 1574,
-                            "game-obj": "Spells",
-                            "name": "infuse vitality",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "infuse vitality",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sanctuary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 1498,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Executor Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine wrath",
+                "aonid": 1499,
+                "game-obj": "Spells",
+                "name": "divine wrath",
+                "type": "link"
+              },
+              {
+                "alt": "spiritual armament",
+                "aonid": 1687,
+                "game-obj": "Spells",
+                "name": "spiritual armament",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "blindness",
+                "aonid": 1453,
+                "game-obj": "Spells",
+                "name": "blindness",
+                "type": "link"
+              },
+              {
+                "alt": "holy light",
+                "aonid": 1557,
+                "game-obj": "Spells",
+                "name": "holy light",
+                "type": "link"
+              },
+              {
+                "alt": "ring of truth",
+                "aonid": 1656,
+                "game-obj": "Spells",
+                "name": "ring of truth",
+                "type": "link"
+              },
+              {
+                "alt": "deafness",
+                "aonid": 1483,
+                "game-obj": "Spells",
+                "name": "deafness",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "bless",
+                "aonid": 1451,
+                "game-obj": "Spells",
+                "name": "bless",
+                "type": "link"
+              },
+              {
+                "alt": "infuse vitality",
+                "aonid": 1574,
+                "game-obj": "Spells",
+                "name": "infuse vitality",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 1498,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -412,152 +230,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young executor dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blessed boundary",
-                            "aonid": 1452,
-                            "game-obj": "Spells",
-                            "name": "blessed boundary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blessed boundary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit blast",
-                            "aonid": 1685,
-                            "game-obj": "Spells",
-                            "name": "spirit blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spiritual armament",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine immolation",
-                            "aonid": 1496,
-                            "game-obj": "Spells",
-                            "name": "divine immolation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine immolation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "holy light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spiritual guardian",
-                            "aonid": 1688,
-                            "game-obj": "Spells",
-                            "name": "spiritual guardian",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spiritual guardian",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Executor Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "blessed boundary",
+                "aonid": 1452,
+                "game-obj": "Spells",
+                "name": "blessed boundary",
+                "type": "link"
+              },
+              {
+                "alt": "spirit blast",
+                "aonid": 1685,
+                "game-obj": "Spells",
+                "name": "spirit blast",
+                "type": "link"
+              },
+              {
+                "alt": "divine immolation",
+                "aonid": 1496,
+                "game-obj": "Spells",
+                "name": "divine immolation",
+                "type": "link"
+              },
+              {
+                "alt": "spiritual guardian",
+                "aonid": 1688,
+                "game-obj": "Spells",
+                "name": "spiritual guardian",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -573,152 +280,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult executor dragon"
-                ],
-                "saving_throw": {
-                  "dc": 40,
-                  "subtype": "save_dc",
-                  "text": "DC 40",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "canticle of everlasting grief",
-                            "aonid": 1459,
-                            "game-obj": "Spells",
-                            "name": "canticle of everlasting grief",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "canticle of everlasting grief",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine inspiration",
-                            "aonid": 1497,
-                            "game-obj": "Spells",
-                            "name": "divine inspiration",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine inspiration",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spiritual armament",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine decree",
-                            "aonid": 1495,
-                            "game-obj": "Spells",
-                            "name": "divine decree",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine decree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "execute",
-                            "aonid": 1519,
-                            "game-obj": "Spells",
-                            "name": "execute",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "execute",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "holy light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Executor Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "canticle of everlasting grief",
+                "aonid": 1459,
+                "game-obj": "Spells",
+                "name": "canticle of everlasting grief",
+                "type": "link"
+              },
+              {
+                "alt": "divine inspiration",
+                "aonid": 1497,
+                "game-obj": "Spells",
+                "name": "divine inspiration",
+                "type": "link"
+              },
+              {
+                "alt": "divine decree",
+                "aonid": 1495,
+                "game-obj": "Spells",
+                "name": "divine decree",
+                "type": "link"
+              },
+              {
+                "alt": "execute",
+                "aonid": 1519,
+                "game-obj": "Spells",
+                "name": "execute",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -734,116 +330,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As ancient executor dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "divine decree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presenc",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presenc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Executor Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presenc",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presenc",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -858,48 +365,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -910,263 +380,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1176,7 +430,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1202,6 +455,969 @@
         }
       ],
       "text": "Executor dragon spellcasters might focus on holy or unholy spells, depending on their personality and sanctification. The following spell choices represent a holy executor dragon.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "divine wrath",
+          "aonid": 1499,
+          "game-obj": "Spells",
+          "name": "divine wrath",
+          "type": "link"
+        },
+        {
+          "alt": "spiritual armament",
+          "aonid": 1687,
+          "game-obj": "Spells",
+          "name": "spiritual armament",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "blindness",
+          "aonid": 1453,
+          "game-obj": "Spells",
+          "name": "blindness",
+          "type": "link"
+        },
+        {
+          "alt": "holy light",
+          "aonid": 1557,
+          "game-obj": "Spells",
+          "name": "holy light",
+          "type": "link"
+        },
+        {
+          "alt": "ring of truth",
+          "aonid": 1656,
+          "game-obj": "Spells",
+          "name": "ring of truth",
+          "type": "link"
+        },
+        {
+          "alt": "deafness",
+          "aonid": 1483,
+          "game-obj": "Spells",
+          "name": "deafness",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "bless",
+          "aonid": 1451,
+          "game-obj": "Spells",
+          "name": "bless",
+          "type": "link"
+        },
+        {
+          "alt": "infuse vitality",
+          "aonid": 1574,
+          "game-obj": "Spells",
+          "name": "infuse vitality",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 1498,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Young Executor Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 131",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 131",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine wrath",
+                      "aonid": 1499,
+                      "game-obj": "Spells",
+                      "name": "divine wrath",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine wrath",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spiritual armament",
+                      "aonid": 1687,
+                      "game-obj": "Spells",
+                      "name": "spiritual armament",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spiritual armament",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blindness",
+                      "aonid": 1453,
+                      "game-obj": "Spells",
+                      "name": "blindness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blindness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "holy light",
+                      "aonid": 1557,
+                      "game-obj": "Spells",
+                      "name": "holy light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "holy light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ring of truth",
+                      "aonid": 1656,
+                      "game-obj": "Spells",
+                      "name": "ring of truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ring of truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "deafness",
+                      "aonid": 1483,
+                      "game-obj": "Spells",
+                      "name": "deafness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "deafness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spiritual armament",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bless",
+                      "aonid": 1451,
+                      "game-obj": "Spells",
+                      "name": "bless",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bless",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "infuse vitality",
+                      "aonid": 1574,
+                      "game-obj": "Spells",
+                      "name": "infuse vitality",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "infuse vitality",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sanctuary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 1498,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 28, attack +20; **4th** *divine wrath*, *spiritual armament*, *unfettered movement*; **3rd** *blindness*, *holy light*, *ring of truth*; **2nd** *deafness*, *revealing light*, *spiritual armament*; **1st** *bless*, *infuse vitality*, **sanctuary**; **Cantrips (4th)** *detect magic*, *divine lance*, *guidance*, *light*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "blessed boundary",
+          "aonid": 1452,
+          "game-obj": "Spells",
+          "name": "blessed boundary",
+          "type": "link"
+        },
+        {
+          "alt": "spirit blast",
+          "aonid": 1685,
+          "game-obj": "Spells",
+          "name": "spirit blast",
+          "type": "link"
+        },
+        {
+          "alt": "divine immolation",
+          "aonid": 1496,
+          "game-obj": "Spells",
+          "name": "divine immolation",
+          "type": "link"
+        },
+        {
+          "alt": "spiritual guardian",
+          "aonid": 1688,
+          "game-obj": "Spells",
+          "name": "spiritual guardian",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Executor Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 131",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 131",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young executor dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blessed boundary",
+                      "aonid": 1452,
+                      "game-obj": "Spells",
+                      "name": "blessed boundary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blessed boundary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit blast",
+                      "aonid": 1685,
+                      "game-obj": "Spells",
+                      "name": "spirit blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spiritual armament",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine immolation",
+                      "aonid": 1496,
+                      "game-obj": "Spells",
+                      "name": "divine immolation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine immolation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "holy light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spiritual guardian",
+                      "aonid": 1688,
+                      "game-obj": "Spells",
+                      "name": "spiritual guardian",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spiritual guardian",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 33, attack +25; As young executor dragon, plus **6th** *blessed boundary*, *spirit blast*, *spiritual armament*; **5th** *divine immolation*, *holy light*, *spiritual guardian*; **Cantrips (6th)** *detect magic*, *divine lance*, *guidance*, *light*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "canticle of everlasting grief",
+          "aonid": 1459,
+          "game-obj": "Spells",
+          "name": "canticle of everlasting grief",
+          "type": "link"
+        },
+        {
+          "alt": "divine inspiration",
+          "aonid": 1497,
+          "game-obj": "Spells",
+          "name": "divine inspiration",
+          "type": "link"
+        },
+        {
+          "alt": "divine decree",
+          "aonid": 1495,
+          "game-obj": "Spells",
+          "name": "divine decree",
+          "type": "link"
+        },
+        {
+          "alt": "execute",
+          "aonid": 1519,
+          "game-obj": "Spells",
+          "name": "execute",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Executor Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 131",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 131",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult executor dragon"
+          ],
+          "saving_throw": {
+            "dc": 40,
+            "subtype": "save_dc",
+            "text": "DC 40",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "canticle of everlasting grief",
+                      "aonid": 1459,
+                      "game-obj": "Spells",
+                      "name": "canticle of everlasting grief",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "canticle of everlasting grief",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine inspiration",
+                      "aonid": 1497,
+                      "game-obj": "Spells",
+                      "name": "divine inspiration",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine inspiration",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spiritual armament",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine decree",
+                      "aonid": 1495,
+                      "game-obj": "Spells",
+                      "name": "divine decree",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine decree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "execute",
+                      "aonid": 1519,
+                      "game-obj": "Spells",
+                      "name": "execute",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "execute",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "holy light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 40, attack +32; As adult executor dragon, plus **8th** *canticle of everlasting grief*, *divine inspiration*, *spiritual armament*; **7th** *divine decree*, *execute*, *holy light*; **Cantrips (8th)** *detect magic*, *divine lance*, *guidance*, *light*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presenc",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presenc",
+          "type": "link"
+        }
+      ],
+      "name": "Executor Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 131",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 131",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As ancient executor dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "divine decree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presenc",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presenc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 44, attack +36; As ancient executor dragon, plus **10th** *divine decree*; **9th** *massacre*, *overwhelming presenc*e; **Cantrips (10th)** *detect magic*, *divine lance*, *guidance*, *light*, *shield*",
       "type": "section"
     },
     {
@@ -1516,6 +1732,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 131",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 131",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 131,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1663,6 +1935,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 131",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 131",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 131,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_forest.json
+++ b/monster_families/draconic_codex/dragon_forest.json
@@ -81,341 +81,139 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mirage",
-                            "aonid": 1604,
-                            "game-obj": "Spells",
-                            "name": "mirage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mirage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "speak with plants",
-                            "aonid": 1681,
-                            "game-obj": "Spells",
-                            "name": "speak with plants",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "speak with plants",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vapor form",
-                            "aonid": 1738,
-                            "game-obj": "Spells",
-                            "name": "vapor form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vapor form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "insect form",
-                            "aonid": 1575,
-                            "game-obj": "Spells",
-                            "name": "insect form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "insect form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mad monkeys",
-                            "aonid": 1590,
-                            "game-obj": "Spells",
-                            "name": "mad monkeys",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mad monkeys",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of thorns",
-                            "aonid": 1752,
-                            "game-obj": "Spells",
-                            "name": "wall of thorns",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of thorns",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "animal messenger",
-                            "aonid": 1441,
-                            "game-obj": "Spells",
-                            "name": "animal messenger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "animal messenger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "darkness",
-                            "aonid": 1480,
-                            "game-obj": "Spells",
-                            "name": "darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gecko grip",
-                            "aonid": 1541,
-                            "game-obj": "Spells",
-                            "name": "gecko grip",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gecko grip",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "goblin pox",
-                            "aonid": 1545,
-                            "game-obj": "Spells",
-                            "name": "goblin pox",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "goblin pox",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pest form",
-                            "aonid": 1626,
-                            "game-obj": "Spells",
-                            "name": "pest form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pest form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "weaken earth",
-                            "aonid": 1345,
-                            "game-obj": "Spells",
-                            "name": "weaken earth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "weaken earth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "caustic blast",
-                            "aonid": 1461,
-                            "game-obj": "Spells",
-                            "name": "caustic blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangle vine",
-                            "aonid": 1713,
-                            "game-obj": "Spells",
-                            "name": "tangle vine",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "plant growth",
-                            "aonid": 121,
-                            "game-obj": "Rituals",
-                            "name": "plant growth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "plant growth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Forest Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mirage",
+                "aonid": 1604,
+                "game-obj": "Spells",
+                "name": "mirage",
+                "type": "link"
+              },
+              {
+                "alt": "speak with plants",
+                "aonid": 1681,
+                "game-obj": "Spells",
+                "name": "speak with plants",
+                "type": "link"
+              },
+              {
+                "alt": "vapor form",
+                "aonid": 1738,
+                "game-obj": "Spells",
+                "name": "vapor form",
+                "type": "link"
+              },
+              {
+                "alt": "insect form",
+                "aonid": 1575,
+                "game-obj": "Spells",
+                "name": "insect form",
+                "type": "link"
+              },
+              {
+                "alt": "mad monkeys",
+                "aonid": 1590,
+                "game-obj": "Spells",
+                "name": "mad monkeys",
+                "type": "link"
+              },
+              {
+                "alt": "wall of thorns",
+                "aonid": 1752,
+                "game-obj": "Spells",
+                "name": "wall of thorns",
+                "type": "link"
+              },
+              {
+                "alt": "animal messenger",
+                "aonid": 1441,
+                "game-obj": "Spells",
+                "name": "animal messenger",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "gecko grip",
+                "aonid": 1541,
+                "game-obj": "Spells",
+                "name": "gecko grip",
+                "type": "link"
+              },
+              {
+                "alt": "goblin pox",
+                "aonid": 1545,
+                "game-obj": "Spells",
+                "name": "goblin pox",
+                "type": "link"
+              },
+              {
+                "alt": "pest form",
+                "aonid": 1626,
+                "game-obj": "Spells",
+                "name": "pest form",
+                "type": "link"
+              },
+              {
+                "alt": "weaken earth",
+                "aonid": 1345,
+                "game-obj": "Spells",
+                "name": "weaken earth",
+                "type": "link"
+              },
+              {
+                "alt": "caustic blast",
+                "aonid": 1461,
+                "game-obj": "Spells",
+                "name": "caustic blast",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tangle vine",
+                "aonid": 1713,
+                "game-obj": "Spells",
+                "name": "tangle vine",
+                "type": "link"
+              },
+              {
+                "alt": "plant growth",
+                "aonid": 121,
+                "game-obj": "Rituals",
+                "name": "plant growth",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -431,193 +229,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young forest dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cursed metamorphosis",
-                            "aonid": 1479,
-                            "game-obj": "Spells",
-                            "name": "cursed metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cursed metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "lignify",
-                            "aonid": 1404,
-                            "game-obj": "Spells",
-                            "name": "lignify",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "lignify",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangling creepers",
-                            "aonid": 1714,
-                            "game-obj": "Spells",
-                            "name": "tangling creepers",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangling creepers",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moon frenzy",
-                            "aonid": 1609,
-                            "game-obj": "Spells",
-                            "name": "moon frenzy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moon frenzy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nature\u2019s pathway",
-                            "aonid": 1613,
-                            "game-obj": "Spells",
-                            "name": "nature\u2019s pathway",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nature\u2019s pathway",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "primal call",
-                            "aonid": 122,
-                            "game-obj": "Rituals",
-                            "name": "primal call",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "primal call",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Forest Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cursed metamorphosis",
+                "aonid": 1479,
+                "game-obj": "Spells",
+                "name": "cursed metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "lignify",
+                "aonid": 1404,
+                "game-obj": "Spells",
+                "name": "lignify",
+                "type": "link"
+              },
+              {
+                "alt": "tangling creepers",
+                "aonid": 1714,
+                "game-obj": "Spells",
+                "name": "tangling creepers",
+                "type": "link"
+              },
+              {
+                "alt": "moon frenzy",
+                "aonid": 1609,
+                "game-obj": "Spells",
+                "name": "moon frenzy",
+                "type": "link"
+              },
+              {
+                "alt": "nature\u2019s pathway",
+                "aonid": 1613,
+                "game-obj": "Spells",
+                "name": "nature\u2019s pathway",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
+              },
+              {
+                "alt": "primal call",
+                "aonid": 122,
+                "game-obj": "Rituals",
+                "name": "primal call",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -633,208 +300,69 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult forest dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "punishing winds",
-                            "aonid": 1643,
-                            "game-obj": "Spells",
-                            "name": "punishing winds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "punishing winds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "rainbow fumarole",
-                            "aonid": 1361,
-                            "game-obj": "Spells",
-                            "name": "rainbow fumarole",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "rainbow fumarole",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "eclipse burst",
-                            "aonid": 1508,
-                            "game-obj": "Spells",
-                            "name": "eclipse burst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "eclipse burst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true target",
-                            "aonid": 1726,
-                            "game-obj": "Spells",
-                            "name": "true target",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true target",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Forest Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
+              },
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "punishing winds",
+                "aonid": 1643,
+                "game-obj": "Spells",
+                "name": "punishing winds",
+                "type": "link"
+              },
+              {
+                "alt": "rainbow fumarole",
+                "aonid": 1361,
+                "game-obj": "Spells",
+                "name": "rainbow fumarole",
+                "type": "link"
+              },
+              {
+                "alt": "eclipse burst",
+                "aonid": 1508,
+                "game-obj": "Spells",
+                "name": "eclipse burst",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "true target",
+                "aonid": 1726,
+                "game-obj": "Spells",
+                "name": "true target",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -850,125 +378,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient forest dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "indestructibility",
-                            "aonid": 1573,
-                            "game-obj": "Spells",
-                            "name": "indestructibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "indestructibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nature\u2019s enmity",
-                            "aonid": 2010,
-                            "game-obj": "Spells",
-                            "name": "nature\u2019s enmity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nature\u2019s enmity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Forest Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
+              },
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "nature\u2019s enmity",
+                "aonid": 2010,
+                "game-obj": "Spells",
+                "name": "nature\u2019s enmity",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -983,48 +420,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1035,263 +435,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1301,7 +485,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1327,6 +510,1193 @@
         }
       ],
       "text": "Forest dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "mirage",
+          "aonid": 1604,
+          "game-obj": "Spells",
+          "name": "mirage",
+          "type": "link"
+        },
+        {
+          "alt": "speak with plants",
+          "aonid": 1681,
+          "game-obj": "Spells",
+          "name": "speak with plants",
+          "type": "link"
+        },
+        {
+          "alt": "vapor form",
+          "aonid": 1738,
+          "game-obj": "Spells",
+          "name": "vapor form",
+          "type": "link"
+        },
+        {
+          "alt": "insect form",
+          "aonid": 1575,
+          "game-obj": "Spells",
+          "name": "insect form",
+          "type": "link"
+        },
+        {
+          "alt": "mad monkeys",
+          "aonid": 1590,
+          "game-obj": "Spells",
+          "name": "mad monkeys",
+          "type": "link"
+        },
+        {
+          "alt": "wall of thorns",
+          "aonid": 1752,
+          "game-obj": "Spells",
+          "name": "wall of thorns",
+          "type": "link"
+        },
+        {
+          "alt": "animal messenger",
+          "aonid": 1441,
+          "game-obj": "Spells",
+          "name": "animal messenger",
+          "type": "link"
+        },
+        {
+          "alt": "darkness",
+          "aonid": 1480,
+          "game-obj": "Spells",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "gecko grip",
+          "aonid": 1541,
+          "game-obj": "Spells",
+          "name": "gecko grip",
+          "type": "link"
+        },
+        {
+          "alt": "goblin pox",
+          "aonid": 1545,
+          "game-obj": "Spells",
+          "name": "goblin pox",
+          "type": "link"
+        },
+        {
+          "alt": "pest form",
+          "aonid": 1626,
+          "game-obj": "Spells",
+          "name": "pest form",
+          "type": "link"
+        },
+        {
+          "alt": "weaken earth",
+          "aonid": 1345,
+          "game-obj": "Spells",
+          "name": "weaken earth",
+          "type": "link"
+        },
+        {
+          "alt": "caustic blast",
+          "aonid": 1461,
+          "game-obj": "Spells",
+          "name": "caustic blast",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tangle vine",
+          "aonid": 1713,
+          "game-obj": "Spells",
+          "name": "tangle vine",
+          "type": "link"
+        },
+        {
+          "alt": "plant growth",
+          "aonid": 121,
+          "game-obj": "Rituals",
+          "name": "plant growth",
+          "type": "link"
+        }
+      ],
+      "name": "Young Forest Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 135",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 135",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 135,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mirage",
+                      "aonid": 1604,
+                      "game-obj": "Spells",
+                      "name": "mirage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mirage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "speak with plants",
+                      "aonid": 1681,
+                      "game-obj": "Spells",
+                      "name": "speak with plants",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "speak with plants",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vapor form",
+                      "aonid": 1738,
+                      "game-obj": "Spells",
+                      "name": "vapor form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vapor form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "insect form",
+                      "aonid": 1575,
+                      "game-obj": "Spells",
+                      "name": "insect form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "insect form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mad monkeys",
+                      "aonid": 1590,
+                      "game-obj": "Spells",
+                      "name": "mad monkeys",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mad monkeys",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of thorns",
+                      "aonid": 1752,
+                      "game-obj": "Spells",
+                      "name": "wall of thorns",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of thorns",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "animal messenger",
+                      "aonid": 1441,
+                      "game-obj": "Spells",
+                      "name": "animal messenger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "animal messenger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "darkness",
+                      "aonid": 1480,
+                      "game-obj": "Spells",
+                      "name": "darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gecko grip",
+                      "aonid": 1541,
+                      "game-obj": "Spells",
+                      "name": "gecko grip",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gecko grip",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "goblin pox",
+                      "aonid": 1545,
+                      "game-obj": "Spells",
+                      "name": "goblin pox",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "goblin pox",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pest form",
+                      "aonid": 1626,
+                      "game-obj": "Spells",
+                      "name": "pest form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pest form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "weaken earth",
+                      "aonid": 1345,
+                      "game-obj": "Spells",
+                      "name": "weaken earth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "weaken earth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "caustic blast",
+                      "aonid": 1461,
+                      "game-obj": "Spells",
+                      "name": "caustic blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangle vine",
+                      "aonid": 1713,
+                      "game-obj": "Spells",
+                      "name": "tangle vine",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "plant growth",
+                      "aonid": 121,
+                      "game-obj": "Rituals",
+                      "name": "plant growth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "plant growth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 29, attack +21; **4th** *mirage*, *speak with plants*, *vapor form*; **3rd** *insect form*, *mad monkeys*, *wall of thorns*; **2nd** *animal messenger*, *darkness*, *gecko grip*; **1st** *goblin pox*, *pest form*, *weaken earth*; **Cantrips (4th)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *tangle vine*; **Rituals** DC 29; *plant growth*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cursed metamorphosis",
+          "aonid": 1479,
+          "game-obj": "Spells",
+          "name": "cursed metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "lignify",
+          "aonid": 1404,
+          "game-obj": "Spells",
+          "name": "lignify",
+          "type": "link"
+        },
+        {
+          "alt": "tangling creepers",
+          "aonid": 1714,
+          "game-obj": "Spells",
+          "name": "tangling creepers",
+          "type": "link"
+        },
+        {
+          "alt": "moon frenzy",
+          "aonid": 1609,
+          "game-obj": "Spells",
+          "name": "moon frenzy",
+          "type": "link"
+        },
+        {
+          "alt": "nature\u2019s pathway",
+          "aonid": 1613,
+          "game-obj": "Spells",
+          "name": "nature\u2019s pathway",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        },
+        {
+          "alt": "primal call",
+          "aonid": 122,
+          "game-obj": "Rituals",
+          "name": "primal call",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Forest Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 135",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 135",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 135,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young forest dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cursed metamorphosis",
+                      "aonid": 1479,
+                      "game-obj": "Spells",
+                      "name": "cursed metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cursed metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "lignify",
+                      "aonid": 1404,
+                      "game-obj": "Spells",
+                      "name": "lignify",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "lignify",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangling creepers",
+                      "aonid": 1714,
+                      "game-obj": "Spells",
+                      "name": "tangling creepers",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangling creepers",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moon frenzy",
+                      "aonid": 1609,
+                      "game-obj": "Spells",
+                      "name": "moon frenzy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moon frenzy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nature\u2019s pathway",
+                      "aonid": 1613,
+                      "game-obj": "Spells",
+                      "name": "nature\u2019s pathway",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nature\u2019s pathway",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "primal call",
+                      "aonid": 122,
+                      "game-obj": "Rituals",
+                      "name": "primal call",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "primal call",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 34, attack +26; As young forest dragon, plus **6th** *cursed metamorphosis*, *lignify*, *tangling creepers*; **5th** *moon frenzy*, *nature\u2019s pathway*, *toxic cloud*; **Cantrips (6th)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *tangle vine*; **Rituals** DC 34; *primal call*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        },
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "punishing winds",
+          "aonid": 1643,
+          "game-obj": "Spells",
+          "name": "punishing winds",
+          "type": "link"
+        },
+        {
+          "alt": "rainbow fumarole",
+          "aonid": 1361,
+          "game-obj": "Spells",
+          "name": "rainbow fumarole",
+          "type": "link"
+        },
+        {
+          "alt": "eclipse burst",
+          "aonid": 1508,
+          "game-obj": "Spells",
+          "name": "eclipse burst",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "true target",
+          "aonid": 1726,
+          "game-obj": "Spells",
+          "name": "true target",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Forest Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 135",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 135",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 135,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult forest dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "punishing winds",
+                      "aonid": 1643,
+                      "game-obj": "Spells",
+                      "name": "punishing winds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "punishing winds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "rainbow fumarole",
+                      "aonid": 1361,
+                      "game-obj": "Spells",
+                      "name": "rainbow fumarole",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "rainbow fumarole",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "eclipse burst",
+                      "aonid": 1508,
+                      "game-obj": "Spells",
+                      "name": "eclipse burst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "eclipse burst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true target",
+                      "aonid": 1726,
+                      "game-obj": "Spells",
+                      "name": "true target",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true target",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +33; As adult forest dragon, plus **9th** *implosion*, *massacre*; **8th** *desiccate*, *punishing winds*, *rainbow fumarole*; **7th** *eclipse burst*, *regenerate*, *true target*; **Cantrips (9th)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        },
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "nature\u2019s enmity",
+          "aonid": 2010,
+          "game-obj": "Spells",
+          "name": "nature\u2019s enmity",
+          "type": "link"
+        }
+      ],
+      "name": "Forest Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 135",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 135",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 135,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient forest dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "indestructibility",
+                      "aonid": 1573,
+                      "game-obj": "Spells",
+                      "name": "indestructibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "indestructibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nature\u2019s enmity",
+                      "aonid": 2010,
+                      "game-obj": "Spells",
+                      "name": "nature\u2019s enmity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nature\u2019s enmity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 45, attack +37; As ancient forest dragon, plus **10th** *indestructibility*, *manifestation*; **9th** *nature\u2019s enmity*; **Cantrips (10th)** *caustic blast*, *detect magic*, *guidance*, *read aura*, *tangle vine*",
       "type": "section"
     },
     {
@@ -1641,6 +2011,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 135",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 135",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 135,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1788,6 +2214,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 135",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 135",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 135,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_magma.json
+++ b/monster_families/draconic_codex/dragon_magma.json
@@ -65,306 +65,125 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "28"
-                ],
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fireball",
-                            "aonid": 1530,
-                            "game-obj": "Spells",
-                            "name": "fireball",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mountain resilience",
-                            "aonid": 1610,
-                            "game-obj": "Spells",
-                            "name": "mountain resilience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mountain resilience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of fire",
-                            "aonid": 1748,
-                            "game-obj": "Spells",
-                            "name": "wall of fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sound body",
-                            "aonid": 1679,
-                            "game-obj": "Spells",
-                            "name": "sound body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sound body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "air bubble",
-                            "aonid": 1438,
-                            "game-obj": "Spells",
-                            "name": "air bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "air bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 1547,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vanishing tracks",
-                            "aonid": 1737,
-                            "game-obj": "Spells",
-                            "name": "vanishing tracks",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vanishing tracks",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ignition",
-                            "aonid": 1565,
-                            "game-obj": "Spells",
-                            "name": "ignition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Magma Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fireball",
+                "aonid": 1530,
+                "game-obj": "Spells",
+                "name": "fireball",
+                "type": "link"
+              },
+              {
+                "alt": "mountain resilience",
+                "aonid": 1610,
+                "game-obj": "Spells",
+                "name": "mountain resilience",
+                "type": "link"
+              },
+              {
+                "alt": "wall of fire",
+                "aonid": 1748,
+                "game-obj": "Spells",
+                "name": "wall of fire",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "sound body",
+                "aonid": 1679,
+                "game-obj": "Spells",
+                "name": "sound body",
+                "type": "link"
+              },
+              {
+                "alt": "air bubble",
+                "aonid": 1438,
+                "game-obj": "Spells",
+                "name": "air bubble",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 1547,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "vanishing tracks",
+                "aonid": 1737,
+                "game-obj": "Spells",
+                "name": "vanishing tracks",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "ignition",
+                "aonid": 1565,
+                "game-obj": "Spells",
+                "name": "ignition",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -380,152 +199,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as young magma dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "petrify",
-                            "aonid": 1628,
-                            "game-obj": "Spells",
-                            "name": "petrify",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "petrify",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of stone",
-                            "aonid": 1751,
-                            "game-obj": "Spells",
-                            "name": "wall of stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Magma Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "petrify",
+                "aonid": 1628,
+                "game-obj": "Spells",
+                "name": "petrify",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
+              },
+              {
+                "alt": "wall of stone",
+                "aonid": 1751,
+                "game-obj": "Spells",
+                "name": "wall of stone",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -541,152 +249,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as adult magma dragon"
-                ],
-                "saving_throw": {
-                  "dc": 40,
-                  "subtype": "save_dc",
-                  "text": "DC 40",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthquake",
-                            "aonid": 1507,
-                            "game-obj": "Spells",
-                            "name": "earthquake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthquake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fiery body",
-                            "aonid": 1527,
-                            "game-obj": "Spells",
-                            "name": "fiery body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fiery body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "volcanic eruption",
-                            "aonid": 1746,
-                            "game-obj": "Spells",
-                            "name": "volcanic eruption",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "volcanic eruption",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Magma Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "earthquake",
+                "aonid": 1507,
+                "game-obj": "Spells",
+                "name": "earthquake",
+                "type": "link"
+              },
+              {
+                "alt": "fiery body",
+                "aonid": 1527,
+                "game-obj": "Spells",
+                "name": "fiery body",
+                "type": "link"
+              },
+              {
+                "alt": "volcanic eruption",
+                "aonid": 1746,
+                "game-obj": "Spells",
+                "name": "volcanic eruption",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -702,102 +299,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as ancient magma dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Magma Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -812,48 +334,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -864,263 +349,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1130,7 +399,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1156,6 +424,968 @@
         }
       ],
       "text": "Magma dragon spellcasters often know the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fireball",
+          "aonid": 1530,
+          "game-obj": "Spells",
+          "name": "fireball",
+          "type": "link"
+        },
+        {
+          "alt": "mountain resilience",
+          "aonid": 1610,
+          "game-obj": "Spells",
+          "name": "mountain resilience",
+          "type": "link"
+        },
+        {
+          "alt": "wall of fire",
+          "aonid": 1748,
+          "game-obj": "Spells",
+          "name": "wall of fire",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "sound body",
+          "aonid": 1679,
+          "game-obj": "Spells",
+          "name": "sound body",
+          "type": "link"
+        },
+        {
+          "alt": "air bubble",
+          "aonid": 1438,
+          "game-obj": "Spells",
+          "name": "air bubble",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 1547,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "vanishing tracks",
+          "aonid": 1737,
+          "game-obj": "Spells",
+          "name": "vanishing tracks",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "ignition",
+          "aonid": 1565,
+          "game-obj": "Spells",
+          "name": "ignition",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Young Magma Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 139",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 139",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 139,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "28"
+          ],
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fireball",
+                      "aonid": 1530,
+                      "game-obj": "Spells",
+                      "name": "fireball",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mountain resilience",
+                      "aonid": 1610,
+                      "game-obj": "Spells",
+                      "name": "mountain resilience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mountain resilience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of fire",
+                      "aonid": 1748,
+                      "game-obj": "Spells",
+                      "name": "wall of fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sound body",
+                      "aonid": 1679,
+                      "game-obj": "Spells",
+                      "name": "sound body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sound body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "air bubble",
+                      "aonid": 1438,
+                      "game-obj": "Spells",
+                      "name": "air bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "air bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 1547,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vanishing tracks",
+                      "aonid": 1737,
+                      "game-obj": "Spells",
+                      "name": "vanishing tracks",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vanishing tracks",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ignition",
+                      "aonid": 1565,
+                      "game-obj": "Spells",
+                      "name": "ignition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells DC** 28, attack +20; **4th** *fireball*, *mountain resilience*, *wall of fire*; **3rd** *fireball*, *haste*, *slow*; **2nd** *mist*, *revealing light*, *sound body*; **1st** *air bubble*, *grease*, *vanishing tracks*; **Cantrips (4th)** *detect magic*, *ignition*, *prestidigitation*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "petrify",
+          "aonid": 1628,
+          "game-obj": "Spells",
+          "name": "petrify",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        },
+        {
+          "alt": "wall of stone",
+          "aonid": 1751,
+          "game-obj": "Spells",
+          "name": "wall of stone",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Magma Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 139",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 139",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 139,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as young magma dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "petrify",
+                      "aonid": 1628,
+                      "game-obj": "Spells",
+                      "name": "petrify",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "petrify",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of stone",
+                      "aonid": 1751,
+                      "game-obj": "Spells",
+                      "name": "wall of stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 33, attack +25; as young magma dragon, plus **6th** *fireball*, *petrify*, *truesight*; **5th** *fireball*, *toxic cloud*, *wall of stone*; **Cantrips (6th)** *detect magic*, *ignition*, *prestidigitation*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "earthquake",
+          "aonid": 1507,
+          "game-obj": "Spells",
+          "name": "earthquake",
+          "type": "link"
+        },
+        {
+          "alt": "fiery body",
+          "aonid": 1527,
+          "game-obj": "Spells",
+          "name": "fiery body",
+          "type": "link"
+        },
+        {
+          "alt": "volcanic eruption",
+          "aonid": 1746,
+          "game-obj": "Spells",
+          "name": "volcanic eruption",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Magma Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 139",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 139",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 139,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as adult magma dragon"
+          ],
+          "saving_throw": {
+            "dc": 40,
+            "subtype": "save_dc",
+            "text": "DC 40",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthquake",
+                      "aonid": 1507,
+                      "game-obj": "Spells",
+                      "name": "earthquake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthquake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fiery body",
+                      "aonid": 1527,
+                      "game-obj": "Spells",
+                      "name": "fiery body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fiery body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "volcanic eruption",
+                      "aonid": 1746,
+                      "game-obj": "Spells",
+                      "name": "volcanic eruption",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "volcanic eruption",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 40, attack +32; as adult magma dragon, plus **8th** *desiccate*, *earthquake*, *fireball*; **7th** *fiery body*, *fireball*, *volcanic eruption*; **Cantrips (8th)** *detect magic*, *ignition*, *prestidigitation*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        }
+      ],
+      "name": "Magma Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 139",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 139",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 139,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as ancient magma dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 44, attack +36; as ancient magma dragon, plus **9th** *falling stars*, *massacre*; **Cantrips (9th)** *detect magic*, *ignition*, *prestidigitation*, *read aura*, *sigil*",
       "type": "section"
     },
     {
@@ -1470,6 +1700,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 139",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 139",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 139,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1617,6 +1903,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 139",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 139",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 139,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_mocking.json
+++ b/monster_families/draconic_codex/dragon_mocking.json
@@ -65,318 +65,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mirage",
-                            "aonid": 1604,
-                            "game-obj": "Spells",
-                            "name": "mirage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mirage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hypnotize",
-                            "aonid": 1564,
-                            "game-obj": "Spells",
-                            "name": "hypnotize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hypnotize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "paralyze",
-                            "aonid": 1622,
-                            "game-obj": "Spells",
-                            "name": "paralyze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "paralyze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blur",
-                            "aonid": 1455,
-                            "game-obj": "Spells",
-                            "name": "blur",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blur",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory creature",
-                            "aonid": 1567,
-                            "game-obj": "Spells",
-                            "name": "illusory creature",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "illusory creature",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal treasure",
-                            "aonid": 2013,
-                            "game-obj": "Spells",
-                            "name": "phantasmal treasure",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal treasure",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dizzying colors",
-                            "aonid": 1500,
-                            "game-obj": "Spells",
-                            "name": "dizzying colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dizzying colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sleep",
-                            "aonid": 1675,
-                            "game-obj": "Spells",
-                            "name": "sleep",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sleep",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "summon instrument",
-                            "aonid": 1703,
-                            "game-obj": "Spells",
-                            "name": "summon instrument",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 1718,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Mocking Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "mirage",
+                "aonid": 1604,
+                "game-obj": "Spells",
+                "name": "mirage",
+                "type": "link"
+              },
+              {
+                "alt": "hypnotize",
+                "aonid": 1564,
+                "game-obj": "Spells",
+                "name": "hypnotize",
+                "type": "link"
+              },
+              {
+                "alt": "paralyze",
+                "aonid": 1622,
+                "game-obj": "Spells",
+                "name": "paralyze",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "blur",
+                "aonid": 1455,
+                "game-obj": "Spells",
+                "name": "blur",
+                "type": "link"
+              },
+              {
+                "alt": "illusory creature",
+                "aonid": 1567,
+                "game-obj": "Spells",
+                "name": "illusory creature",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal treasure",
+                "aonid": 2013,
+                "game-obj": "Spells",
+                "name": "phantasmal treasure",
+                "type": "link"
+              },
+              {
+                "alt": "dizzying colors",
+                "aonid": 1500,
+                "game-obj": "Spells",
+                "name": "dizzying colors",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 1675,
+                "game-obj": "Spells",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "summon instrument",
+                "aonid": 1703,
+                "game-obj": "Spells",
+                "name": "summon instrument",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 1718,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -392,170 +206,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young mocking dragon"
-                ],
-                "saving_throw": {
-                  "dc": 32,
-                  "subtype": "save_dc",
-                  "text": "DC 32",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cursed metamorphosis",
-                            "aonid": 1479,
-                            "game-obj": "Spells",
-                            "name": "cursed metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cursed metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vibrant pattern",
-                            "aonid": 1741,
-                            "game-obj": "Spells",
-                            "name": "vibrant pattern",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vibrant pattern",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cloak of colors",
-                            "aonid": 1977,
-                            "game-obj": "Spells",
-                            "name": "cloak of colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cloak of colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "strange geometry",
-                            "aonid": 2032,
-                            "game-obj": "Spells",
-                            "name": "strange geometry",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "strange geometry",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "synesthesia",
-                            "aonid": 2035,
-                            "game-obj": "Spells",
-                            "name": "synesthesia",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "synesthesia",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Mocking Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cursed metamorphosis",
+                "aonid": 1479,
+                "game-obj": "Spells",
+                "name": "cursed metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "vibrant pattern",
+                "aonid": 1741,
+                "game-obj": "Spells",
+                "name": "vibrant pattern",
+                "type": "link"
+              },
+              {
+                "alt": "cloak of colors",
+                "aonid": 1977,
+                "game-obj": "Spells",
+                "name": "cloak of colors",
+                "type": "link"
+              },
+              {
+                "alt": "strange geometry",
+                "aonid": 2032,
+                "game-obj": "Spells",
+                "name": "strange geometry",
+                "type": "link"
+              },
+              {
+                "alt": "synesthesia",
+                "aonid": 2035,
+                "game-obj": "Spells",
+                "name": "synesthesia",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -571,170 +270,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult mocking dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusing colors",
-                            "aonid": 1980,
-                            "game-obj": "Spells",
-                            "name": "confusing colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusing colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "quandary",
-                            "aonid": 1644,
-                            "game-obj": "Spells",
-                            "name": "quandary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "quandary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "uncontrollable dance",
-                            "aonid": 1730,
-                            "game-obj": "Spells",
-                            "name": "uncontrollable dance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "uncontrollable dance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "duplicate foe",
-                            "aonid": 1505,
-                            "game-obj": "Spells",
-                            "name": "duplicate foe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "duplicate foe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "visions of danger",
-                            "aonid": 2040,
-                            "game-obj": "Spells",
-                            "name": "visions of danger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "visions of danger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "warp mind",
-                            "aonid": 1754,
-                            "game-obj": "Spells",
-                            "name": "warp mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "warp mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Mocking Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "confusing colors",
+                "aonid": 1980,
+                "game-obj": "Spells",
+                "name": "confusing colors",
+                "type": "link"
+              },
+              {
+                "alt": "quandary",
+                "aonid": 1644,
+                "game-obj": "Spells",
+                "name": "quandary",
+                "type": "link"
+              },
+              {
+                "alt": "uncontrollable dance",
+                "aonid": 1730,
+                "game-obj": "Spells",
+                "name": "uncontrollable dance",
+                "type": "link"
+              },
+              {
+                "alt": "duplicate foe",
+                "aonid": 1505,
+                "game-obj": "Spells",
+                "name": "duplicate foe",
+                "type": "link"
+              },
+              {
+                "alt": "visions of danger",
+                "aonid": 2040,
+                "game-obj": "Spells",
+                "name": "visions of danger",
+                "type": "link"
+              },
+              {
+                "alt": "warp mind",
+                "aonid": 1754,
+                "game-obj": "Spells",
+                "name": "warp mind",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -750,140 +334,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient mocking dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fabricated truth",
-                            "aonid": 1520,
-                            "game-obj": "Spells",
-                            "name": "fabricated truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fabricated truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfathomable song",
-                            "aonid": 1731,
-                            "game-obj": "Spells",
-                            "name": "unfathomable song",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfathomable song",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon instrument",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Mocking Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fabricated truth",
+                "aonid": 1520,
+                "game-obj": "Spells",
+                "name": "fabricated truth",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
+              },
+              {
+                "alt": "unfathomable song",
+                "aonid": 1731,
+                "game-obj": "Spells",
+                "name": "unfathomable song",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -898,48 +383,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -950,263 +398,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1216,7 +448,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1242,6 +473,1103 @@
         }
       ],
       "text": "Mocking dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "mirage",
+          "aonid": 1604,
+          "game-obj": "Spells",
+          "name": "mirage",
+          "type": "link"
+        },
+        {
+          "alt": "hypnotize",
+          "aonid": 1564,
+          "game-obj": "Spells",
+          "name": "hypnotize",
+          "type": "link"
+        },
+        {
+          "alt": "paralyze",
+          "aonid": 1622,
+          "game-obj": "Spells",
+          "name": "paralyze",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "blur",
+          "aonid": 1455,
+          "game-obj": "Spells",
+          "name": "blur",
+          "type": "link"
+        },
+        {
+          "alt": "illusory creature",
+          "aonid": 1567,
+          "game-obj": "Spells",
+          "name": "illusory creature",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal treasure",
+          "aonid": 2013,
+          "game-obj": "Spells",
+          "name": "phantasmal treasure",
+          "type": "link"
+        },
+        {
+          "alt": "dizzying colors",
+          "aonid": 1500,
+          "game-obj": "Spells",
+          "name": "dizzying colors",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 1675,
+          "game-obj": "Spells",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "summon instrument",
+          "aonid": 1703,
+          "game-obj": "Spells",
+          "name": "summon instrument",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 1718,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Young Mocking Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 143",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 143",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 143,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mirage",
+                      "aonid": 1604,
+                      "game-obj": "Spells",
+                      "name": "mirage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mirage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hypnotize",
+                      "aonid": 1564,
+                      "game-obj": "Spells",
+                      "name": "hypnotize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hypnotize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "paralyze",
+                      "aonid": 1622,
+                      "game-obj": "Spells",
+                      "name": "paralyze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "paralyze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blur",
+                      "aonid": 1455,
+                      "game-obj": "Spells",
+                      "name": "blur",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blur",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory creature",
+                      "aonid": 1567,
+                      "game-obj": "Spells",
+                      "name": "illusory creature",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "illusory creature",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal treasure",
+                      "aonid": 2013,
+                      "game-obj": "Spells",
+                      "name": "phantasmal treasure",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal treasure",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dizzying colors",
+                      "aonid": 1500,
+                      "game-obj": "Spells",
+                      "name": "dizzying colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dizzying colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sleep",
+                      "aonid": 1675,
+                      "game-obj": "Spells",
+                      "name": "sleep",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sleep",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "summon instrument",
+                      "aonid": 1703,
+                      "game-obj": "Spells",
+                      "name": "summon instrument",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 1718,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 26, attack +18; **4th** *confusion*, *dispel magic*, *mirage*; **3rd** *hypnotize*, *paralyze*, *slow*; **2nd** *blur*, *illusory creature*, *phantasmal treasure*; **1st** *dizzying colors*, *fear*, *sleep*; **Cantrips (4th)** *detect magic*, *figment*, *summon instrument*, *telekinetic hand*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cursed metamorphosis",
+          "aonid": 1479,
+          "game-obj": "Spells",
+          "name": "cursed metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "vibrant pattern",
+          "aonid": 1741,
+          "game-obj": "Spells",
+          "name": "vibrant pattern",
+          "type": "link"
+        },
+        {
+          "alt": "cloak of colors",
+          "aonid": 1977,
+          "game-obj": "Spells",
+          "name": "cloak of colors",
+          "type": "link"
+        },
+        {
+          "alt": "strange geometry",
+          "aonid": 2032,
+          "game-obj": "Spells",
+          "name": "strange geometry",
+          "type": "link"
+        },
+        {
+          "alt": "synesthesia",
+          "aonid": 2035,
+          "game-obj": "Spells",
+          "name": "synesthesia",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Mocking Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 143",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 143",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 143,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young mocking dragon"
+          ],
+          "saving_throw": {
+            "dc": 32,
+            "subtype": "save_dc",
+            "text": "DC 32",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cursed metamorphosis",
+                      "aonid": 1479,
+                      "game-obj": "Spells",
+                      "name": "cursed metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cursed metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vibrant pattern",
+                      "aonid": 1741,
+                      "game-obj": "Spells",
+                      "name": "vibrant pattern",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vibrant pattern",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cloak of colors",
+                      "aonid": 1977,
+                      "game-obj": "Spells",
+                      "name": "cloak of colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cloak of colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "strange geometry",
+                      "aonid": 2032,
+                      "game-obj": "Spells",
+                      "name": "strange geometry",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "strange geometry",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "synesthesia",
+                      "aonid": 2035,
+                      "game-obj": "Spells",
+                      "name": "synesthesia",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "synesthesia",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 32, attack +24; As young mocking dragon, plus **6th** *cursed metamorphosis*, *truesight*, *vibrant pattern*; **5th** *cloak of colors*, *strange geometry*, *synesthesia*; **Cantrips (6th)** *detect magic*, *figment*, *summon instrument*, *telekinetic hand*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "confusing colors",
+          "aonid": 1980,
+          "game-obj": "Spells",
+          "name": "confusing colors",
+          "type": "link"
+        },
+        {
+          "alt": "quandary",
+          "aonid": 1644,
+          "game-obj": "Spells",
+          "name": "quandary",
+          "type": "link"
+        },
+        {
+          "alt": "uncontrollable dance",
+          "aonid": 1730,
+          "game-obj": "Spells",
+          "name": "uncontrollable dance",
+          "type": "link"
+        },
+        {
+          "alt": "duplicate foe",
+          "aonid": 1505,
+          "game-obj": "Spells",
+          "name": "duplicate foe",
+          "type": "link"
+        },
+        {
+          "alt": "visions of danger",
+          "aonid": 2040,
+          "game-obj": "Spells",
+          "name": "visions of danger",
+          "type": "link"
+        },
+        {
+          "alt": "warp mind",
+          "aonid": 1754,
+          "game-obj": "Spells",
+          "name": "warp mind",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Mocking Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 143",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 143",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 143,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult mocking dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusing colors",
+                      "aonid": 1980,
+                      "game-obj": "Spells",
+                      "name": "confusing colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusing colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "quandary",
+                      "aonid": 1644,
+                      "game-obj": "Spells",
+                      "name": "quandary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "quandary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "uncontrollable dance",
+                      "aonid": 1730,
+                      "game-obj": "Spells",
+                      "name": "uncontrollable dance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "uncontrollable dance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "duplicate foe",
+                      "aonid": 1505,
+                      "game-obj": "Spells",
+                      "name": "duplicate foe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "duplicate foe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "visions of danger",
+                      "aonid": 2040,
+                      "game-obj": "Spells",
+                      "name": "visions of danger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "visions of danger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "warp mind",
+                      "aonid": 1754,
+                      "game-obj": "Spells",
+                      "name": "warp mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "warp mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 38, attack +30; As adult mocking dragon, plus **8th** *confusing colors*, *quandary*, *uncontrollable dance*; **7th** *duplicate foe*, *visions of danger*, *warp mind*; **Cantrips (8th)** *detect magic*, *figment*, *summon instrument*, *telekinetic hand*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fabricated truth",
+          "aonid": 1520,
+          "game-obj": "Spells",
+          "name": "fabricated truth",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        },
+        {
+          "alt": "unfathomable song",
+          "aonid": 1731,
+          "game-obj": "Spells",
+          "name": "unfathomable song",
+          "type": "link"
+        }
+      ],
+      "name": "Mocking Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 143",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 143",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 143,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient mocking dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fabricated truth",
+                      "aonid": 1520,
+                      "game-obj": "Spells",
+                      "name": "fabricated truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fabricated truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfathomable song",
+                      "aonid": 1731,
+                      "game-obj": "Spells",
+                      "name": "unfathomable song",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfathomable song",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon instrument",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 42, attack +34; As ancient mocking dragon, plus **10th** *fabricated truth*; **9th** *overwhelming presence*, *phantasmagoria*, *unfathomable song*; **Cantrips (10th)** *detect magic*, *figment*, *summon instrument*, *telekinetic hand*, *telekinetic projectile*",
       "type": "section"
     },
     {
@@ -1556,6 +1884,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 143",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 143",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 143,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1703,6 +2087,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 143",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 143",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 143,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_oath.json
+++ b/monster_families/draconic_codex/dragon_oath.json
@@ -65,300 +65,118 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heal",
-                            "aonid": 1554,
-                            "game-obj": "Spells",
-                            "name": "heal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vital beacon",
-                            "aonid": 1743,
-                            "game-obj": "Spells",
-                            "name": "vital beacon",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vital beacon",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cleanse affliction",
-                            "aonid": 1467,
-                            "game-obj": "Spells",
-                            "name": "cleanse affliction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cleanse affliction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heroism",
-                            "aonid": 1555,
-                            "game-obj": "Spells",
-                            "name": "heroism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "cleanse affliction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "status",
-                            "aonid": 1690,
-                            "game-obj": "Spells",
-                            "name": "status",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "status",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translate",
-                            "aonid": 1723,
-                            "game-obj": "Spells",
-                            "name": "translate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "protection",
-                            "aonid": 1641,
-                            "game-obj": "Spells",
-                            "name": "protection",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "protection",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit link",
-                            "aonid": 1686,
-                            "game-obj": "Spells",
-                            "name": "spirit link",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit link",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "thoughtful gift",
-                            "aonid": 2037,
-                            "game-obj": "Spells",
-                            "name": "thoughtful gift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "thoughtful gift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bullhorn",
-                            "aonid": 1971,
-                            "game-obj": "Spells",
-                            "name": "bullhorn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "forbidding ward",
-                            "aonid": 1535,
-                            "game-obj": "Spells",
-                            "name": "forbidding ward",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 1689,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Oath Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "heal",
+                "aonid": 1554,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
+              },
+              {
+                "alt": "vital beacon",
+                "aonid": 1743,
+                "game-obj": "Spells",
+                "name": "vital beacon",
+                "type": "link"
+              },
+              {
+                "alt": "cleanse affliction",
+                "aonid": 1467,
+                "game-obj": "Spells",
+                "name": "cleanse affliction",
+                "type": "link"
+              },
+              {
+                "alt": "heroism",
+                "aonid": 1555,
+                "game-obj": "Spells",
+                "name": "heroism",
+                "type": "link"
+              },
+              {
+                "alt": "status",
+                "aonid": 1690,
+                "game-obj": "Spells",
+                "name": "status",
+                "type": "link"
+              },
+              {
+                "alt": "translate",
+                "aonid": 1723,
+                "game-obj": "Spells",
+                "name": "translate",
+                "type": "link"
+              },
+              {
+                "alt": "protection",
+                "aonid": 1641,
+                "game-obj": "Spells",
+                "name": "protection",
+                "type": "link"
+              },
+              {
+                "alt": "spirit link",
+                "aonid": 1686,
+                "game-obj": "Spells",
+                "name": "spirit link",
+                "type": "link"
+              },
+              {
+                "alt": "thoughtful gift",
+                "aonid": 2037,
+                "game-obj": "Spells",
+                "name": "thoughtful gift",
+                "type": "link"
+              },
+              {
+                "alt": "bullhorn",
+                "aonid": 1971,
+                "game-obj": "Spells",
+                "name": "bullhorn",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "forbidding ward",
+                "aonid": 1535,
+                "game-obj": "Spells",
+                "name": "forbidding ward",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 1689,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -374,143 +192,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young oath dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "zealous conviction",
-                            "aonid": 1760,
-                            "game-obj": "Spells",
-                            "name": "zealous conviction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "zealous conviction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resist energy",
-                            "aonid": 1651,
-                            "game-obj": "Spells",
-                            "name": "resist energy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resist energy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spirit link",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Oath Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "zealous conviction",
+                "aonid": 1760,
+                "game-obj": "Spells",
+                "name": "zealous conviction",
+                "type": "link"
+              },
+              {
+                "alt": "resist energy",
+                "aonid": 1651,
+                "game-obj": "Spells",
+                "name": "resist energy",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -526,205 +235,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult oath dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "field of life",
-                            "aonid": 1526,
-                            "game-obj": "Spells",
-                            "name": "field of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "field of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine decree",
-                            "aonid": 1495,
-                            "game-obj": "Spells",
-                            "name": "divine decree",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine decree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sound body",
-                            "aonid": 1679,
-                            "game-obj": "Spells",
-                            "name": "sound body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sound body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spell riposte",
-                            "aonid": 2027,
-                            "game-obj": "Spells",
-                            "name": "spell riposte",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spell riposte",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Oath Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "field of life",
+                "aonid": 1526,
+                "game-obj": "Spells",
+                "name": "field of life",
+                "type": "link"
+              },
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "divine decree",
+                "aonid": 1495,
+                "game-obj": "Spells",
+                "name": "divine decree",
+                "type": "link"
+              },
+              {
+                "alt": "sound body",
+                "aonid": 1679,
+                "game-obj": "Spells",
+                "name": "sound body",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "spell riposte",
+                "aonid": 2027,
+                "game-obj": "Spells",
+                "name": "spell riposte",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -740,101 +306,20 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As ancient oath dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revival",
-                            "aonid": 1654,
-                            "game-obj": "Spells",
-                            "name": "revival",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revival",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Oath Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "revival",
+                "aonid": 1654,
+                "game-obj": "Spells",
+                "name": "revival",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -849,48 +334,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -901,263 +349,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1167,7 +399,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1193,6 +424,1005 @@
         }
       ],
       "text": "Oath dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "heal",
+          "aonid": 1554,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        },
+        {
+          "alt": "vital beacon",
+          "aonid": 1743,
+          "game-obj": "Spells",
+          "name": "vital beacon",
+          "type": "link"
+        },
+        {
+          "alt": "cleanse affliction",
+          "aonid": 1467,
+          "game-obj": "Spells",
+          "name": "cleanse affliction",
+          "type": "link"
+        },
+        {
+          "alt": "heroism",
+          "aonid": 1555,
+          "game-obj": "Spells",
+          "name": "heroism",
+          "type": "link"
+        },
+        {
+          "alt": "status",
+          "aonid": 1690,
+          "game-obj": "Spells",
+          "name": "status",
+          "type": "link"
+        },
+        {
+          "alt": "translate",
+          "aonid": 1723,
+          "game-obj": "Spells",
+          "name": "translate",
+          "type": "link"
+        },
+        {
+          "alt": "protection",
+          "aonid": 1641,
+          "game-obj": "Spells",
+          "name": "protection",
+          "type": "link"
+        },
+        {
+          "alt": "spirit link",
+          "aonid": 1686,
+          "game-obj": "Spells",
+          "name": "spirit link",
+          "type": "link"
+        },
+        {
+          "alt": "thoughtful gift",
+          "aonid": 2037,
+          "game-obj": "Spells",
+          "name": "thoughtful gift",
+          "type": "link"
+        },
+        {
+          "alt": "bullhorn",
+          "aonid": 1971,
+          "game-obj": "Spells",
+          "name": "bullhorn",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "forbidding ward",
+          "aonid": 1535,
+          "game-obj": "Spells",
+          "name": "forbidding ward",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 1689,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Young Oath Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 147",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 147",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 147,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heal",
+                      "aonid": 1554,
+                      "game-obj": "Spells",
+                      "name": "heal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vital beacon",
+                      "aonid": 1743,
+                      "game-obj": "Spells",
+                      "name": "vital beacon",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vital beacon",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cleanse affliction",
+                      "aonid": 1467,
+                      "game-obj": "Spells",
+                      "name": "cleanse affliction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cleanse affliction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heroism",
+                      "aonid": 1555,
+                      "game-obj": "Spells",
+                      "name": "heroism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "cleanse affliction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "status",
+                      "aonid": 1690,
+                      "game-obj": "Spells",
+                      "name": "status",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "status",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translate",
+                      "aonid": 1723,
+                      "game-obj": "Spells",
+                      "name": "translate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "protection",
+                      "aonid": 1641,
+                      "game-obj": "Spells",
+                      "name": "protection",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "protection",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit link",
+                      "aonid": 1686,
+                      "game-obj": "Spells",
+                      "name": "spirit link",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit link",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "thoughtful gift",
+                      "aonid": 2037,
+                      "game-obj": "Spells",
+                      "name": "thoughtful gift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "thoughtful gift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bullhorn",
+                      "aonid": 1971,
+                      "game-obj": "Spells",
+                      "name": "bullhorn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "forbidding ward",
+                      "aonid": 1535,
+                      "game-obj": "Spells",
+                      "name": "forbidding ward",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 1689,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 29, attack +21; **4th** *clear mind*, *heal*, *vital beacon*; **3rd** *cleanse affliction*, *heal*, *heroism*; **2nd** *cleanse affliction*, *status*, *translate*; **1st** *protection*, *spirit link*, *thoughtful gift*; **Cantrips (4th)** *bullhorn*, *detect magic*, *forbidding ward*, *guidance*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "zealous conviction",
+          "aonid": 1760,
+          "game-obj": "Spells",
+          "name": "zealous conviction",
+          "type": "link"
+        },
+        {
+          "alt": "resist energy",
+          "aonid": 1651,
+          "game-obj": "Spells",
+          "name": "resist energy",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Oath Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 147",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 147",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 147,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young oath dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "zealous conviction",
+                      "aonid": 1760,
+                      "game-obj": "Spells",
+                      "name": "zealous conviction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "zealous conviction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resist energy",
+                      "aonid": 1651,
+                      "game-obj": "Spells",
+                      "name": "resist energy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resist energy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spirit link",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 34, attack +26; As young oath dragon, plus **6th** *clear mind*, *heroism*, *zealous conviction*; **5th** *resist energy*, *spirit link*, *truespeech*; **Cantrips (6th)** *bullhorn*, *detect magic*, *forbidding ward*, *guidance*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "field of life",
+          "aonid": 1526,
+          "game-obj": "Spells",
+          "name": "field of life",
+          "type": "link"
+        },
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "divine decree",
+          "aonid": 1495,
+          "game-obj": "Spells",
+          "name": "divine decree",
+          "type": "link"
+        },
+        {
+          "alt": "sound body",
+          "aonid": 1679,
+          "game-obj": "Spells",
+          "name": "sound body",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "spell riposte",
+          "aonid": 2027,
+          "game-obj": "Spells",
+          "name": "spell riposte",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Oath Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 147",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 147",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 147,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult oath dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "field of life",
+                      "aonid": 1526,
+                      "game-obj": "Spells",
+                      "name": "field of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "field of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine decree",
+                      "aonid": 1495,
+                      "game-obj": "Spells",
+                      "name": "divine decree",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine decree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sound body",
+                      "aonid": 1679,
+                      "game-obj": "Spells",
+                      "name": "sound body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sound body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spell riposte",
+                      "aonid": 2027,
+                      "game-obj": "Spells",
+                      "name": "spell riposte",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spell riposte",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 41, attack +33; As adult oath dragon, plus **9th** *field of life*, *foresight*, *heroism*; **8th** *clear mind*, *divine decree*, *sound body*; **7th** **dispel magic**, *energy aegis*, *spell riposte*; **Cantrips (9th)** *bullhorn*, *detect magic*, *forbidding ward*, *guidance*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "revival",
+          "aonid": 1654,
+          "game-obj": "Spells",
+          "name": "revival",
+          "type": "link"
+        }
+      ],
+      "name": "Oath Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 147",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 147",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 147,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As ancient oath dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revival",
+                      "aonid": 1654,
+                      "game-obj": "Spells",
+                      "name": "revival",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revival",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 45, attack +37; As ancient oath dragon, plus **10th** *revival*; **9th** *heal*; **Cantrips (10th)** *bullhorn*, *detect magic*, *forbidding ward*, *guidance*, *stabilize*",
       "type": "section"
     },
     {
@@ -1507,6 +1737,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 147",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 147",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 147,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1654,6 +1940,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 147",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 147",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 147,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_rime.json
+++ b/monster_families/draconic_codex/dragon_rime.json
@@ -65,256 +65,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 24,
-                  "subtype": "save_dc",
-                  "text": "DC 24",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 16,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "aqueous orb",
-                            "aonid": 1443,
-                            "game-obj": "Spells",
-                            "name": "aqueous orb",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "aqueous orb",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chilling spray",
-                            "aonid": 1975,
-                            "game-obj": "Spells",
-                            "name": "chilling spray",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chilling spray",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dismantle",
-                            "aonid": 1987,
-                            "game-obj": "Spells",
-                            "name": "dismantle",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dismantle",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "environmental endurance",
-                            "aonid": 1517,
-                            "game-obj": "Spells",
-                            "name": "environmental endurance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "environmental endurance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shatter",
-                            "aonid": 1670,
-                            "game-obj": "Spells",
-                            "name": "shatter",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shatter",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "chilling spray",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hydraulic push",
-                            "aonid": 1561,
-                            "game-obj": "Spells",
-                            "name": "hydraulic push",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hydraulic push",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vanishing tracks",
-                            "aonid": 1737,
-                            "game-obj": "Spells",
-                            "name": "vanishing tracks",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vanishing tracks",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "frostbite",
-                            "aonid": 1539,
-                            "game-obj": "Spells",
-                            "name": "frostbite",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gale blast",
-                            "aonid": 1994,
-                            "game-obj": "Spells",
-                            "name": "gale blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gale blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spout",
-                            "aonid": 2031,
-                            "game-obj": "Spells",
-                            "name": "spout",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Rime Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "aqueous orb",
+                "aonid": 1443,
+                "game-obj": "Spells",
+                "name": "aqueous orb",
+                "type": "link"
+              },
+              {
+                "alt": "chilling spray",
+                "aonid": 1975,
+                "game-obj": "Spells",
+                "name": "chilling spray",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "dismantle",
+                "aonid": 1987,
+                "game-obj": "Spells",
+                "name": "dismantle",
+                "type": "link"
+              },
+              {
+                "alt": "environmental endurance",
+                "aonid": 1517,
+                "game-obj": "Spells",
+                "name": "environmental endurance",
+                "type": "link"
+              },
+              {
+                "alt": "shatter",
+                "aonid": 1670,
+                "game-obj": "Spells",
+                "name": "shatter",
+                "type": "link"
+              },
+              {
+                "alt": "hydraulic push",
+                "aonid": 1561,
+                "game-obj": "Spells",
+                "name": "hydraulic push",
+                "type": "link"
+              },
+              {
+                "alt": "vanishing tracks",
+                "aonid": 1737,
+                "game-obj": "Spells",
+                "name": "vanishing tracks",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "frostbite",
+                "aonid": 1539,
+                "game-obj": "Spells",
+                "name": "frostbite",
+                "type": "link"
+              },
+              {
+                "alt": "gale blast",
+                "aonid": 1994,
+                "game-obj": "Spells",
+                "name": "gale blast",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "spout",
+                "aonid": 2031,
+                "game-obj": "Spells",
+                "name": "spout",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -330,170 +178,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young rime dragon"
-                ],
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "control water",
-                            "aonid": 1473,
-                            "game-obj": "Spells",
-                            "name": "control water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "control water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "howling blizzard",
-                            "aonid": 1559,
-                            "game-obj": "Spells",
-                            "name": "howling blizzard",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "howling blizzard",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "speak with stones",
-                            "aonid": 1682,
-                            "game-obj": "Spells",
-                            "name": "speak with stones",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "speak with stones",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ice storm",
-                            "aonid": 2001,
-                            "game-obj": "Spells",
-                            "name": "ice storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ice storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shape stone",
-                            "aonid": 1667,
-                            "game-obj": "Spells",
-                            "name": "shape stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shape stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "gale blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Rime Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "control water",
+                "aonid": 1473,
+                "game-obj": "Spells",
+                "name": "control water",
+                "type": "link"
+              },
+              {
+                "alt": "howling blizzard",
+                "aonid": 1559,
+                "game-obj": "Spells",
+                "name": "howling blizzard",
+                "type": "link"
+              },
+              {
+                "alt": "speak with stones",
+                "aonid": 1682,
+                "game-obj": "Spells",
+                "name": "speak with stones",
+                "type": "link"
+              },
+              {
+                "alt": "ice storm",
+                "aonid": 2001,
+                "game-obj": "Spells",
+                "name": "ice storm",
+                "type": "link"
+              },
+              {
+                "alt": "shape stone",
+                "aonid": 1667,
+                "game-obj": "Spells",
+                "name": "shape stone",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -509,190 +242,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult rime dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "arctic rift",
-                            "aonid": 1444,
-                            "game-obj": "Spells",
-                            "name": "arctic rift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "arctic rift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthquake",
-                            "aonid": 1507,
-                            "game-obj": "Spells",
-                            "name": "earthquake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthquake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "howling blizzard",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered pack",
-                            "aonid": 1733,
-                            "game-obj": "Spells",
-                            "name": "unfettered pack",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered pack",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "chilling spray",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "frost pillar",
-                            "aonid": 1389,
-                            "game-obj": "Spells",
-                            "name": "frost pillar",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "frost pillar",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "gale blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Rime Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arctic rift",
+                "aonid": 1444,
+                "game-obj": "Spells",
+                "name": "arctic rift",
+                "type": "link"
+              },
+              {
+                "alt": "earthquake",
+                "aonid": 1507,
+                "game-obj": "Spells",
+                "name": "earthquake",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered pack",
+                "aonid": 1733,
+                "game-obj": "Spells",
+                "name": "unfettered pack",
+                "type": "link"
+              },
+              {
+                "alt": "frost pillar",
+                "aonid": 1389,
+                "game-obj": "Spells",
+                "name": "frost pillar",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -708,125 +306,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient rime dragon"
-                ],
-                "saving_throw": {
-                  "dc": 40,
-                  "subtype": "save_dc",
-                  "text": "DC 40",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wrathful storm",
-                            "aonid": 1759,
-                            "game-obj": "Spells",
-                            "name": "wrathful storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wrathful storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "gale blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Rime Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "wrathful storm",
+                "aonid": 1759,
+                "game-obj": "Spells",
+                "name": "wrathful storm",
+                "type": "link"
+              },
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -841,48 +348,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -893,263 +363,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1159,7 +413,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1185,6 +438,1011 @@
         }
       ],
       "text": "Rime dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "aqueous orb",
+          "aonid": 1443,
+          "game-obj": "Spells",
+          "name": "aqueous orb",
+          "type": "link"
+        },
+        {
+          "alt": "chilling spray",
+          "aonid": 1975,
+          "game-obj": "Spells",
+          "name": "chilling spray",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "dismantle",
+          "aonid": 1987,
+          "game-obj": "Spells",
+          "name": "dismantle",
+          "type": "link"
+        },
+        {
+          "alt": "environmental endurance",
+          "aonid": 1517,
+          "game-obj": "Spells",
+          "name": "environmental endurance",
+          "type": "link"
+        },
+        {
+          "alt": "shatter",
+          "aonid": 1670,
+          "game-obj": "Spells",
+          "name": "shatter",
+          "type": "link"
+        },
+        {
+          "alt": "hydraulic push",
+          "aonid": 1561,
+          "game-obj": "Spells",
+          "name": "hydraulic push",
+          "type": "link"
+        },
+        {
+          "alt": "vanishing tracks",
+          "aonid": 1737,
+          "game-obj": "Spells",
+          "name": "vanishing tracks",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "frostbite",
+          "aonid": 1539,
+          "game-obj": "Spells",
+          "name": "frostbite",
+          "type": "link"
+        },
+        {
+          "alt": "gale blast",
+          "aonid": 1994,
+          "game-obj": "Spells",
+          "name": "gale blast",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "spout",
+          "aonid": 2031,
+          "game-obj": "Spells",
+          "name": "spout",
+          "type": "link"
+        }
+      ],
+      "name": "Young Rime Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 151",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 151",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 151,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 24,
+            "subtype": "save_dc",
+            "text": "DC 24",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 16,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "aqueous orb",
+                      "aonid": 1443,
+                      "game-obj": "Spells",
+                      "name": "aqueous orb",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "aqueous orb",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chilling spray",
+                      "aonid": 1975,
+                      "game-obj": "Spells",
+                      "name": "chilling spray",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chilling spray",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dismantle",
+                      "aonid": 1987,
+                      "game-obj": "Spells",
+                      "name": "dismantle",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dismantle",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "environmental endurance",
+                      "aonid": 1517,
+                      "game-obj": "Spells",
+                      "name": "environmental endurance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "environmental endurance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shatter",
+                      "aonid": 1670,
+                      "game-obj": "Spells",
+                      "name": "shatter",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shatter",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "chilling spray",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hydraulic push",
+                      "aonid": 1561,
+                      "game-obj": "Spells",
+                      "name": "hydraulic push",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hydraulic push",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vanishing tracks",
+                      "aonid": 1737,
+                      "game-obj": "Spells",
+                      "name": "vanishing tracks",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vanishing tracks",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "frostbite",
+                      "aonid": 1539,
+                      "game-obj": "Spells",
+                      "name": "frostbite",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gale blast",
+                      "aonid": 1994,
+                      "game-obj": "Spells",
+                      "name": "gale blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gale blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spout",
+                      "aonid": 2031,
+                      "game-obj": "Spells",
+                      "name": "spout",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 24; attack +16; **3rd** *aqueous orb*, *chilling spray*, *slow*; **2nd** *dismantle*, *environmental endurance*, *shatter*; **1st** *chilling spray*, *hydraulic push*, *vanishing tracks*; **Cantrips (3rd)** *detect magic*, *frostbite*, *gale blast*, *know the way*, *spout*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "control water",
+          "aonid": 1473,
+          "game-obj": "Spells",
+          "name": "control water",
+          "type": "link"
+        },
+        {
+          "alt": "howling blizzard",
+          "aonid": 1559,
+          "game-obj": "Spells",
+          "name": "howling blizzard",
+          "type": "link"
+        },
+        {
+          "alt": "speak with stones",
+          "aonid": 1682,
+          "game-obj": "Spells",
+          "name": "speak with stones",
+          "type": "link"
+        },
+        {
+          "alt": "ice storm",
+          "aonid": 2001,
+          "game-obj": "Spells",
+          "name": "ice storm",
+          "type": "link"
+        },
+        {
+          "alt": "shape stone",
+          "aonid": 1667,
+          "game-obj": "Spells",
+          "name": "shape stone",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Rime Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 151",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 151",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 151,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young rime dragon"
+          ],
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "control water",
+                      "aonid": 1473,
+                      "game-obj": "Spells",
+                      "name": "control water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "control water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "howling blizzard",
+                      "aonid": 1559,
+                      "game-obj": "Spells",
+                      "name": "howling blizzard",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "howling blizzard",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "speak with stones",
+                      "aonid": 1682,
+                      "game-obj": "Spells",
+                      "name": "speak with stones",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "speak with stones",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ice storm",
+                      "aonid": 2001,
+                      "game-obj": "Spells",
+                      "name": "ice storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ice storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shape stone",
+                      "aonid": 1667,
+                      "game-obj": "Spells",
+                      "name": "shape stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shape stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "gale blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 29; attack +21; As young rime dragon, plus **5th** *control water*, *howling blizzard*, *speak with stones*; **4th** *ice storm*, *shape stone*, *unfettered movement*; **Cantrips (5th)** *detect magic*, *frostbite*, *gale blast*, *know the way*, *spout*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "arctic rift",
+          "aonid": 1444,
+          "game-obj": "Spells",
+          "name": "arctic rift",
+          "type": "link"
+        },
+        {
+          "alt": "earthquake",
+          "aonid": 1507,
+          "game-obj": "Spells",
+          "name": "earthquake",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered pack",
+          "aonid": 1733,
+          "game-obj": "Spells",
+          "name": "unfettered pack",
+          "type": "link"
+        },
+        {
+          "alt": "frost pillar",
+          "aonid": 1389,
+          "game-obj": "Spells",
+          "name": "frost pillar",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Rime Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 151",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 151",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 151,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult rime dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "arctic rift",
+                      "aonid": 1444,
+                      "game-obj": "Spells",
+                      "name": "arctic rift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "arctic rift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthquake",
+                      "aonid": 1507,
+                      "game-obj": "Spells",
+                      "name": "earthquake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthquake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "howling blizzard",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered pack",
+                      "aonid": 1733,
+                      "game-obj": "Spells",
+                      "name": "unfettered pack",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered pack",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "chilling spray",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "frost pillar",
+                      "aonid": 1389,
+                      "game-obj": "Spells",
+                      "name": "frost pillar",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "frost pillar",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "gale blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 36; attack +28; As adult rime dragon, plus **8th** *arctic rift*, *earthquake*; **7th** *howling blizzard*, *regenerate*, *unfettered pack*; **6th** *chilling spray*, *frost pillar*, *truesight*; **Cantrips (8th)** *detect magic*, *frostbite*, *gale blast*, *know the way*, *spout*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "wrathful storm",
+          "aonid": 1759,
+          "game-obj": "Spells",
+          "name": "wrathful storm",
+          "type": "link"
+        },
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        }
+      ],
+      "name": "Rime Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 151",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 151",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 151,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient rime dragon"
+          ],
+          "saving_throw": {
+            "dc": 40,
+            "subtype": "save_dc",
+            "text": "DC 40",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wrathful storm",
+                      "aonid": 1759,
+                      "game-obj": "Spells",
+                      "name": "wrathful storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wrathful storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "gale blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 40; attack +32; As ancient rime dragon, plus **9th** *implosion*, *wrathful storm*; **8th** *desiccate*; **Cantrips (9th)** *detect magic*, *frostbite*, *gale blast*, *know the way*, *spout*",
       "type": "section"
     },
     {
@@ -1499,6 +1757,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 151",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 151",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 151,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1646,6 +1960,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 151",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 151",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 151,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_sage.json
+++ b/monster_families/draconic_codex/dragon_sage.json
@@ -65,356 +65,146 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scouting eye",
-                            "aonid": 1661,
-                            "game-obj": "Spells",
-                            "name": "scouting eye",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scouting eye",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "synesthesia",
-                            "aonid": 2035,
-                            "game-obj": "Spells",
-                            "name": "synesthesia",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "synesthesia",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispelling globe",
-                            "aonid": 1494,
-                            "game-obj": "Spells",
-                            "name": "dispelling globe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispelling globe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translocate",
-                            "aonid": 1724,
-                            "game-obj": "Spells",
-                            "name": "translocate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translocate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hypercognition",
-                            "aonid": 1563,
-                            "game-obj": "Spells",
-                            "name": "hypercognition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hypercognition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mind reading",
-                            "aonid": 1602,
-                            "game-obj": "Spells",
-                            "name": "mind reading",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mind reading",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 1560,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stupefy",
-                            "aonid": 1691,
-                            "game-obj": "Spells",
-                            "name": "stupefy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stupefy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translate",
-                            "aonid": 1723,
-                            "game-obj": "Spells",
-                            "name": "translate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "d\u00e9j\u00e0 vu",
-                            "aonid": 1986,
-                            "game-obj": "Spells",
-                            "name": "d\u00e9j\u00e0 vu",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "d\u00e9j\u00e0 vu",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ill omen",
-                            "aonid": 1566,
-                            "game-obj": "Spells",
-                            "name": "ill omen",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ill omen",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Sage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "scouting eye",
+                "aonid": 1661,
+                "game-obj": "Spells",
+                "name": "scouting eye",
+                "type": "link"
+              },
+              {
+                "alt": "synesthesia",
+                "aonid": 2035,
+                "game-obj": "Spells",
+                "name": "synesthesia",
+                "type": "link"
+              },
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "dispelling globe",
+                "aonid": 1494,
+                "game-obj": "Spells",
+                "name": "dispelling globe",
+                "type": "link"
+              },
+              {
+                "alt": "translocate",
+                "aonid": 1724,
+                "game-obj": "Spells",
+                "name": "translocate",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "hypercognition",
+                "aonid": 1563,
+                "game-obj": "Spells",
+                "name": "hypercognition",
+                "type": "link"
+              },
+              {
+                "alt": "mind reading",
+                "aonid": 1602,
+                "game-obj": "Spells",
+                "name": "mind reading",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 1560,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "stupefy",
+                "aonid": 1691,
+                "game-obj": "Spells",
+                "name": "stupefy",
+                "type": "link"
+              },
+              {
+                "alt": "translate",
+                "aonid": 1723,
+                "game-obj": "Spells",
+                "name": "translate",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "d\u00e9j\u00e0 vu",
+                "aonid": 1986,
+                "game-obj": "Spells",
+                "name": "d\u00e9j\u00e0 vu",
+                "type": "link"
+              },
+              {
+                "alt": "ill omen",
+                "aonid": 1566,
+                "game-obj": "Spells",
+                "name": "ill omen",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -430,178 +220,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young sage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 1640,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "visions of danger",
-                            "aonid": 2040,
-                            "game-obj": "Spells",
-                            "name": "visions of danger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "visions of danger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dominate",
-                            "aonid": 1501,
-                            "game-obj": "Spells",
-                            "name": "dominate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dominate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "repulsion",
-                            "aonid": 1650,
-                            "game-obj": "Spells",
-                            "name": "repulsion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "repulsion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spellwrack",
-                            "aonid": 1683,
-                            "game-obj": "Spells",
-                            "name": "spellwrack",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spellwrack",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "subconscious suggestion",
-                            "aonid": 1692,
-                            "game-obj": "Spells",
-                            "name": "subconscious suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "subconscious suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Sage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "project image",
+                "aonid": 1640,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
+              },
+              {
+                "alt": "visions of danger",
+                "aonid": 2040,
+                "game-obj": "Spells",
+                "name": "visions of danger",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "repulsion",
+                "aonid": 1650,
+                "game-obj": "Spells",
+                "name": "repulsion",
+                "type": "link"
+              },
+              {
+                "alt": "spellwrack",
+                "aonid": 1683,
+                "game-obj": "Spells",
+                "name": "spellwrack",
+                "type": "link"
+              },
+              {
+                "alt": "subconscious suggestion",
+                "aonid": 1692,
+                "game-obj": "Spells",
+                "name": "subconscious suggestion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -617,187 +284,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult sage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telepathic demand",
-                            "aonid": 2036,
-                            "game-obj": "Spells",
-                            "name": "telepathic demand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telepathic demand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "quandary",
-                            "aonid": 1644,
-                            "game-obj": "Spells",
-                            "name": "quandary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "quandary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spiritual epidemic",
-                            "aonid": 2030,
-                            "game-obj": "Spells",
-                            "name": "spiritual epidemic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spiritual epidemic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spell riposte",
-                            "aonid": 2027,
-                            "game-obj": "Spells",
-                            "name": "spell riposte",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spell riposte",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Sage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "telepathic demand",
+                "aonid": 2036,
+                "game-obj": "Spells",
+                "name": "telepathic demand",
+                "type": "link"
+              },
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
+              },
+              {
+                "alt": "quandary",
+                "aonid": 1644,
+                "game-obj": "Spells",
+                "name": "quandary",
+                "type": "link"
+              },
+              {
+                "alt": "spiritual epidemic",
+                "aonid": 2030,
+                "game-obj": "Spells",
+                "name": "spiritual epidemic",
+                "type": "link"
+              },
+              {
+                "alt": "spell riposte",
+                "aonid": 2027,
+                "game-obj": "Spells",
+                "name": "spell riposte",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -813,110 +355,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient sage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 48,
-                  "subtype": "save_dc",
-                  "text": "DC 48",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 40,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Sage Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -931,48 +390,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -983,263 +405,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1249,7 +455,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1275,6 +480,1143 @@
         }
       ],
       "text": "Sage dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "scouting eye",
+          "aonid": 1661,
+          "game-obj": "Spells",
+          "name": "scouting eye",
+          "type": "link"
+        },
+        {
+          "alt": "synesthesia",
+          "aonid": 2035,
+          "game-obj": "Spells",
+          "name": "synesthesia",
+          "type": "link"
+        },
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "dispelling globe",
+          "aonid": 1494,
+          "game-obj": "Spells",
+          "name": "dispelling globe",
+          "type": "link"
+        },
+        {
+          "alt": "translocate",
+          "aonid": 1724,
+          "game-obj": "Spells",
+          "name": "translocate",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "hypercognition",
+          "aonid": 1563,
+          "game-obj": "Spells",
+          "name": "hypercognition",
+          "type": "link"
+        },
+        {
+          "alt": "mind reading",
+          "aonid": 1602,
+          "game-obj": "Spells",
+          "name": "mind reading",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 1560,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "stupefy",
+          "aonid": 1691,
+          "game-obj": "Spells",
+          "name": "stupefy",
+          "type": "link"
+        },
+        {
+          "alt": "translate",
+          "aonid": 1723,
+          "game-obj": "Spells",
+          "name": "translate",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "d\u00e9j\u00e0 vu",
+          "aonid": 1986,
+          "game-obj": "Spells",
+          "name": "d\u00e9j\u00e0 vu",
+          "type": "link"
+        },
+        {
+          "alt": "ill omen",
+          "aonid": 1566,
+          "game-obj": "Spells",
+          "name": "ill omen",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Young Sage Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 155",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 155",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 155,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scouting eye",
+                      "aonid": 1661,
+                      "game-obj": "Spells",
+                      "name": "scouting eye",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scouting eye",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "synesthesia",
+                      "aonid": 2035,
+                      "game-obj": "Spells",
+                      "name": "synesthesia",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "synesthesia",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispelling globe",
+                      "aonid": 1494,
+                      "game-obj": "Spells",
+                      "name": "dispelling globe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispelling globe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translocate",
+                      "aonid": 1724,
+                      "game-obj": "Spells",
+                      "name": "translocate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translocate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hypercognition",
+                      "aonid": 1563,
+                      "game-obj": "Spells",
+                      "name": "hypercognition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hypercognition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mind reading",
+                      "aonid": 1602,
+                      "game-obj": "Spells",
+                      "name": "mind reading",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mind reading",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 1560,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stupefy",
+                      "aonid": 1691,
+                      "game-obj": "Spells",
+                      "name": "stupefy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stupefy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translate",
+                      "aonid": 1723,
+                      "game-obj": "Spells",
+                      "name": "translate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "d\u00e9j\u00e0 vu",
+                      "aonid": 1986,
+                      "game-obj": "Spells",
+                      "name": "d\u00e9j\u00e0 vu",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "d\u00e9j\u00e0 vu",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ill omen",
+                      "aonid": 1566,
+                      "game-obj": "Spells",
+                      "name": "ill omen",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ill omen",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 28, attack +20; **5th** *scouting eye*, *synesthesia*; **4th** *confusion*, *dispelling globe*, *translocate*; **3rd** *haste*, *hypercognition*, *mind reading*; **2nd** *humanoid form*, *stupefy*, *translate*; **1st** *command*, *d\u00e9j\u00e0 vu*, *ill omen*; **Cantrips (5th)** *daze*, *detect magic*, *read aura*, *shield*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "project image",
+          "aonid": 1640,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        },
+        {
+          "alt": "visions of danger",
+          "aonid": 2040,
+          "game-obj": "Spells",
+          "name": "visions of danger",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "repulsion",
+          "aonid": 1650,
+          "game-obj": "Spells",
+          "name": "repulsion",
+          "type": "link"
+        },
+        {
+          "alt": "spellwrack",
+          "aonid": 1683,
+          "game-obj": "Spells",
+          "name": "spellwrack",
+          "type": "link"
+        },
+        {
+          "alt": "subconscious suggestion",
+          "aonid": 1692,
+          "game-obj": "Spells",
+          "name": "subconscious suggestion",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Sage Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 155",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 155",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 155,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young sage dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 1640,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "visions of danger",
+                      "aonid": 2040,
+                      "game-obj": "Spells",
+                      "name": "visions of danger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "visions of danger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dominate",
+                      "aonid": 1501,
+                      "game-obj": "Spells",
+                      "name": "dominate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dominate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "repulsion",
+                      "aonid": 1650,
+                      "game-obj": "Spells",
+                      "name": "repulsion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "repulsion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spellwrack",
+                      "aonid": 1683,
+                      "game-obj": "Spells",
+                      "name": "spellwrack",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spellwrack",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "subconscious suggestion",
+                      "aonid": 1692,
+                      "game-obj": "Spells",
+                      "name": "subconscious suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "subconscious suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 33, attack +25; As young sage dragon, plus **7th** *project image*, *visions of danger*; **6th** *dominate*, *repulsion*, *spellwrack*; **5th** *subconscious suggestion*; **Cantrips (7th)** *daze*, *detect magic*, *read aura*, *shield*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "telepathic demand",
+          "aonid": 2036,
+          "game-obj": "Spells",
+          "name": "telepathic demand",
+          "type": "link"
+        },
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        },
+        {
+          "alt": "quandary",
+          "aonid": 1644,
+          "game-obj": "Spells",
+          "name": "quandary",
+          "type": "link"
+        },
+        {
+          "alt": "spiritual epidemic",
+          "aonid": 2030,
+          "game-obj": "Spells",
+          "name": "spiritual epidemic",
+          "type": "link"
+        },
+        {
+          "alt": "spell riposte",
+          "aonid": 2027,
+          "game-obj": "Spells",
+          "name": "spell riposte",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Sage Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 155",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 155",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 155,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult sage dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telepathic demand",
+                      "aonid": 2036,
+                      "game-obj": "Spells",
+                      "name": "telepathic demand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telepathic demand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "quandary",
+                      "aonid": 1644,
+                      "game-obj": "Spells",
+                      "name": "quandary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "quandary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spiritual epidemic",
+                      "aonid": 2030,
+                      "game-obj": "Spells",
+                      "name": "spiritual epidemic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spiritual epidemic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spell riposte",
+                      "aonid": 2027,
+                      "game-obj": "Spells",
+                      "name": "spell riposte",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spell riposte",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 44, attack +36; As adult sage dragon, plus **9th** *foresight*, *telepathic demand*; **8th** *pinpoint*, *quandary*, *spiritual epidemic*; **7th** *spell riposte*; **Cantrips (9th)** *daze*, *read aura*, *shield*, *sigil*, **telekinetic hand**",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        }
+      ],
+      "name": "Sage Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 155",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 155",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 155,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient sage dragon"
+          ],
+          "saving_throw": {
+            "dc": 48,
+            "subtype": "save_dc",
+            "text": "DC 48",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 40,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 48, attack +40; As ancient sage dragon, plus **10th** *manifestation*; **9th** *overwhelming presence*; **Cantrips (10th)** *daze*, *read aura*, *shield*, *sigil*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -1589,6 +1931,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 155",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 155",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 155,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1736,6 +2134,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 155",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 155",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 155,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_sea.json
+++ b/monster_families/draconic_codex/dragon_sea.json
@@ -65,265 +65,111 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "feet to fins",
-                            "aonid": 1525,
-                            "game-obj": "Spells",
-                            "name": "feet to fins",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "feet to fins",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of wind",
-                            "aonid": 1753,
-                            "game-obj": "Spells",
-                            "name": "wall of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "laughing fit",
-                            "aonid": 1583,
-                            "game-obj": "Spells",
-                            "name": "laughing fit",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "laughing fit",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resist energy",
-                            "aonid": 1651,
-                            "game-obj": "Spells",
-                            "name": "resist energy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resist energy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water breathing",
-                            "aonid": 1755,
-                            "game-obj": "Spells",
-                            "name": "water breathing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water breathing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "air bubble",
-                            "aonid": 1438,
-                            "game-obj": "Spells",
-                            "name": "air bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "air bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 1547,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grim tendrils",
-                            "aonid": 1548,
-                            "game-obj": "Spells",
-                            "name": "grim tendrils",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grim tendrils",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Sea Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "feet to fins",
+                "aonid": 1525,
+                "game-obj": "Spells",
+                "name": "feet to fins",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "wall of wind",
+                "aonid": 1753,
+                "game-obj": "Spells",
+                "name": "wall of wind",
+                "type": "link"
+              },
+              {
+                "alt": "laughing fit",
+                "aonid": 1583,
+                "game-obj": "Spells",
+                "name": "laughing fit",
+                "type": "link"
+              },
+              {
+                "alt": "resist energy",
+                "aonid": 1651,
+                "game-obj": "Spells",
+                "name": "resist energy",
+                "type": "link"
+              },
+              {
+                "alt": "water breathing",
+                "aonid": 1755,
+                "game-obj": "Spells",
+                "name": "water breathing",
+                "type": "link"
+              },
+              {
+                "alt": "air bubble",
+                "aonid": 1438,
+                "game-obj": "Spells",
+                "name": "air bubble",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 1547,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "grim tendrils",
+                "aonid": 1548,
+                "game-obj": "Spells",
+                "name": "grim tendrils",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -339,193 +185,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young sea dragon"
-                ],
-                "saving_throw": {
-                  "dc": 32,
-                  "subtype": "save_dc",
-                  "text": "DC 32",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mariner\u2019s curse",
-                            "aonid": 1593,
-                            "game-obj": "Spells",
-                            "name": "mariner\u2019s curse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mariner\u2019s curse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of ice",
-                            "aonid": 1750,
-                            "game-obj": "Spells",
-                            "name": "wall of ice",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of ice",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispelling globe",
-                            "aonid": 1494,
-                            "game-obj": "Spells",
-                            "name": "dispelling globe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispelling globe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translocate",
-                            "aonid": 1724,
-                            "game-obj": "Spells",
-                            "name": "translocate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translocate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vapor form",
-                            "aonid": 1738,
-                            "game-obj": "Spells",
-                            "name": "vapor form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vapor form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "commune",
-                            "aonid": 114,
-                            "game-obj": "Rituals",
-                            "name": "commune",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "commune",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Sea Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mariner\u2019s curse",
+                "aonid": 1593,
+                "game-obj": "Spells",
+                "name": "mariner\u2019s curse",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
+              },
+              {
+                "alt": "wall of ice",
+                "aonid": 1750,
+                "game-obj": "Spells",
+                "name": "wall of ice",
+                "type": "link"
+              },
+              {
+                "alt": "dispelling globe",
+                "aonid": 1494,
+                "game-obj": "Spells",
+                "name": "dispelling globe",
+                "type": "link"
+              },
+              {
+                "alt": "translocate",
+                "aonid": 1724,
+                "game-obj": "Spells",
+                "name": "translocate",
+                "type": "link"
+              },
+              {
+                "alt": "vapor form",
+                "aonid": 1738,
+                "game-obj": "Spells",
+                "name": "vapor form",
+                "type": "link"
+              },
+              {
+                "alt": "commune",
+                "aonid": 114,
+                "game-obj": "Rituals",
+                "name": "commune",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -541,237 +256,76 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult sea dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 1490,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 1640,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spell riposte",
-                            "aonid": 2027,
-                            "game-obj": "Spells",
-                            "name": "spell riposte",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spell riposte",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal calamity",
-                            "aonid": 1630,
-                            "game-obj": "Spells",
-                            "name": "phantasmal calamity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal calamity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "repulsion",
-                            "aonid": 1650,
-                            "game-obj": "Spells",
-                            "name": "repulsion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "repulsion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "commune",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Sea Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "disappearance",
+                "aonid": 1490,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "project image",
+                "aonid": 1640,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
+              },
+              {
+                "alt": "spell riposte",
+                "aonid": 2027,
+                "game-obj": "Spells",
+                "name": "spell riposte",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal calamity",
+                "aonid": 1630,
+                "game-obj": "Spells",
+                "name": "phantasmal calamity",
+                "type": "link"
+              },
+              {
+                "alt": "repulsion",
+                "aonid": 1650,
+                "game-obj": "Spells",
+                "name": "repulsion",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -787,154 +341,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As ancient sea dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cataclysm",
-                            "aonid": 1460,
-                            "game-obj": "Spells",
-                            "name": "cataclysm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cataclysm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wrathful storm",
-                            "aonid": 1759,
-                            "game-obj": "Spells",
-                            "name": "wrathful storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wrathful storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "commune",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Sea Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cataclysm",
+                "aonid": 1460,
+                "game-obj": "Spells",
+                "name": "cataclysm",
+                "type": "link"
+              },
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "wrathful storm",
+                "aonid": 1759,
+                "game-obj": "Spells",
+                "name": "wrathful storm",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -949,48 +390,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1001,263 +405,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1267,7 +455,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1293,6 +480,1161 @@
         }
       ],
       "text": "Sea dragon spellcasters are likely to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "feet to fins",
+          "aonid": 1525,
+          "game-obj": "Spells",
+          "name": "feet to fins",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "wall of wind",
+          "aonid": 1753,
+          "game-obj": "Spells",
+          "name": "wall of wind",
+          "type": "link"
+        },
+        {
+          "alt": "laughing fit",
+          "aonid": 1583,
+          "game-obj": "Spells",
+          "name": "laughing fit",
+          "type": "link"
+        },
+        {
+          "alt": "resist energy",
+          "aonid": 1651,
+          "game-obj": "Spells",
+          "name": "resist energy",
+          "type": "link"
+        },
+        {
+          "alt": "water breathing",
+          "aonid": 1755,
+          "game-obj": "Spells",
+          "name": "water breathing",
+          "type": "link"
+        },
+        {
+          "alt": "air bubble",
+          "aonid": 1438,
+          "game-obj": "Spells",
+          "name": "air bubble",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 1547,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "grim tendrils",
+          "aonid": 1548,
+          "game-obj": "Spells",
+          "name": "grim tendrils",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Young Sea Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 159",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 159",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 159,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "feet to fins",
+                      "aonid": 1525,
+                      "game-obj": "Spells",
+                      "name": "feet to fins",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "feet to fins",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of wind",
+                      "aonid": 1753,
+                      "game-obj": "Spells",
+                      "name": "wall of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "laughing fit",
+                      "aonid": 1583,
+                      "game-obj": "Spells",
+                      "name": "laughing fit",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "laughing fit",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resist energy",
+                      "aonid": 1651,
+                      "game-obj": "Spells",
+                      "name": "resist energy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resist energy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water breathing",
+                      "aonid": 1755,
+                      "game-obj": "Spells",
+                      "name": "water breathing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water breathing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "air bubble",
+                      "aonid": 1438,
+                      "game-obj": "Spells",
+                      "name": "air bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "air bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 1547,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grim tendrils",
+                      "aonid": 1548,
+                      "game-obj": "Spells",
+                      "name": "grim tendrils",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grim tendrils",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 26, attack +18; **3rd** *feet to fins*, *haste*, *wall of wind*; **2nd** *laughing fit*, *resist energy*, *water breathing*; **1st** *air bubble*, *grease*, *grim tendrils*; **Cantrips (3rd)** *detect magic*, *message*, *prestidigitation*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "mariner\u2019s curse",
+          "aonid": 1593,
+          "game-obj": "Spells",
+          "name": "mariner\u2019s curse",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        },
+        {
+          "alt": "wall of ice",
+          "aonid": 1750,
+          "game-obj": "Spells",
+          "name": "wall of ice",
+          "type": "link"
+        },
+        {
+          "alt": "dispelling globe",
+          "aonid": 1494,
+          "game-obj": "Spells",
+          "name": "dispelling globe",
+          "type": "link"
+        },
+        {
+          "alt": "translocate",
+          "aonid": 1724,
+          "game-obj": "Spells",
+          "name": "translocate",
+          "type": "link"
+        },
+        {
+          "alt": "vapor form",
+          "aonid": 1738,
+          "game-obj": "Spells",
+          "name": "vapor form",
+          "type": "link"
+        },
+        {
+          "alt": "commune",
+          "aonid": 114,
+          "game-obj": "Rituals",
+          "name": "commune",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Sea Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 159",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 159",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 159,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young sea dragon"
+          ],
+          "saving_throw": {
+            "dc": 32,
+            "subtype": "save_dc",
+            "text": "DC 32",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mariner\u2019s curse",
+                      "aonid": 1593,
+                      "game-obj": "Spells",
+                      "name": "mariner\u2019s curse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mariner\u2019s curse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of ice",
+                      "aonid": 1750,
+                      "game-obj": "Spells",
+                      "name": "wall of ice",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of ice",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispelling globe",
+                      "aonid": 1494,
+                      "game-obj": "Spells",
+                      "name": "dispelling globe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispelling globe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translocate",
+                      "aonid": 1724,
+                      "game-obj": "Spells",
+                      "name": "translocate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translocate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vapor form",
+                      "aonid": 1738,
+                      "game-obj": "Spells",
+                      "name": "vapor form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vapor form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "commune",
+                      "aonid": 114,
+                      "game-obj": "Rituals",
+                      "name": "commune",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "commune",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 32, attack +24; As young sea dragon, plus **5th** *mariner\u2019s curse*, *truespeech*, *wall of ice*; **4th** *dispelling globe*, *translocate*, *vapor form*; **Cantrips (5th)** *detect magic*, *message*, *prestidigitation*, *read aura*, *shield*; **Rituals** DC 32; *commune*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "disappearance",
+          "aonid": 1490,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "project image",
+          "aonid": 1640,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        },
+        {
+          "alt": "spell riposte",
+          "aonid": 2027,
+          "game-obj": "Spells",
+          "name": "spell riposte",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal calamity",
+          "aonid": 1630,
+          "game-obj": "Spells",
+          "name": "phantasmal calamity",
+          "type": "link"
+        },
+        {
+          "alt": "repulsion",
+          "aonid": 1650,
+          "game-obj": "Spells",
+          "name": "repulsion",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Sea Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 159",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 159",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 159,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult sea dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 1490,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 1640,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spell riposte",
+                      "aonid": 2027,
+                      "game-obj": "Spells",
+                      "name": "spell riposte",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spell riposte",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal calamity",
+                      "aonid": 1630,
+                      "game-obj": "Spells",
+                      "name": "phantasmal calamity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal calamity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "repulsion",
+                      "aonid": 1650,
+                      "game-obj": "Spells",
+                      "name": "repulsion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "repulsion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "commune",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 38, attack +30; As adult sea dragon, plus **8th** *desiccate*, *disappearance*, *pinpoint*; **7th** *energy aegis*, *project image*, *spell riposte*; **6th** *phantasmal calamity*, *repulsion*, *truesight*; **Cantrips (8th)** *detect magic*, *message*, *prestidigitation*, *read aura*, *shield*; **Rituals** DC 38; *commune*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cataclysm",
+          "aonid": 1460,
+          "game-obj": "Spells",
+          "name": "cataclysm",
+          "type": "link"
+        },
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "wrathful storm",
+          "aonid": 1759,
+          "game-obj": "Spells",
+          "name": "wrathful storm",
+          "type": "link"
+        }
+      ],
+      "name": "Sea Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 159",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 159",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 159,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As ancient sea dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cataclysm",
+                      "aonid": 1460,
+                      "game-obj": "Spells",
+                      "name": "cataclysm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cataclysm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wrathful storm",
+                      "aonid": 1759,
+                      "game-obj": "Spells",
+                      "name": "wrathful storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wrathful storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "commune",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 42, attack +34; As ancient sea dragon, plus **10th** *cataclysm*, *manifestation*; **9th** *foresight*, *wrathful storm*; **Cantrips (10th)** *detect magic*, *message*, *prestidigitation*, *read aura*, *shield*; **Rituals** DC 42; *commune*",
       "type": "section"
     },
     {
@@ -1607,6 +1949,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 159",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 159",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 159,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1754,6 +2152,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 159",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 159",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 159,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_sky.json
+++ b/monster_families/draconic_codex/dragon_sky.json
@@ -102,341 +102,139 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine wrath",
-                            "aonid": 1499,
-                            "game-obj": "Spells",
-                            "name": "divine wrath",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine wrath",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read omens",
-                            "aonid": 1647,
-                            "game-obj": "Spells",
-                            "name": "read omens",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read omens",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ream message",
-                            "aonid": 1503,
-                            "game-obj": "Spells",
-                            "name": "ream message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dream message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heroism",
-                            "aonid": 1555,
-                            "game-obj": "Spells",
-                            "name": "heroism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "locate",
-                            "aonid": 1588,
-                            "game-obj": "Spells",
-                            "name": "locate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "locate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "augury",
-                            "aonid": 1445,
-                            "game-obj": "Spells",
-                            "name": "augury",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "augury",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translate",
-                            "aonid": 1723,
-                            "game-obj": "Spells",
-                            "name": "translate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create food",
-                            "aonid": 1475,
-                            "game-obj": "Spells",
-                            "name": "create food",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create food",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "alarm",
-                            "aonid": 1439,
-                            "game-obj": "Spells",
-                            "name": "alarm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "alarm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bless",
-                            "aonid": 1451,
-                            "game-obj": "Spells",
-                            "name": "bless",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bless",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sanctuary",
-                            "aonid": 1660,
-                            "game-obj": "Spells",
-                            "name": "sanctuary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sanctuary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 1498,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 1381,
-                            "game-obj": "Rules",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "consecrate",
-                            "aonid": 115,
-                            "game-obj": "Rituals",
-                            "name": "consecrate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "consecrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Sky Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine wrath",
+                "aonid": 1499,
+                "game-obj": "Spells",
+                "name": "divine wrath",
+                "type": "link"
+              },
+              {
+                "alt": "read omens",
+                "aonid": 1647,
+                "game-obj": "Spells",
+                "name": "read omens",
+                "type": "link"
+              },
+              {
+                "alt": "ream message",
+                "aonid": 1503,
+                "game-obj": "Spells",
+                "name": "ream message",
+                "type": "link"
+              },
+              {
+                "alt": "heroism",
+                "aonid": 1555,
+                "game-obj": "Spells",
+                "name": "heroism",
+                "type": "link"
+              },
+              {
+                "alt": "locate",
+                "aonid": 1588,
+                "game-obj": "Spells",
+                "name": "locate",
+                "type": "link"
+              },
+              {
+                "alt": "augury",
+                "aonid": 1445,
+                "game-obj": "Spells",
+                "name": "augury",
+                "type": "link"
+              },
+              {
+                "alt": "translate",
+                "aonid": 1723,
+                "game-obj": "Spells",
+                "name": "translate",
+                "type": "link"
+              },
+              {
+                "alt": "create food",
+                "aonid": 1475,
+                "game-obj": "Spells",
+                "name": "create food",
+                "type": "link"
+              },
+              {
+                "alt": "alarm",
+                "aonid": 1439,
+                "game-obj": "Spells",
+                "name": "alarm",
+                "type": "link"
+              },
+              {
+                "alt": "bless",
+                "aonid": 1451,
+                "game-obj": "Spells",
+                "name": "bless",
+                "type": "link"
+              },
+              {
+                "alt": "sanctuary",
+                "aonid": 1660,
+                "game-obj": "Spells",
+                "name": "sanctuary",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 1498,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 1381,
+                "game-obj": "Rules",
+                "name": "stabilize",
+                "type": "link"
+              },
+              {
+                "alt": "consecrate",
+                "aonid": 115,
+                "game-obj": "Rituals",
+                "name": "consecrate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -452,193 +250,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young sky dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blessed boundary",
-                            "aonid": 1452,
-                            "game-obj": "Spells",
-                            "name": "blessed boundary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blessed boundary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit blast",
-                            "aonid": 1685,
-                            "game-obj": "Spells",
-                            "name": "spirit blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scouting eye",
-                            "aonid": 1661,
-                            "game-obj": "Spells",
-                            "name": "scouting eye",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scouting eye",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "atone",
-                            "aonid": 108,
-                            "game-obj": "Rituals",
-                            "name": "atone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "atone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Sky Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "blessed boundary",
+                "aonid": 1452,
+                "game-obj": "Spells",
+                "name": "blessed boundary",
+                "type": "link"
+              },
+              {
+                "alt": "spirit blast",
+                "aonid": 1685,
+                "game-obj": "Spells",
+                "name": "spirit blast",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "scouting eye",
+                "aonid": 1661,
+                "game-obj": "Spells",
+                "name": "scouting eye",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
+              },
+              {
+                "alt": "atone",
+                "aonid": 108,
+                "game-obj": "Rituals",
+                "name": "atone",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -654,184 +321,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult sky dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "canticle of everlasting grief",
-                            "aonid": 1459,
-                            "game-obj": "Spells",
-                            "name": "canticle of everlasting grief",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "canticle of everlasting grief",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine decree",
-                            "aonid": 1495,
-                            "game-obj": "Spells",
-                            "name": "divine decree",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine decree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "interplanar teleport",
-                            "aonid": 1576,
-                            "game-obj": "Spells",
-                            "name": "interplanar teleport",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "interplanar teleport",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sunburst",
-                            "aonid": 1707,
-                            "game-obj": "Spells",
-                            "name": "sunburst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sunburst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "collective memories",
-                            "aonid": 113,
-                            "game-obj": "Rituals",
-                            "name": "collective memories",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "collective memories",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Sky Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "canticle of everlasting grief",
+                "aonid": 1459,
+                "game-obj": "Spells",
+                "name": "canticle of everlasting grief",
+                "type": "link"
+              },
+              {
+                "alt": "divine decree",
+                "aonid": 1495,
+                "game-obj": "Spells",
+                "name": "divine decree",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "interplanar teleport",
+                "aonid": 1576,
+                "game-obj": "Spells",
+                "name": "interplanar teleport",
+                "type": "link"
+              },
+              {
+                "alt": "sunburst",
+                "aonid": 1707,
+                "game-obj": "Spells",
+                "name": "sunburst",
+                "type": "link"
+              },
+              {
+                "alt": "collective memories",
+                "aonid": 113,
+                "game-obj": "Rituals",
+                "name": "collective memories",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -847,146 +385,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As ancient sky dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cataclysm",
-                            "aonid": 1460,
-                            "game-obj": "Spells",
-                            "name": "cataclysm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cataclysm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gate",
-                            "aonid": 1540,
-                            "game-obj": "Spells",
-                            "name": "gate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wrathful storm",
-                            "aonid": 1759,
-                            "game-obj": "Spells",
-                            "name": "wrathful storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wrathful storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Sky Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cataclysm",
+                "aonid": 1460,
+                "game-obj": "Spells",
+                "name": "cataclysm",
+                "type": "link"
+              },
+              {
+                "alt": "gate",
+                "aonid": 1540,
+                "game-obj": "Spells",
+                "name": "gate",
+                "type": "link"
+              },
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "wrathful storm",
+                "aonid": 1759,
+                "game-obj": "Spells",
+                "name": "wrathful storm",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1001,48 +434,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1053,263 +449,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1319,7 +499,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1345,6 +524,1183 @@
         }
       ],
       "text": "Sky dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine wrath",
+          "aonid": 1499,
+          "game-obj": "Spells",
+          "name": "divine wrath",
+          "type": "link"
+        },
+        {
+          "alt": "read omens",
+          "aonid": 1647,
+          "game-obj": "Spells",
+          "name": "read omens",
+          "type": "link"
+        },
+        {
+          "alt": "ream message",
+          "aonid": 1503,
+          "game-obj": "Spells",
+          "name": "ream message",
+          "type": "link"
+        },
+        {
+          "alt": "heroism",
+          "aonid": 1555,
+          "game-obj": "Spells",
+          "name": "heroism",
+          "type": "link"
+        },
+        {
+          "alt": "locate",
+          "aonid": 1588,
+          "game-obj": "Spells",
+          "name": "locate",
+          "type": "link"
+        },
+        {
+          "alt": "augury",
+          "aonid": 1445,
+          "game-obj": "Spells",
+          "name": "augury",
+          "type": "link"
+        },
+        {
+          "alt": "translate",
+          "aonid": 1723,
+          "game-obj": "Spells",
+          "name": "translate",
+          "type": "link"
+        },
+        {
+          "alt": "create food",
+          "aonid": 1475,
+          "game-obj": "Spells",
+          "name": "create food",
+          "type": "link"
+        },
+        {
+          "alt": "alarm",
+          "aonid": 1439,
+          "game-obj": "Spells",
+          "name": "alarm",
+          "type": "link"
+        },
+        {
+          "alt": "bless",
+          "aonid": 1451,
+          "game-obj": "Spells",
+          "name": "bless",
+          "type": "link"
+        },
+        {
+          "alt": "sanctuary",
+          "aonid": 1660,
+          "game-obj": "Spells",
+          "name": "sanctuary",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 1498,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 1381,
+          "game-obj": "Rules",
+          "name": "stabilize",
+          "type": "link"
+        },
+        {
+          "alt": "consecrate",
+          "aonid": 115,
+          "game-obj": "Rituals",
+          "name": "consecrate",
+          "type": "link"
+        }
+      ],
+      "name": "Young Sky Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 163",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 163",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 163,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine wrath",
+                      "aonid": 1499,
+                      "game-obj": "Spells",
+                      "name": "divine wrath",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine wrath",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read omens",
+                      "aonid": 1647,
+                      "game-obj": "Spells",
+                      "name": "read omens",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read omens",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ream message",
+                      "aonid": 1503,
+                      "game-obj": "Spells",
+                      "name": "ream message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dream message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heroism",
+                      "aonid": 1555,
+                      "game-obj": "Spells",
+                      "name": "heroism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "locate",
+                      "aonid": 1588,
+                      "game-obj": "Spells",
+                      "name": "locate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "locate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "augury",
+                      "aonid": 1445,
+                      "game-obj": "Spells",
+                      "name": "augury",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "augury",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translate",
+                      "aonid": 1723,
+                      "game-obj": "Spells",
+                      "name": "translate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create food",
+                      "aonid": 1475,
+                      "game-obj": "Spells",
+                      "name": "create food",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create food",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "alarm",
+                      "aonid": 1439,
+                      "game-obj": "Spells",
+                      "name": "alarm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "alarm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bless",
+                      "aonid": 1451,
+                      "game-obj": "Spells",
+                      "name": "bless",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bless",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sanctuary",
+                      "aonid": 1660,
+                      "game-obj": "Spells",
+                      "name": "sanctuary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sanctuary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 1498,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 1381,
+                      "game-obj": "Rules",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "consecrate",
+                      "aonid": 115,
+                      "game-obj": "Rituals",
+                      "name": "consecrate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "consecrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 28, attack +20; **4th** *dispel magic*, *divine wrath*, *read omens*; **3rd** d*ream message*, *heroism*, *locate*; **2nd** *augury*, *translate*, *create food*; **1st** *alarm*, *bless*, *sanctuary*; **Cantrips (4th)** *detect magic*, *divine lance*, *read aura*, *shield*, stabilize; **Rituals** DC 28; *consecrate*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "blessed boundary",
+          "aonid": 1452,
+          "game-obj": "Spells",
+          "name": "blessed boundary",
+          "type": "link"
+        },
+        {
+          "alt": "spirit blast",
+          "aonid": 1685,
+          "game-obj": "Spells",
+          "name": "spirit blast",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "scouting eye",
+          "aonid": 1661,
+          "game-obj": "Spells",
+          "name": "scouting eye",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        },
+        {
+          "alt": "atone",
+          "aonid": 108,
+          "game-obj": "Rituals",
+          "name": "atone",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Sky Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 163",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 163",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 163,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young sky dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blessed boundary",
+                      "aonid": 1452,
+                      "game-obj": "Spells",
+                      "name": "blessed boundary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blessed boundary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit blast",
+                      "aonid": 1685,
+                      "game-obj": "Spells",
+                      "name": "spirit blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scouting eye",
+                      "aonid": 1661,
+                      "game-obj": "Spells",
+                      "name": "scouting eye",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scouting eye",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "atone",
+                      "aonid": 108,
+                      "game-obj": "Rituals",
+                      "name": "atone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "atone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 33, attack +25; As young sky dragon, plus **6th** *blessed boundary*, *spirit blast*, *truesight*; **5th** *banishment*, *scouting eye*, *truespeech*; **Cantrips (6th)** *detect magic*, *divine lance*, *read aura*, *shield*, *stabilize*; **Rituals** DC 33; *atone*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "canticle of everlasting grief",
+          "aonid": 1459,
+          "game-obj": "Spells",
+          "name": "canticle of everlasting grief",
+          "type": "link"
+        },
+        {
+          "alt": "divine decree",
+          "aonid": 1495,
+          "game-obj": "Spells",
+          "name": "divine decree",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "interplanar teleport",
+          "aonid": 1576,
+          "game-obj": "Spells",
+          "name": "interplanar teleport",
+          "type": "link"
+        },
+        {
+          "alt": "sunburst",
+          "aonid": 1707,
+          "game-obj": "Spells",
+          "name": "sunburst",
+          "type": "link"
+        },
+        {
+          "alt": "collective memories",
+          "aonid": 113,
+          "game-obj": "Rituals",
+          "name": "collective memories",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Sky Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 163",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 163",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 163,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult sky dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "canticle of everlasting grief",
+                      "aonid": 1459,
+                      "game-obj": "Spells",
+                      "name": "canticle of everlasting grief",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "canticle of everlasting grief",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine decree",
+                      "aonid": 1495,
+                      "game-obj": "Spells",
+                      "name": "divine decree",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine decree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "interplanar teleport",
+                      "aonid": 1576,
+                      "game-obj": "Spells",
+                      "name": "interplanar teleport",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "interplanar teleport",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sunburst",
+                      "aonid": 1707,
+                      "game-obj": "Spells",
+                      "name": "sunburst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sunburst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "collective memories",
+                      "aonid": 113,
+                      "game-obj": "Rituals",
+                      "name": "collective memories",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "collective memories",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 40, attack +32; As adult sky dragon, plus **8th** *canticle of everlasting grief*, *divine decree*, **pinpoint**; **7th** *energy aegis*, *interplanar teleport*, *sunburst*; **Cantrips (9th)** *detect magic*, *divine lance*, *read aura*, *shield*, *stabilize*; **Rituals** DC 42; *collective memories*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cataclysm",
+          "aonid": 1460,
+          "game-obj": "Spells",
+          "name": "cataclysm",
+          "type": "link"
+        },
+        {
+          "alt": "gate",
+          "aonid": 1540,
+          "game-obj": "Spells",
+          "name": "gate",
+          "type": "link"
+        },
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "wrathful storm",
+          "aonid": 1759,
+          "game-obj": "Spells",
+          "name": "wrathful storm",
+          "type": "link"
+        }
+      ],
+      "name": "Sky Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 163",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 163",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 163,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As ancient sky dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cataclysm",
+                      "aonid": 1460,
+                      "game-obj": "Spells",
+                      "name": "cataclysm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cataclysm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gate",
+                      "aonid": 1540,
+                      "game-obj": "Spells",
+                      "name": "gate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wrathful storm",
+                      "aonid": 1759,
+                      "game-obj": "Spells",
+                      "name": "wrathful storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wrathful storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 44, attack +36; As ancient sky dragon, plus **10th** *cataclysm*, *gate*; **9th** *falling stars*, *wrathful storm*; **Cantrips (10th)** *detect magic*, *divine lance*, *read aura*, *shield*, *stabilize*; **Rituals** DC 44",
       "type": "section"
     },
     {
@@ -1659,6 +2015,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 163",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 163",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 163,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1806,6 +2218,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 163",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 163",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 163,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_sovereign.json
+++ b/monster_families/draconic_codex/dragon_sovereign.json
@@ -74,318 +74,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect scrying",
-                            "aonid": 1487,
-                            "game-obj": "Spells",
-                            "name": "detect scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "flicker",
-                            "aonid": 1532,
-                            "game-obj": "Spells",
-                            "name": "flicker",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "flicker",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "silence",
-                            "aonid": 1674,
-                            "game-obj": "Spells",
-                            "name": "silence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "silence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enthrall",
-                            "aonid": 1516,
-                            "game-obj": "Spells",
-                            "name": "enthrall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enthrall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heroism",
-                            "aonid": 1555,
-                            "game-obj": "Spells",
-                            "name": "heroism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heroism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hypnotize",
-                            "aonid": 1564,
-                            "game-obj": "Spells",
-                            "name": "hypnotize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hypnotize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "status",
-                            "aonid": 1690,
-                            "game-obj": "Spells",
-                            "name": "status",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "status",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translate",
-                            "aonid": 1723,
-                            "game-obj": "Spells",
-                            "name": "translate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory disguise",
-                            "aonid": 1568,
-                            "game-obj": "Spells",
-                            "name": "illusory disguise",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "illusory disguise",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sure strike",
-                            "aonid": 1709,
-                            "game-obj": "Spells",
-                            "name": "sure strike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sure strike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Sovereign Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "detect scrying",
+                "aonid": 1487,
+                "game-obj": "Spells",
+                "name": "detect scrying",
+                "type": "link"
+              },
+              {
+                "alt": "flicker",
+                "aonid": 1532,
+                "game-obj": "Spells",
+                "name": "flicker",
+                "type": "link"
+              },
+              {
+                "alt": "silence",
+                "aonid": 1674,
+                "game-obj": "Spells",
+                "name": "silence",
+                "type": "link"
+              },
+              {
+                "alt": "enthrall",
+                "aonid": 1516,
+                "game-obj": "Spells",
+                "name": "enthrall",
+                "type": "link"
+              },
+              {
+                "alt": "heroism",
+                "aonid": 1555,
+                "game-obj": "Spells",
+                "name": "heroism",
+                "type": "link"
+              },
+              {
+                "alt": "hypnotize",
+                "aonid": 1564,
+                "game-obj": "Spells",
+                "name": "hypnotize",
+                "type": "link"
+              },
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "status",
+                "aonid": 1690,
+                "game-obj": "Spells",
+                "name": "status",
+                "type": "link"
+              },
+              {
+                "alt": "translate",
+                "aonid": 1723,
+                "game-obj": "Spells",
+                "name": "translate",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "illusory disguise",
+                "aonid": 1568,
+                "game-obj": "Spells",
+                "name": "illusory disguise",
+                "type": "link"
+              },
+              {
+                "alt": "sure strike",
+                "aonid": 1709,
+                "game-obj": "Spells",
+                "name": "sure strike",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -401,170 +215,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young sovereign dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dominate",
-                            "aonid": 1501,
-                            "game-obj": "Spells",
-                            "name": "dominate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dominate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "never mind",
-                            "aonid": 1614,
-                            "game-obj": "Spells",
-                            "name": "never mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "never mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "zealous conviction",
-                            "aonid": 1760,
-                            "game-obj": "Spells",
-                            "name": "zealous conviction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "zealous conviction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dreaming potential",
-                            "aonid": 1504,
-                            "game-obj": "Spells",
-                            "name": "dreaming potential",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dreaming potential",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "subconscious suggestion",
-                            "aonid": 1692,
-                            "game-obj": "Spells",
-                            "name": "subconscious suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "subconscious suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Sovereign Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "never mind",
+                "aonid": 1614,
+                "game-obj": "Spells",
+                "name": "never mind",
+                "type": "link"
+              },
+              {
+                "alt": "zealous conviction",
+                "aonid": 1760,
+                "game-obj": "Spells",
+                "name": "zealous conviction",
+                "type": "link"
+              },
+              {
+                "alt": "dreaming potential",
+                "aonid": 1504,
+                "game-obj": "Spells",
+                "name": "dreaming potential",
+                "type": "link"
+              },
+              {
+                "alt": "subconscious suggestion",
+                "aonid": 1692,
+                "game-obj": "Spells",
+                "name": "subconscious suggestion",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -580,223 +279,76 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult sovereign dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telepathic demand",
-                            "aonid": 2036,
-                            "game-obj": "Spells",
-                            "name": "telepathic demand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telepathic demand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 1490,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dream council",
-                            "aonid": 1988,
-                            "game-obj": "Spells",
-                            "name": "dream council",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dream council",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "quandary",
-                            "aonid": 1644,
-                            "game-obj": "Spells",
-                            "name": "quandary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "quandary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar palace",
-                            "aonid": 1634,
-                            "game-obj": "Spells",
-                            "name": "planar palace",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar palace",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar seal",
-                            "aonid": 1635,
-                            "game-obj": "Spells",
-                            "name": "planar seal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar seal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true target",
-                            "aonid": 1726,
-                            "game-obj": "Spells",
-                            "name": "true target",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true target",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Sovereign Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "telepathic demand",
+                "aonid": 2036,
+                "game-obj": "Spells",
+                "name": "telepathic demand",
+                "type": "link"
+              },
+              {
+                "alt": "disappearance",
+                "aonid": 1490,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "dream council",
+                "aonid": 1988,
+                "game-obj": "Spells",
+                "name": "dream council",
+                "type": "link"
+              },
+              {
+                "alt": "quandary",
+                "aonid": 1644,
+                "game-obj": "Spells",
+                "name": "quandary",
+                "type": "link"
+              },
+              {
+                "alt": "planar palace",
+                "aonid": 1634,
+                "game-obj": "Spells",
+                "name": "planar palace",
+                "type": "link"
+              },
+              {
+                "alt": "planar seal",
+                "aonid": 1635,
+                "game-obj": "Spells",
+                "name": "planar seal",
+                "type": "link"
+              },
+              {
+                "alt": "true target",
+                "aonid": 1726,
+                "game-obj": "Spells",
+                "name": "true target",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -811,44 +363,28 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "gate",
-                    "aonid": 1540,
-                    "game-obj": "Spells",
-                    "name": "gate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "indestructibility",
-                    "aonid": 1573,
-                    "game-obj": "Spells",
-                    "name": "indestructibility",
-                    "type": "link"
-                  }
-                ],
-                "name": "10th",
-                "subtype": "ability",
-                "text": "*gate*, *indestructibility*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Cantrips (10th)",
-                "subtype": "ability",
-                "text": "*daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sovereign Archdragon')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "gate",
+                "aonid": 1540,
+                "game-obj": "Spells",
+                "name": "gate",
+                "type": "link"
+              },
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -858,54 +394,16 @@
         ],
         "name": "Sovereign Archdragon",
         "subtype": "monster_family",
-        "text": "Occult Prepared Spells DC 46, attack +38; As ancient sovereign dragon, plus",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -916,263 +414,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1182,7 +464,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1208,6 +489,1059 @@
         }
       ],
       "text": "Sovereign dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "detect scrying",
+          "aonid": 1487,
+          "game-obj": "Spells",
+          "name": "detect scrying",
+          "type": "link"
+        },
+        {
+          "alt": "flicker",
+          "aonid": 1532,
+          "game-obj": "Spells",
+          "name": "flicker",
+          "type": "link"
+        },
+        {
+          "alt": "silence",
+          "aonid": 1674,
+          "game-obj": "Spells",
+          "name": "silence",
+          "type": "link"
+        },
+        {
+          "alt": "enthrall",
+          "aonid": 1516,
+          "game-obj": "Spells",
+          "name": "enthrall",
+          "type": "link"
+        },
+        {
+          "alt": "heroism",
+          "aonid": 1555,
+          "game-obj": "Spells",
+          "name": "heroism",
+          "type": "link"
+        },
+        {
+          "alt": "hypnotize",
+          "aonid": 1564,
+          "game-obj": "Spells",
+          "name": "hypnotize",
+          "type": "link"
+        },
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "status",
+          "aonid": 1690,
+          "game-obj": "Spells",
+          "name": "status",
+          "type": "link"
+        },
+        {
+          "alt": "translate",
+          "aonid": 1723,
+          "game-obj": "Spells",
+          "name": "translate",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "illusory disguise",
+          "aonid": 1568,
+          "game-obj": "Spells",
+          "name": "illusory disguise",
+          "type": "link"
+        },
+        {
+          "alt": "sure strike",
+          "aonid": 1709,
+          "game-obj": "Spells",
+          "name": "sure strike",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        }
+      ],
+      "name": "Young Sovereign Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 167",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 167",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 167,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect scrying",
+                      "aonid": 1487,
+                      "game-obj": "Spells",
+                      "name": "detect scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "flicker",
+                      "aonid": 1532,
+                      "game-obj": "Spells",
+                      "name": "flicker",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "flicker",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "silence",
+                      "aonid": 1674,
+                      "game-obj": "Spells",
+                      "name": "silence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "silence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enthrall",
+                      "aonid": 1516,
+                      "game-obj": "Spells",
+                      "name": "enthrall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enthrall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heroism",
+                      "aonid": 1555,
+                      "game-obj": "Spells",
+                      "name": "heroism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heroism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hypnotize",
+                      "aonid": 1564,
+                      "game-obj": "Spells",
+                      "name": "hypnotize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hypnotize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "status",
+                      "aonid": 1690,
+                      "game-obj": "Spells",
+                      "name": "status",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "status",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translate",
+                      "aonid": 1723,
+                      "game-obj": "Spells",
+                      "name": "translate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory disguise",
+                      "aonid": 1568,
+                      "game-obj": "Spells",
+                      "name": "illusory disguise",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "illusory disguise",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sure strike",
+                      "aonid": 1709,
+                      "game-obj": "Spells",
+                      "name": "sure strike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sure strike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 30, attack +22; **4th** *detect scrying*, *flicker*, *silence*; **3rd** *enthrall*, *heroism*, *hypnotize*; **2nd** *clear mind*, *status*, *translate*; **1st** *command*, *illusory disguise*, *sure strike*; **Cantrips (4th)** *daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "never mind",
+          "aonid": 1614,
+          "game-obj": "Spells",
+          "name": "never mind",
+          "type": "link"
+        },
+        {
+          "alt": "zealous conviction",
+          "aonid": 1760,
+          "game-obj": "Spells",
+          "name": "zealous conviction",
+          "type": "link"
+        },
+        {
+          "alt": "dreaming potential",
+          "aonid": 1504,
+          "game-obj": "Spells",
+          "name": "dreaming potential",
+          "type": "link"
+        },
+        {
+          "alt": "subconscious suggestion",
+          "aonid": 1692,
+          "game-obj": "Spells",
+          "name": "subconscious suggestion",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Sovereign Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 167",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 167",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 167,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young sovereign dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dominate",
+                      "aonid": 1501,
+                      "game-obj": "Spells",
+                      "name": "dominate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dominate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "never mind",
+                      "aonid": 1614,
+                      "game-obj": "Spells",
+                      "name": "never mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "never mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "zealous conviction",
+                      "aonid": 1760,
+                      "game-obj": "Spells",
+                      "name": "zealous conviction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "zealous conviction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dreaming potential",
+                      "aonid": 1504,
+                      "game-obj": "Spells",
+                      "name": "dreaming potential",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dreaming potential",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "subconscious suggestion",
+                      "aonid": 1692,
+                      "game-obj": "Spells",
+                      "name": "subconscious suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "subconscious suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 36, attack +28; As young sovereign dragon, plus **6th** *dominate*, *never mind*, *zealous conviction*; **5th** *dreaming potential*, *subconscious suggestion*, *truespeech*; **Cantrips (6th)** *daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "telepathic demand",
+          "aonid": 2036,
+          "game-obj": "Spells",
+          "name": "telepathic demand",
+          "type": "link"
+        },
+        {
+          "alt": "disappearance",
+          "aonid": 1490,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "dream council",
+          "aonid": 1988,
+          "game-obj": "Spells",
+          "name": "dream council",
+          "type": "link"
+        },
+        {
+          "alt": "quandary",
+          "aonid": 1644,
+          "game-obj": "Spells",
+          "name": "quandary",
+          "type": "link"
+        },
+        {
+          "alt": "planar palace",
+          "aonid": 1634,
+          "game-obj": "Spells",
+          "name": "planar palace",
+          "type": "link"
+        },
+        {
+          "alt": "planar seal",
+          "aonid": 1635,
+          "game-obj": "Spells",
+          "name": "planar seal",
+          "type": "link"
+        },
+        {
+          "alt": "true target",
+          "aonid": 1726,
+          "game-obj": "Spells",
+          "name": "true target",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Sovereign Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 167",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 167",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 167,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult sovereign dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telepathic demand",
+                      "aonid": 2036,
+                      "game-obj": "Spells",
+                      "name": "telepathic demand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telepathic demand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 1490,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dream council",
+                      "aonid": 1988,
+                      "game-obj": "Spells",
+                      "name": "dream council",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dream council",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "quandary",
+                      "aonid": 1644,
+                      "game-obj": "Spells",
+                      "name": "quandary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "quandary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar palace",
+                      "aonid": 1634,
+                      "game-obj": "Spells",
+                      "name": "planar palace",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar palace",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar seal",
+                      "aonid": 1635,
+                      "game-obj": "Spells",
+                      "name": "planar seal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar seal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true target",
+                      "aonid": 1726,
+                      "game-obj": "Spells",
+                      "name": "true target",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true target",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 42, attack +34; As adult sovereign dragon, plus **9th** *foresight*, *overwhelming presence*, *telepathic demand*; **8th** *disappearance*, *dream council*, *quandary*; **7th** *planar palace*, *planar seal*, *true target*; **Cantrips (9th)** *daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "gate",
+              "aonid": 1540,
+              "game-obj": "Spells",
+              "name": "gate",
+              "type": "link"
+            },
+            {
+              "alt": "indestructibility",
+              "aonid": 1573,
+              "game-obj": "Spells",
+              "name": "indestructibility",
+              "type": "link"
+            }
+          ],
+          "name": "10th",
+          "subtype": "ability",
+          "text": "*gate*, *indestructibility*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Cantrips (10th)",
+          "subtype": "ability",
+          "text": "*daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "gate",
+          "aonid": 1540,
+          "game-obj": "Spells",
+          "name": "gate",
+          "type": "link"
+        },
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        }
+      ],
+      "name": "Sovereign Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 167",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 167",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 167,
+          "type": "source"
+        }
+      ],
+      "text": "Occult Prepared Spells DC 46, attack +38; As ancient sovereign dragon, plus **10th** *gate*, *indestructibility*; **Cantrips (10th)** *daze*, *detect magic*, *prestidigitation*, *read aura*, *shield*",
       "type": "section"
     },
     {
@@ -1522,6 +1856,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 167",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 167",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 167,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1669,6 +2059,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 167",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 167",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 167,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_stormcrown.json
+++ b/monster_families/draconic_codex/dragon_stormcrown.json
@@ -65,303 +65,125 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bestial curse",
-                            "aonid": 1966,
-                            "game-obj": "Spells",
-                            "name": "bestial curse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bestial curse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stifling stillness",
-                            "aonid": 1322,
-                            "game-obj": "Spells",
-                            "name": "stifling stillness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stifling stillness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blindness",
-                            "aonid": 1453,
-                            "game-obj": "Spells",
-                            "name": "blindness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blindness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tempest cloak",
-                            "aonid": 1323,
-                            "game-obj": "Spells",
-                            "name": "tempest cloak",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tempest cloak",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "deafness",
-                            "aonid": 1483,
-                            "game-obj": "Spells",
-                            "name": "deafness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "deafness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shatter",
-                            "aonid": 1670,
-                            "game-obj": "Spells",
-                            "name": "shatter",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shatter",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "charm",
-                            "aonid": 1463,
-                            "game-obj": "Spells",
-                            "name": "charm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "charm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create water",
-                            "aonid": 1476,
-                            "game-obj": "Spells",
-                            "name": "create water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 1547,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 1509,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 1381,
-                            "game-obj": "Rules",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Stormcrown Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "bestial curse",
+                "aonid": 1966,
+                "game-obj": "Spells",
+                "name": "bestial curse",
+                "type": "link"
+              },
+              {
+                "alt": "stifling stillness",
+                "aonid": 1322,
+                "game-obj": "Spells",
+                "name": "stifling stillness",
+                "type": "link"
+              },
+              {
+                "alt": "blindness",
+                "aonid": 1453,
+                "game-obj": "Spells",
+                "name": "blindness",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "tempest cloak",
+                "aonid": 1323,
+                "game-obj": "Spells",
+                "name": "tempest cloak",
+                "type": "link"
+              },
+              {
+                "alt": "deafness",
+                "aonid": 1483,
+                "game-obj": "Spells",
+                "name": "deafness",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "shatter",
+                "aonid": 1670,
+                "game-obj": "Spells",
+                "name": "shatter",
+                "type": "link"
+              },
+              {
+                "alt": "charm",
+                "aonid": 1463,
+                "game-obj": "Spells",
+                "name": "charm",
+                "type": "link"
+              },
+              {
+                "alt": "create water",
+                "aonid": 1476,
+                "game-obj": "Spells",
+                "name": "create water",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 1547,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 1509,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 1381,
+                "game-obj": "Rules",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -377,178 +199,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as young stormcrown dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hydraulic torrent",
-                            "aonid": 1562,
-                            "game-obj": "Spells",
-                            "name": "hydraulic torrent",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "control water",
-                            "aonid": 1473,
-                            "game-obj": "Spells",
-                            "name": "control water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "control water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pressure zone",
-                            "aonid": 1318,
-                            "game-obj": "Spells",
-                            "name": "pressure zone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pressure zone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wisdom of the winds",
-                            "aonid": 1326,
-                            "game-obj": "Spells",
-                            "name": "wisdom of the winds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wisdom of the winds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "zephyr slip",
-                            "aonid": 1327,
-                            "game-obj": "Spells",
-                            "name": "zephyr slip",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "zephyr slip",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Stormcrown Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "hydraulic torrent",
+                "aonid": 1562,
+                "game-obj": "Spells",
+                "name": "hydraulic torrent",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "control water",
+                "aonid": 1473,
+                "game-obj": "Spells",
+                "name": "control water",
+                "type": "link"
+              },
+              {
+                "alt": "pressure zone",
+                "aonid": 1318,
+                "game-obj": "Spells",
+                "name": "pressure zone",
+                "type": "link"
+              },
+              {
+                "alt": "wisdom of the winds",
+                "aonid": 1326,
+                "game-obj": "Spells",
+                "name": "wisdom of the winds",
+                "type": "link"
+              },
+              {
+                "alt": "zephyr slip",
+                "aonid": 1327,
+                "game-obj": "Spells",
+                "name": "zephyr slip",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -564,193 +263,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as adult stormcrown dragon"
-                ],
-                "saving_throw": {
-                  "dc": 40,
-                  "subtype": "save_dc",
-                  "text": "DC 40",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heal",
-                            "aonid": 1554,
-                            "game-obj": "Spells",
-                            "name": "heal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 1607,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "punishing winds",
-                            "aonid": 1643,
-                            "game-obj": "Spells",
-                            "name": "punishing winds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "punishing winds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shock to the system",
-                            "aonid": 1320,
-                            "game-obj": "Spells",
-                            "name": "shock to the system",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shock to the system",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chain lightning",
-                            "aonid": 1462,
-                            "game-obj": "Spells",
-                            "name": "chain lightning",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chain lightning",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Storm Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "heal",
+                "aonid": 1554,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
+              },
+              {
+                "alt": "moment of renewal",
+                "aonid": 1607,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "punishing winds",
+                "aonid": 1643,
+                "game-obj": "Spells",
+                "name": "punishing winds",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "shock to the system",
+                "aonid": 1320,
+                "game-obj": "Spells",
+                "name": "shock to the system",
+                "type": "link"
+              },
+              {
+                "alt": "chain lightning",
+                "aonid": 1462,
+                "game-obj": "Spells",
+                "name": "chain lightning",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -766,155 +334,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "as ancient stormcrown dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "indestructibility",
-                            "aonid": 1573,
-                            "game-obj": "Spells",
-                            "name": "indestructibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "indestructibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Stormcrown Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
+              },
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -929,48 +390,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -981,263 +405,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1247,7 +455,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1273,6 +480,1141 @@
         }
       ],
       "text": "Stormcrown dragon spellcasters often cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "bestial curse",
+          "aonid": 1966,
+          "game-obj": "Spells",
+          "name": "bestial curse",
+          "type": "link"
+        },
+        {
+          "alt": "stifling stillness",
+          "aonid": 1322,
+          "game-obj": "Spells",
+          "name": "stifling stillness",
+          "type": "link"
+        },
+        {
+          "alt": "blindness",
+          "aonid": 1453,
+          "game-obj": "Spells",
+          "name": "blindness",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "tempest cloak",
+          "aonid": 1323,
+          "game-obj": "Spells",
+          "name": "tempest cloak",
+          "type": "link"
+        },
+        {
+          "alt": "deafness",
+          "aonid": 1483,
+          "game-obj": "Spells",
+          "name": "deafness",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "shatter",
+          "aonid": 1670,
+          "game-obj": "Spells",
+          "name": "shatter",
+          "type": "link"
+        },
+        {
+          "alt": "charm",
+          "aonid": 1463,
+          "game-obj": "Spells",
+          "name": "charm",
+          "type": "link"
+        },
+        {
+          "alt": "create water",
+          "aonid": 1476,
+          "game-obj": "Spells",
+          "name": "create water",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 1547,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 1509,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 1381,
+          "game-obj": "Rules",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Young Stormcrown Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 171",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 171",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 171,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bestial curse",
+                      "aonid": 1966,
+                      "game-obj": "Spells",
+                      "name": "bestial curse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bestial curse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stifling stillness",
+                      "aonid": 1322,
+                      "game-obj": "Spells",
+                      "name": "stifling stillness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stifling stillness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blindness",
+                      "aonid": 1453,
+                      "game-obj": "Spells",
+                      "name": "blindness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blindness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tempest cloak",
+                      "aonid": 1323,
+                      "game-obj": "Spells",
+                      "name": "tempest cloak",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tempest cloak",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "deafness",
+                      "aonid": 1483,
+                      "game-obj": "Spells",
+                      "name": "deafness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "deafness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shatter",
+                      "aonid": 1670,
+                      "game-obj": "Spells",
+                      "name": "shatter",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shatter",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "charm",
+                      "aonid": 1463,
+                      "game-obj": "Spells",
+                      "name": "charm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "charm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create water",
+                      "aonid": 1476,
+                      "game-obj": "Spells",
+                      "name": "create water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 1547,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 1509,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 1381,
+                      "game-obj": "Rules",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 28, attack +20; **4th** *bestial curse*, *stifling stillness*; **3rd** *blindness*, *haste*, *tempest cloak*; **2nd** *deafness*, *mist*, *shatter*; **1st** *charm*, *create water*, *grease*; **Cantrips (4th)** *detect magic*, *electric arc*, *know the way*, *read aura*, stabilize",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "hydraulic torrent",
+          "aonid": 1562,
+          "game-obj": "Spells",
+          "name": "hydraulic torrent",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "control water",
+          "aonid": 1473,
+          "game-obj": "Spells",
+          "name": "control water",
+          "type": "link"
+        },
+        {
+          "alt": "pressure zone",
+          "aonid": 1318,
+          "game-obj": "Spells",
+          "name": "pressure zone",
+          "type": "link"
+        },
+        {
+          "alt": "wisdom of the winds",
+          "aonid": 1326,
+          "game-obj": "Spells",
+          "name": "wisdom of the winds",
+          "type": "link"
+        },
+        {
+          "alt": "zephyr slip",
+          "aonid": 1327,
+          "game-obj": "Spells",
+          "name": "zephyr slip",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Stormcrown Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 171",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 171",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 171,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as young stormcrown dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hydraulic torrent",
+                      "aonid": 1562,
+                      "game-obj": "Spells",
+                      "name": "hydraulic torrent",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "control water",
+                      "aonid": 1473,
+                      "game-obj": "Spells",
+                      "name": "control water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "control water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pressure zone",
+                      "aonid": 1318,
+                      "game-obj": "Spells",
+                      "name": "pressure zone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pressure zone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wisdom of the winds",
+                      "aonid": 1326,
+                      "game-obj": "Spells",
+                      "name": "wisdom of the winds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wisdom of the winds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "zephyr slip",
+                      "aonid": 1327,
+                      "game-obj": "Spells",
+                      "name": "zephyr slip",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "zephyr slip",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 33, attack +25; as young stormcrown dragon, plus **6th** *hydraulic torrent*, *truesight*; **5th** *control water*, *pressure zone*, *wisdom of the winds*; **4th** *zephyr slip*; **Cantrips (6th)** *detect magic*, *electric arc*, *know the way*, *read aura*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "heal",
+          "aonid": 1554,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        },
+        {
+          "alt": "moment of renewal",
+          "aonid": 1607,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "punishing winds",
+          "aonid": 1643,
+          "game-obj": "Spells",
+          "name": "punishing winds",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "shock to the system",
+          "aonid": 1320,
+          "game-obj": "Spells",
+          "name": "shock to the system",
+          "type": "link"
+        },
+        {
+          "alt": "chain lightning",
+          "aonid": 1462,
+          "game-obj": "Spells",
+          "name": "chain lightning",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Storm Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 171",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 171",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 171,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as adult stormcrown dragon"
+          ],
+          "saving_throw": {
+            "dc": 40,
+            "subtype": "save_dc",
+            "text": "DC 40",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heal",
+                      "aonid": 1554,
+                      "game-obj": "Spells",
+                      "name": "heal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 1607,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "punishing winds",
+                      "aonid": 1643,
+                      "game-obj": "Spells",
+                      "name": "punishing winds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "punishing winds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shock to the system",
+                      "aonid": 1320,
+                      "game-obj": "Spells",
+                      "name": "shock to the system",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shock to the system",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chain lightning",
+                      "aonid": 1462,
+                      "game-obj": "Spells",
+                      "name": "chain lightning",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chain lightning",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 40, attack +32; as adult stormcrown dragon, plus **8th** *heal*, *moment of renewal*, *punishing winds*; **7th** *mask of terror*, *regenerate*, *shock to the system*; **6th** *chain lightning*; **Cantrips (8th)** *detect magic*, *electric arc*, *know the way*, *read aura*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        },
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        }
+      ],
+      "name": "Stormcrown Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 171",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 171",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 171,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "as ancient stormcrown dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "indestructibility",
+                      "aonid": 1573,
+                      "game-obj": "Spells",
+                      "name": "indestructibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "indestructibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 44, attack +36; as ancient stormcrown dragon, plus **10th** *indestructibility*, *manifestation*; **9th** *detonate magic*, *falling stars*, *implosion*; **Cantrips (10th)** *detect magic*, *electric arc*, *know the way*, *read aura*, *stabilize*",
       "type": "section"
     },
     {
@@ -1587,6 +1929,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 171",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 171",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 171,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1734,6 +2132,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 171",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 171",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 171,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_time.json
+++ b/monster_families/draconic_codex/dragon_time.json
@@ -75,394 +75,160 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal calamity",
-                            "aonid": 1630,
-                            "game-obj": "Spells",
-                            "name": "phantasmal calamity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal calamity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "invoke spirits",
-                            "aonid": 1578,
-                            "game-obj": "Spells",
-                            "name": "invoke spirits",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "invoke spirits",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "flicker",
-                            "aonid": 1532,
-                            "game-obj": "Spells",
-                            "name": "flicker",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "flicker",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vision of death",
-                            "aonid": 1742,
-                            "game-obj": "Spells",
-                            "name": "vision of death",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vision of death",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enthrall",
-                            "aonid": 1516,
-                            "game-obj": "Spells",
-                            "name": "enthrall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enthrall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "temporal twin",
-                            "aonid": 1191,
-                            "game-obj": "Spells",
-                            "name": "temporal twin",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "temporal twin",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blur",
-                            "aonid": 1455,
-                            "game-obj": "Spells",
-                            "name": "blur",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blur",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "loose time\u2019s arrow",
-                            "aonid": 1185,
-                            "game-obj": "Spells",
-                            "name": "loose time\u2019s arrow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "loose time\u2019s arrow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "see the unseen",
-                            "aonid": 1663,
-                            "game-obj": "Spells",
-                            "name": "see the unseen",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "see the unseen",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal minion",
-                            "aonid": 1631,
-                            "game-obj": "Spells",
-                            "name": "phantasmal minion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal minion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count_text": "\u00d72",
-                        "links": [
-                          {
-                            "alt": "sure strike",
-                            "aonid": 1709,
-                            "game-obj": "Spells",
-                            "name": "sure strike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sure strike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Time Dragon\"')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "phantasmal calamity",
+                "aonid": 1630,
+                "game-obj": "Spells",
+                "name": "phantasmal calamity",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "invoke spirits",
+                "aonid": 1578,
+                "game-obj": "Spells",
+                "name": "invoke spirits",
+                "type": "link"
+              },
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
+              },
+              {
+                "alt": "flicker",
+                "aonid": 1532,
+                "game-obj": "Spells",
+                "name": "flicker",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "vision of death",
+                "aonid": 1742,
+                "game-obj": "Spells",
+                "name": "vision of death",
+                "type": "link"
+              },
+              {
+                "alt": "enthrall",
+                "aonid": 1516,
+                "game-obj": "Spells",
+                "name": "enthrall",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "temporal twin",
+                "aonid": 1191,
+                "game-obj": "Spells",
+                "name": "temporal twin",
+                "type": "link"
+              },
+              {
+                "alt": "blur",
+                "aonid": 1455,
+                "game-obj": "Spells",
+                "name": "blur",
+                "type": "link"
+              },
+              {
+                "alt": "loose time\u2019s arrow",
+                "aonid": 1185,
+                "game-obj": "Spells",
+                "name": "loose time\u2019s arrow",
+                "type": "link"
+              },
+              {
+                "alt": "see the unseen",
+                "aonid": 1663,
+                "game-obj": "Spells",
+                "name": "see the unseen",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal minion",
+                "aonid": 1631,
+                "game-obj": "Spells",
+                "name": "phantasmal minion",
+                "type": "link"
+              },
+              {
+                "alt": "sure strike",
+                "aonid": 1709,
+                "game-obj": "Spells",
+                "name": "sure strike",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -478,178 +244,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young time dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 1490,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "eclipse burst",
-                            "aonid": 1508,
-                            "game-obj": "Spells",
-                            "name": "eclipse burst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "eclipse burst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar palace",
-                            "aonid": 1634,
-                            "game-obj": "Spells",
-                            "name": "planar palace",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar palace",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "retrocognition",
-                            "aonid": 1652,
-                            "game-obj": "Spells",
-                            "name": "retrocognition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "retrocognition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disintegrate",
-                            "aonid": 1492,
-                            "game-obj": "Spells",
-                            "name": "disintegrate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disintegrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Time Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disappearance",
+                "aonid": 1490,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "eclipse burst",
+                "aonid": 1508,
+                "game-obj": "Spells",
+                "name": "eclipse burst",
+                "type": "link"
+              },
+              {
+                "alt": "planar palace",
+                "aonid": 1634,
+                "game-obj": "Spells",
+                "name": "planar palace",
+                "type": "link"
+              },
+              {
+                "alt": "retrocognition",
+                "aonid": 1652,
+                "game-obj": "Spells",
+                "name": "retrocognition",
+                "type": "link"
+              },
+              {
+                "alt": "disintegrate",
+                "aonid": 1492,
+                "game-obj": "Spells",
+                "name": "disintegrate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -665,131 +308,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult time dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "metamorphosis",
-                            "aonid": 1599,
-                            "game-obj": "Spells",
-                            "name": "metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "disintegrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Time Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "metamorphosis",
+                "aonid": 1599,
+                "game-obj": "Spells",
+                "name": "metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -805,102 +351,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult time dragon"
-                ],
-                "saving_throw": {
-                  "dc": 46,
-                  "subtype": "save_dc",
-                  "text": "DC 46",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "remake",
-                            "aonid": 1649,
-                            "game-obj": "Spells",
-                            "name": "remake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "remake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revival",
-                            "aonid": 1654,
-                            "game-obj": "Spells",
-                            "name": "revival",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revival",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Time Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "remake",
+                "aonid": 1649,
+                "game-obj": "Spells",
+                "name": "remake",
+                "type": "link"
+              },
+              {
+                "alt": "revival",
+                "aonid": 1654,
+                "game-obj": "Spells",
+                "name": "revival",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -915,48 +386,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -967,263 +401,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1233,7 +451,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1259,6 +476,1103 @@
         }
       ],
       "text": "Time dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "phantasmal calamity",
+          "aonid": 1630,
+          "game-obj": "Spells",
+          "name": "phantasmal calamity",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "invoke spirits",
+          "aonid": 1578,
+          "game-obj": "Spells",
+          "name": "invoke spirits",
+          "type": "link"
+        },
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        },
+        {
+          "alt": "flicker",
+          "aonid": 1532,
+          "game-obj": "Spells",
+          "name": "flicker",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "vision of death",
+          "aonid": 1742,
+          "game-obj": "Spells",
+          "name": "vision of death",
+          "type": "link"
+        },
+        {
+          "alt": "enthrall",
+          "aonid": 1516,
+          "game-obj": "Spells",
+          "name": "enthrall",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "temporal twin",
+          "aonid": 1191,
+          "game-obj": "Spells",
+          "name": "temporal twin",
+          "type": "link"
+        },
+        {
+          "alt": "blur",
+          "aonid": 1455,
+          "game-obj": "Spells",
+          "name": "blur",
+          "type": "link"
+        },
+        {
+          "alt": "loose time\u2019s arrow",
+          "aonid": 1185,
+          "game-obj": "Spells",
+          "name": "loose time\u2019s arrow",
+          "type": "link"
+        },
+        {
+          "alt": "see the unseen",
+          "aonid": 1663,
+          "game-obj": "Spells",
+          "name": "see the unseen",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal minion",
+          "aonid": 1631,
+          "game-obj": "Spells",
+          "name": "phantasmal minion",
+          "type": "link"
+        },
+        {
+          "alt": "sure strike",
+          "aonid": 1709,
+          "game-obj": "Spells",
+          "name": "sure strike",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Young Time Dragon\"",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 175",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 175",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 175,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal calamity",
+                      "aonid": 1630,
+                      "game-obj": "Spells",
+                      "name": "phantasmal calamity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal calamity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "invoke spirits",
+                      "aonid": 1578,
+                      "game-obj": "Spells",
+                      "name": "invoke spirits",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "invoke spirits",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "flicker",
+                      "aonid": 1532,
+                      "game-obj": "Spells",
+                      "name": "flicker",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "flicker",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vision of death",
+                      "aonid": 1742,
+                      "game-obj": "Spells",
+                      "name": "vision of death",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vision of death",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enthrall",
+                      "aonid": 1516,
+                      "game-obj": "Spells",
+                      "name": "enthrall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enthrall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "temporal twin",
+                      "aonid": 1191,
+                      "game-obj": "Spells",
+                      "name": "temporal twin",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "temporal twin",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blur",
+                      "aonid": 1455,
+                      "game-obj": "Spells",
+                      "name": "blur",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blur",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "loose time\u2019s arrow",
+                      "aonid": 1185,
+                      "game-obj": "Spells",
+                      "name": "loose time\u2019s arrow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "loose time\u2019s arrow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "see the unseen",
+                      "aonid": 1663,
+                      "game-obj": "Spells",
+                      "name": "see the unseen",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "see the unseen",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal minion",
+                      "aonid": 1631,
+                      "game-obj": "Spells",
+                      "name": "phantasmal minion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal minion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count_text": "\u00d72",
+                  "links": [
+                    {
+                      "alt": "sure strike",
+                      "aonid": 1709,
+                      "game-obj": "Spells",
+                      "name": "sure strike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sure strike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 30, attack +22; **6th** *phantasmal calamity*, *truesight*; **5th** *banishment*, *invoke spirits*, *sending*; **4th** *flicker*, *unfettered movement*, *vision of death*; **3rd** *enthrall*, *haste*, *temporal twin*; **2nd** *blur*, *loose time\u2019s arrow*, *see the unseen*; **1st** *phantasmal minion*, *sure strike* (\u00d72); **Cantrips (6th)** *daze*, *detect magic*, *message*, *sigil*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "disappearance",
+          "aonid": 1490,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "eclipse burst",
+          "aonid": 1508,
+          "game-obj": "Spells",
+          "name": "eclipse burst",
+          "type": "link"
+        },
+        {
+          "alt": "planar palace",
+          "aonid": 1634,
+          "game-obj": "Spells",
+          "name": "planar palace",
+          "type": "link"
+        },
+        {
+          "alt": "retrocognition",
+          "aonid": 1652,
+          "game-obj": "Spells",
+          "name": "retrocognition",
+          "type": "link"
+        },
+        {
+          "alt": "disintegrate",
+          "aonid": 1492,
+          "game-obj": "Spells",
+          "name": "disintegrate",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Time Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 175",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 175",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 175,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young time dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 1490,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "eclipse burst",
+                      "aonid": 1508,
+                      "game-obj": "Spells",
+                      "name": "eclipse burst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "eclipse burst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar palace",
+                      "aonid": 1634,
+                      "game-obj": "Spells",
+                      "name": "planar palace",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar palace",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "retrocognition",
+                      "aonid": 1652,
+                      "game-obj": "Spells",
+                      "name": "retrocognition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "retrocognition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disintegrate",
+                      "aonid": 1492,
+                      "game-obj": "Spells",
+                      "name": "disintegrate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disintegrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 36, attack +28; As young time dragon, plus **8th** *disappearance*, *hidden mind*; **7th** *eclipse burst*, *planar palace*, *retrocognition*; **6th** *disintegrate*; **Cantrips (8th)** *daze*, *detect magic*, *message*, *sigil*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "metamorphosis",
+          "aonid": 1599,
+          "game-obj": "Spells",
+          "name": "metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Time Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 175",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 175",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 175,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult time dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "metamorphosis",
+                      "aonid": 1599,
+                      "game-obj": "Spells",
+                      "name": "metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "disintegrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 42, attack +34; As adult time dragon, plus **9th** *falling stars*, *metamorphosis*, *foresight*; **8th** *disintegrate*; **Cantrips (9th)** *daze*, *detect magic*, *message*, *sigil*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "remake",
+          "aonid": 1649,
+          "game-obj": "Spells",
+          "name": "remake",
+          "type": "link"
+        },
+        {
+          "alt": "revival",
+          "aonid": 1654,
+          "game-obj": "Spells",
+          "name": "revival",
+          "type": "link"
+        }
+      ],
+      "name": "Time Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 175",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 175",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 175,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult time dragon"
+          ],
+          "saving_throw": {
+            "dc": 46,
+            "subtype": "save_dc",
+            "text": "DC 46",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "remake",
+                      "aonid": 1649,
+                      "game-obj": "Spells",
+                      "name": "remake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "remake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revival",
+                      "aonid": 1654,
+                      "game-obj": "Spells",
+                      "name": "revival",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revival",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 46, attack +38; As adult time dragon, plus **10th** *remake*, *revival*; **Cantrips (10th)** *daze*, *detect magic*, *message*, *sigil*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -1573,6 +1887,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 175",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 175",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 175,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1720,6 +2090,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 175",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 175",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 175,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_umbral.json
+++ b/monster_families/draconic_codex/dragon_umbral.json
@@ -74,347 +74,139 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shadow blast",
-                            "aonid": 1666,
-                            "game-obj": "Spells",
-                            "name": "shadow blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shadow blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nightmare",
-                            "aonid": 1615,
-                            "game-obj": "Spells",
-                            "name": "nightmare",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nightmare",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vision of death",
-                            "aonid": 1742,
-                            "game-obj": "Spells",
-                            "name": "vision of death",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vision of death",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "whispers of the void",
-                            "aonid": 2046,
-                            "game-obj": "Spells",
-                            "name": "whispers of the void",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "whispers of the void",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bind undead",
-                            "aonid": 1449,
-                            "game-obj": "Spells",
-                            "name": "bind undead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bind undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "veil of privacy",
-                            "aonid": 1739,
-                            "game-obj": "Spells",
-                            "name": "veil of privacy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "veil of privacy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 1560,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "paranoia",
-                            "aonid": 1623,
-                            "game-obj": "Spells",
-                            "name": "paranoia",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "paranoia",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "reaper\u2019s lantern",
-                            "aonid": 2017,
-                            "game-obj": "Spells",
-                            "name": "reaper\u2019s lantern",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "reaper\u2019s lantern",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grim tendrils",
-                            "aonid": 1548,
-                            "game-obj": "Spells",
-                            "name": "grim tendrils",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grim tendrils",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disguise magic",
-                            "aonid": 1491,
-                            "game-obj": "Spells",
-                            "name": "disguise magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disguise magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "void warp",
-                            "aonid": 1745,
-                            "game-obj": "Spells",
-                            "name": "void warp",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Umbral Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "shadow blast",
+                "aonid": 1666,
+                "game-obj": "Spells",
+                "name": "shadow blast",
+                "type": "link"
+              },
+              {
+                "alt": "nightmare",
+                "aonid": 1615,
+                "game-obj": "Spells",
+                "name": "nightmare",
+                "type": "link"
+              },
+              {
+                "alt": "vision of death",
+                "aonid": 1742,
+                "game-obj": "Spells",
+                "name": "vision of death",
+                "type": "link"
+              },
+              {
+                "alt": "whispers of the void",
+                "aonid": 2046,
+                "game-obj": "Spells",
+                "name": "whispers of the void",
+                "type": "link"
+              },
+              {
+                "alt": "bind undead",
+                "aonid": 1449,
+                "game-obj": "Spells",
+                "name": "bind undead",
+                "type": "link"
+              },
+              {
+                "alt": "veil of privacy",
+                "aonid": 1739,
+                "game-obj": "Spells",
+                "name": "veil of privacy",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 1560,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "paranoia",
+                "aonid": 1623,
+                "game-obj": "Spells",
+                "name": "paranoia",
+                "type": "link"
+              },
+              {
+                "alt": "reaper\u2019s lantern",
+                "aonid": 2017,
+                "game-obj": "Spells",
+                "name": "reaper\u2019s lantern",
+                "type": "link"
+              },
+              {
+                "alt": "grim tendrils",
+                "aonid": 1548,
+                "game-obj": "Spells",
+                "name": "grim tendrils",
+                "type": "link"
+              },
+              {
+                "alt": "disguise magic",
+                "aonid": 1491,
+                "game-obj": "Spells",
+                "name": "disguise magic",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "void warp",
+                "aonid": 1745,
+                "game-obj": "Spells",
+                "name": "void warp",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -430,160 +222,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young umbral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "interplanar teleport",
-                            "aonid": 1576,
-                            "game-obj": "Spells",
-                            "name": "interplanar teleport",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "interplanar teleport",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shadow blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "paranoia",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scintillating safeguard",
-                            "aonid": 2023,
-                            "game-obj": "Spells",
-                            "name": "scintillating safeguard",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scintillating safeguard",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slither",
-                            "aonid": 1676,
-                            "game-obj": "Spells",
-                            "name": "slither",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slither",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Umbral Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "interplanar teleport",
+                "aonid": 1576,
+                "game-obj": "Spells",
+                "name": "interplanar teleport",
+                "type": "link"
+              },
+              {
+                "alt": "scintillating safeguard",
+                "aonid": 2023,
+                "game-obj": "Spells",
+                "name": "scintillating safeguard",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "slither",
+                "aonid": 1676,
+                "game-obj": "Spells",
+                "name": "slither",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -599,169 +272,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult umbral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "shadow blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wails of the damned",
-                            "aonid": 1747,
-                            "game-obj": "Spells",
-                            "name": "wails of the damned",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wails of the damned",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "canticle of everlasting grief",
-                            "aonid": 1459,
-                            "game-obj": "Spells",
-                            "name": "canticle of everlasting grief",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "canticle of everlasting grief",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "execute",
-                            "aonid": 1519,
-                            "game-obj": "Spells",
-                            "name": "execute",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "execute",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Umbral Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "wails of the damned",
+                "aonid": 1747,
+                "game-obj": "Spells",
+                "name": "wails of the damned",
+                "type": "link"
+              },
+              {
+                "alt": "canticle of everlasting grief",
+                "aonid": 1459,
+                "game-obj": "Spells",
+                "name": "canticle of everlasting grief",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
+              },
+              {
+                "alt": "execute",
+                "aonid": 1519,
+                "game-obj": "Spells",
+                "name": "execute",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -777,125 +329,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient umbral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 46,
-                  "subtype": "save_dc",
-                  "text": "DC 46",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "indestructibility",
-                            "aonid": 1573,
-                            "game-obj": "Spells",
-                            "name": "indestructibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "indestructibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Umbral Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
+              },
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -910,48 +371,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -962,263 +386,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1228,7 +436,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1254,6 +461,1085 @@
         }
       ],
       "text": "Umbral dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "shadow blast",
+          "aonid": 1666,
+          "game-obj": "Spells",
+          "name": "shadow blast",
+          "type": "link"
+        },
+        {
+          "alt": "nightmare",
+          "aonid": 1615,
+          "game-obj": "Spells",
+          "name": "nightmare",
+          "type": "link"
+        },
+        {
+          "alt": "vision of death",
+          "aonid": 1742,
+          "game-obj": "Spells",
+          "name": "vision of death",
+          "type": "link"
+        },
+        {
+          "alt": "whispers of the void",
+          "aonid": 2046,
+          "game-obj": "Spells",
+          "name": "whispers of the void",
+          "type": "link"
+        },
+        {
+          "alt": "bind undead",
+          "aonid": 1449,
+          "game-obj": "Spells",
+          "name": "bind undead",
+          "type": "link"
+        },
+        {
+          "alt": "veil of privacy",
+          "aonid": 1739,
+          "game-obj": "Spells",
+          "name": "veil of privacy",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 1560,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "paranoia",
+          "aonid": 1623,
+          "game-obj": "Spells",
+          "name": "paranoia",
+          "type": "link"
+        },
+        {
+          "alt": "reaper\u2019s lantern",
+          "aonid": 2017,
+          "game-obj": "Spells",
+          "name": "reaper\u2019s lantern",
+          "type": "link"
+        },
+        {
+          "alt": "grim tendrils",
+          "aonid": 1548,
+          "game-obj": "Spells",
+          "name": "grim tendrils",
+          "type": "link"
+        },
+        {
+          "alt": "disguise magic",
+          "aonid": 1491,
+          "game-obj": "Spells",
+          "name": "disguise magic",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "void warp",
+          "aonid": 1745,
+          "game-obj": "Spells",
+          "name": "void warp",
+          "type": "link"
+        }
+      ],
+      "name": "Young Umbral Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 179",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 179",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 179,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shadow blast",
+                      "aonid": 1666,
+                      "game-obj": "Spells",
+                      "name": "shadow blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shadow blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nightmare",
+                      "aonid": 1615,
+                      "game-obj": "Spells",
+                      "name": "nightmare",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nightmare",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vision of death",
+                      "aonid": 1742,
+                      "game-obj": "Spells",
+                      "name": "vision of death",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vision of death",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "whispers of the void",
+                      "aonid": 2046,
+                      "game-obj": "Spells",
+                      "name": "whispers of the void",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "whispers of the void",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bind undead",
+                      "aonid": 1449,
+                      "game-obj": "Spells",
+                      "name": "bind undead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bind undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "veil of privacy",
+                      "aonid": 1739,
+                      "game-obj": "Spells",
+                      "name": "veil of privacy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "veil of privacy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 1560,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "paranoia",
+                      "aonid": 1623,
+                      "game-obj": "Spells",
+                      "name": "paranoia",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "paranoia",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "reaper\u2019s lantern",
+                      "aonid": 2017,
+                      "game-obj": "Spells",
+                      "name": "reaper\u2019s lantern",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "reaper\u2019s lantern",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grim tendrils",
+                      "aonid": 1548,
+                      "game-obj": "Spells",
+                      "name": "grim tendrils",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grim tendrils",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disguise magic",
+                      "aonid": 1491,
+                      "game-obj": "Spells",
+                      "name": "disguise magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disguise magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "void warp",
+                      "aonid": 1745,
+                      "game-obj": "Spells",
+                      "name": "void warp",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 30, attack +22; **5th** *dispel magic*, *shadow blast*; **4th** *nightmare*, *vision of death*, *whispers of the void*; **3rd** *dispel magic*, *bind undead*, *veil of privacy*; **2nd** *humanoid form*, *paranoia*, *reaper\u2019s lantern*; **1st** *grim tendrils*, *disguise magic*, *fear*; **Cantrips (5th)** *figment*, *know the way*, *light*, *sigil*, *void warp*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "interplanar teleport",
+          "aonid": 1576,
+          "game-obj": "Spells",
+          "name": "interplanar teleport",
+          "type": "link"
+        },
+        {
+          "alt": "scintillating safeguard",
+          "aonid": 2023,
+          "game-obj": "Spells",
+          "name": "scintillating safeguard",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "slither",
+          "aonid": 1676,
+          "game-obj": "Spells",
+          "name": "slither",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Umbral Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 179",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 179",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 179,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young umbral dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "interplanar teleport",
+                      "aonid": 1576,
+                      "game-obj": "Spells",
+                      "name": "interplanar teleport",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "interplanar teleport",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shadow blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "paranoia",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scintillating safeguard",
+                      "aonid": 2023,
+                      "game-obj": "Spells",
+                      "name": "scintillating safeguard",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scintillating safeguard",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slither",
+                      "aonid": 1676,
+                      "game-obj": "Spells",
+                      "name": "slither",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slither",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 36, attack +28; As young umbral dragon, plus **7th** *interplanar teleport*, *shadow blast*; **6th** *paranoia*, *scintillating safeguard*, *truesight*; **5th** *slither*; **Cantrips (7th)** *figment*, *know the way*, *light*, *sigil*, *void warp*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "wails of the damned",
+          "aonid": 1747,
+          "game-obj": "Spells",
+          "name": "wails of the damned",
+          "type": "link"
+        },
+        {
+          "alt": "canticle of everlasting grief",
+          "aonid": 1459,
+          "game-obj": "Spells",
+          "name": "canticle of everlasting grief",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        },
+        {
+          "alt": "execute",
+          "aonid": 1519,
+          "game-obj": "Spells",
+          "name": "execute",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Umbral Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 179",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 179",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 179,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult umbral dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "shadow blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wails of the damned",
+                      "aonid": 1747,
+                      "game-obj": "Spells",
+                      "name": "wails of the damned",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wails of the damned",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "canticle of everlasting grief",
+                      "aonid": 1459,
+                      "game-obj": "Spells",
+                      "name": "canticle of everlasting grief",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "canticle of everlasting grief",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "execute",
+                      "aonid": 1519,
+                      "game-obj": "Spells",
+                      "name": "execute",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "execute",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 42, attack +34; As adult umbral dragon, plus **9th** *shadow blast*, *wails of the damned*; **8th** *canticle of everlasting grief*, *mask of terror*, *pinpoint*; **7th** *execute*; **Cantrips (9th)** *figment*, *know the way*, *light*, *sigil*, *void warp*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        },
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        }
+      ],
+      "name": "Umbral Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 179",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 179",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 179,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient umbral dragon"
+          ],
+          "saving_throw": {
+            "dc": 46,
+            "subtype": "save_dc",
+            "text": "DC 46",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "indestructibility",
+                      "aonid": 1573,
+                      "game-obj": "Spells",
+                      "name": "indestructibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "indestructibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 46, attack +38; As ancient umbral dragon, plus **10th** *indestructibility*, *manifestation*; **9th** *overwhelming presence*; **Cantrips (10th)** *figment*, *know the way*, *light*, *sigil*, *void warp*",
       "type": "section"
     },
     {
@@ -1568,6 +1854,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 179",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 179",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 179,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1715,6 +2057,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 179",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 179",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 179,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_underworld.json
+++ b/monster_families/draconic_codex/dragon_underworld.json
@@ -65,250 +65,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Prepared Arcane Spells",
-                "saving_throw": {
-                  "dc": 25,
-                  "subtype": "save_dc",
-                  "text": "DC 25",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 17,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 1506,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fireball",
-                            "aonid": 1530,
-                            "game-obj": "Spells",
-                            "name": "fireball",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "knock",
-                            "aonid": 1581,
-                            "game-obj": "Spells",
-                            "name": "knock",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "knock",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resist energy",
-                            "aonid": 1651,
-                            "game-obj": "Spells",
-                            "name": "resist energy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resist energy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "carryall",
-                            "aonid": 1972,
-                            "game-obj": "Spells",
-                            "name": "carryall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "carryall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enfeeble",
-                            "aonid": 1513,
-                            "game-obj": "Spells",
-                            "name": "enfeeble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enfeeble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "force barrage",
-                            "aonid": 1536,
-                            "game-obj": "Spells",
-                            "name": "force barrage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "caustic blast",
-                            "aonid": 1461,
-                            "game-obj": "Spells",
-                            "name": "caustic blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ignition",
-                            "aonid": 1565,
-                            "game-obj": "Spells",
-                            "name": "ignition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Underworld Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "earthbind",
+                "aonid": 1506,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "fireball",
+                "aonid": 1530,
+                "game-obj": "Spells",
+                "name": "fireball",
+                "type": "link"
+              },
+              {
+                "alt": "knock",
+                "aonid": 1581,
+                "game-obj": "Spells",
+                "name": "knock",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "resist energy",
+                "aonid": 1651,
+                "game-obj": "Spells",
+                "name": "resist energy",
+                "type": "link"
+              },
+              {
+                "alt": "carryall",
+                "aonid": 1972,
+                "game-obj": "Spells",
+                "name": "carryall",
+                "type": "link"
+              },
+              {
+                "alt": "enfeeble",
+                "aonid": 1513,
+                "game-obj": "Spells",
+                "name": "enfeeble",
+                "type": "link"
+              },
+              {
+                "alt": "force barrage",
+                "aonid": 1536,
+                "game-obj": "Spells",
+                "name": "force barrage",
+                "type": "link"
+              },
+              {
+                "alt": "caustic blast",
+                "aonid": 1461,
+                "game-obj": "Spells",
+                "name": "caustic blast",
+                "type": "link"
+              },
+              {
+                "alt": "ignition",
+                "aonid": 1565,
+                "game-obj": "Spells",
+                "name": "ignition",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -324,178 +178,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Prepared Arcane Spells",
-                "notes": [
-                  "As young underworld dragon"
-                ],
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scouting eye",
-                            "aonid": 1661,
-                            "game-obj": "Spells",
-                            "name": "scouting eye",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scouting eye",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mirage",
-                            "aonid": 1604,
-                            "game-obj": "Spells",
-                            "name": "mirage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mirage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "peaceful bubble",
-                            "aonid": 1624,
-                            "game-obj": "Spells",
-                            "name": "peaceful bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "peaceful bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translocate",
-                            "aonid": 1724,
-                            "game-obj": "Spells",
-                            "name": "translocate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translocate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Underworld Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "scouting eye",
+                "aonid": 1661,
+                "game-obj": "Spells",
+                "name": "scouting eye",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
+              },
+              {
+                "alt": "mirage",
+                "aonid": 1604,
+                "game-obj": "Spells",
+                "name": "mirage",
+                "type": "link"
+              },
+              {
+                "alt": "peaceful bubble",
+                "aonid": 1624,
+                "game-obj": "Spells",
+                "name": "peaceful bubble",
+                "type": "link"
+              },
+              {
+                "alt": "translocate",
+                "aonid": 1724,
+                "game-obj": "Spells",
+                "name": "translocate",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -511,193 +242,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Prepared Arcane Spells",
-                "notes": [
-                  "As adult underworld dragon"
-                ],
-                "saving_throw": {
-                  "dc": 37,
-                  "subtype": "save_dc",
-                  "text": "DC 37",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 29,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fiery body",
-                            "aonid": 1527,
-                            "game-obj": "Spells",
-                            "name": "fiery body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fiery body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mislead",
-                            "aonid": 1605,
-                            "game-obj": "Spells",
-                            "name": "mislead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mislead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spellwrack",
-                            "aonid": 1683,
-                            "game-obj": "Spells",
-                            "name": "spellwrack",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spellwrack",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mind probe",
-                            "aonid": 1601,
-                            "game-obj": "Spells",
-                            "name": "mind probe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mind probe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Underworld Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "fiery body",
+                "aonid": 1527,
+                "game-obj": "Spells",
+                "name": "fiery body",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "mislead",
+                "aonid": 1605,
+                "game-obj": "Spells",
+                "name": "mislead",
+                "type": "link"
+              },
+              {
+                "alt": "spellwrack",
+                "aonid": 1683,
+                "game-obj": "Spells",
+                "name": "spellwrack",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "mind probe",
+                "aonid": 1601,
+                "game-obj": "Spells",
+                "name": "mind probe",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -713,140 +313,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Prepared Arcane Spells",
-                "notes": [
-                  "As ancient underworld dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cataclysm",
-                            "aonid": 1460,
-                            "game-obj": "Spells",
-                            "name": "cataclysm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cataclysm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "remake",
-                            "aonid": 1649,
-                            "game-obj": "Spells",
-                            "name": "remake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "remake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "metamorphosis",
-                            "aonid": 1599,
-                            "game-obj": "Spells",
-                            "name": "metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Underworld Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cataclysm",
+                "aonid": 1460,
+                "game-obj": "Spells",
+                "name": "cataclysm",
+                "type": "link"
+              },
+              {
+                "alt": "remake",
+                "aonid": 1649,
+                "game-obj": "Spells",
+                "name": "remake",
+                "type": "link"
+              },
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "metamorphosis",
+                "aonid": 1599,
+                "game-obj": "Spells",
+                "name": "metamorphosis",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -861,48 +362,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -913,263 +377,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1179,7 +427,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1205,6 +452,1045 @@
         }
       ],
       "text": "Underworld dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "earthbind",
+          "aonid": 1506,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "fireball",
+          "aonid": 1530,
+          "game-obj": "Spells",
+          "name": "fireball",
+          "type": "link"
+        },
+        {
+          "alt": "knock",
+          "aonid": 1581,
+          "game-obj": "Spells",
+          "name": "knock",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "resist energy",
+          "aonid": 1651,
+          "game-obj": "Spells",
+          "name": "resist energy",
+          "type": "link"
+        },
+        {
+          "alt": "carryall",
+          "aonid": 1972,
+          "game-obj": "Spells",
+          "name": "carryall",
+          "type": "link"
+        },
+        {
+          "alt": "enfeeble",
+          "aonid": 1513,
+          "game-obj": "Spells",
+          "name": "enfeeble",
+          "type": "link"
+        },
+        {
+          "alt": "force barrage",
+          "aonid": 1536,
+          "game-obj": "Spells",
+          "name": "force barrage",
+          "type": "link"
+        },
+        {
+          "alt": "caustic blast",
+          "aonid": 1461,
+          "game-obj": "Spells",
+          "name": "caustic blast",
+          "type": "link"
+        },
+        {
+          "alt": "ignition",
+          "aonid": 1565,
+          "game-obj": "Spells",
+          "name": "ignition",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Young Underworld Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 183",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 183",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 183,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Prepared Arcane Spells",
+          "saving_throw": {
+            "dc": 25,
+            "subtype": "save_dc",
+            "text": "DC 25",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 17,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 1506,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fireball",
+                      "aonid": 1530,
+                      "game-obj": "Spells",
+                      "name": "fireball",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "knock",
+                      "aonid": 1581,
+                      "game-obj": "Spells",
+                      "name": "knock",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "knock",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resist energy",
+                      "aonid": 1651,
+                      "game-obj": "Spells",
+                      "name": "resist energy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resist energy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "carryall",
+                      "aonid": 1972,
+                      "game-obj": "Spells",
+                      "name": "carryall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "carryall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enfeeble",
+                      "aonid": 1513,
+                      "game-obj": "Spells",
+                      "name": "enfeeble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enfeeble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "force barrage",
+                      "aonid": 1536,
+                      "game-obj": "Spells",
+                      "name": "force barrage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "caustic blast",
+                      "aonid": 1461,
+                      "game-obj": "Spells",
+                      "name": "caustic blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ignition",
+                      "aonid": 1565,
+                      "game-obj": "Spells",
+                      "name": "ignition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Prepared Arcane Spells** DC 25, attack +17; **3rd** *earthbind*, *fireball*; **2nd** *knock*, *revealing light*, *resist energy*; **1st** *carryall*, *enfeeble*, *force barrage*; **Cantrips (3rd)** *caustic blast*, *ignition*, *read aura*, *shield*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "scouting eye",
+          "aonid": 1661,
+          "game-obj": "Spells",
+          "name": "scouting eye",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        },
+        {
+          "alt": "mirage",
+          "aonid": 1604,
+          "game-obj": "Spells",
+          "name": "mirage",
+          "type": "link"
+        },
+        {
+          "alt": "peaceful bubble",
+          "aonid": 1624,
+          "game-obj": "Spells",
+          "name": "peaceful bubble",
+          "type": "link"
+        },
+        {
+          "alt": "translocate",
+          "aonid": 1724,
+          "game-obj": "Spells",
+          "name": "translocate",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Underworld Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 183",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 183",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 183,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Prepared Arcane Spells",
+          "notes": [
+            "As young underworld dragon"
+          ],
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scouting eye",
+                      "aonid": 1661,
+                      "game-obj": "Spells",
+                      "name": "scouting eye",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scouting eye",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mirage",
+                      "aonid": 1604,
+                      "game-obj": "Spells",
+                      "name": "mirage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mirage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "peaceful bubble",
+                      "aonid": 1624,
+                      "game-obj": "Spells",
+                      "name": "peaceful bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "peaceful bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translocate",
+                      "aonid": 1724,
+                      "game-obj": "Spells",
+                      "name": "translocate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translocate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Prepared Arcane Spells** DC 30, attack +22; As young underworld dragon, plus **5th** *scouting eye*, *toxic cloud*; **4th** *mirage*, *peaceful bubble*, *translocate*; **3rd** *slow*; **Cantrips (5th)** *caustic blast*, *ignition*, *read aura*, *shield*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "fiery body",
+          "aonid": 1527,
+          "game-obj": "Spells",
+          "name": "fiery body",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "mislead",
+          "aonid": 1605,
+          "game-obj": "Spells",
+          "name": "mislead",
+          "type": "link"
+        },
+        {
+          "alt": "spellwrack",
+          "aonid": 1683,
+          "game-obj": "Spells",
+          "name": "spellwrack",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "mind probe",
+          "aonid": 1601,
+          "game-obj": "Spells",
+          "name": "mind probe",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Underworld Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 183",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 183",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 183,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Prepared Arcane Spells",
+          "notes": [
+            "As adult underworld dragon"
+          ],
+          "saving_throw": {
+            "dc": 37,
+            "subtype": "save_dc",
+            "text": "DC 37",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 29,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fiery body",
+                      "aonid": 1527,
+                      "game-obj": "Spells",
+                      "name": "fiery body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fiery body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mislead",
+                      "aonid": 1605,
+                      "game-obj": "Spells",
+                      "name": "mislead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mislead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spellwrack",
+                      "aonid": 1683,
+                      "game-obj": "Spells",
+                      "name": "spellwrack",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spellwrack",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mind probe",
+                      "aonid": 1601,
+                      "game-obj": "Spells",
+                      "name": "mind probe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mind probe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Prepared Arcane Spells** DC 37, attack +29; As adult underworld dragon, plus **7th** *energy aegis*, *fiery body*, *mask of terror*; **6th** *mislead*, *spellwrack*, *truesight*; **5th** *mind probe*; **Cantrips (7th)** *caustic blast*, *ignition*, *read aura*, *shield*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cataclysm",
+          "aonid": 1460,
+          "game-obj": "Spells",
+          "name": "cataclysm",
+          "type": "link"
+        },
+        {
+          "alt": "remake",
+          "aonid": 1649,
+          "game-obj": "Spells",
+          "name": "remake",
+          "type": "link"
+        },
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "metamorphosis",
+          "aonid": 1599,
+          "game-obj": "Spells",
+          "name": "metamorphosis",
+          "type": "link"
+        }
+      ],
+      "name": "Underworld Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 183",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 183",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 183,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Prepared Arcane Spells",
+          "notes": [
+            "As ancient underworld dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cataclysm",
+                      "aonid": 1460,
+                      "game-obj": "Spells",
+                      "name": "cataclysm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cataclysm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "remake",
+                      "aonid": 1649,
+                      "game-obj": "Spells",
+                      "name": "remake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "remake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "metamorphosis",
+                      "aonid": 1599,
+                      "game-obj": "Spells",
+                      "name": "metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Prepared Arcane Spells** DC 41, attack +33; As ancient underworld dragon, plus **10th** *cataclysm*, *remake*; **9th** *detonate magic*, *metamorphosis*; **Cantrips (10th)** *caustic blast*, *ignition*, *read aura*, *shield*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -1519,6 +1805,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 183",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 183",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 183,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1666,6 +2008,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 183",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 183",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 183,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_vizier.json
+++ b/monster_families/draconic_codex/dragon_vizier.json
@@ -65,318 +65,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "honeyed words",
-                            "aonid": 1558,
-                            "game-obj": "Spells",
-                            "name": "honeyed words",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "honeyed words",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nightmare",
-                            "aonid": 1615,
-                            "game-obj": "Spells",
-                            "name": "nightmare",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nightmare",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enthrall",
-                            "aonid": 1516,
-                            "game-obj": "Spells",
-                            "name": "enthrall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enthrall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "locate",
-                            "aonid": 1588,
-                            "game-obj": "Spells",
-                            "name": "locate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "locate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ring of truth",
-                            "aonid": 1656,
-                            "game-obj": "Spells",
-                            "name": "ring of truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ring of truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sound body",
-                            "aonid": 1679,
-                            "game-obj": "Spells",
-                            "name": "sound body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sound body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mindlink",
-                            "aonid": 1603,
-                            "game-obj": "Spells",
-                            "name": "mindlink",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mindlink",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sanctuary",
-                            "aonid": 1660,
-                            "game-obj": "Spells",
-                            "name": "sanctuary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sanctuary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit link",
-                            "aonid": 1686,
-                            "game-obj": "Spells",
-                            "name": "spirit link",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit link",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Vizier Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "honeyed words",
+                "aonid": 1558,
+                "game-obj": "Spells",
+                "name": "honeyed words",
+                "type": "link"
+              },
+              {
+                "alt": "nightmare",
+                "aonid": 1615,
+                "game-obj": "Spells",
+                "name": "nightmare",
+                "type": "link"
+              },
+              {
+                "alt": "enthrall",
+                "aonid": 1516,
+                "game-obj": "Spells",
+                "name": "enthrall",
+                "type": "link"
+              },
+              {
+                "alt": "locate",
+                "aonid": 1588,
+                "game-obj": "Spells",
+                "name": "locate",
+                "type": "link"
+              },
+              {
+                "alt": "ring of truth",
+                "aonid": 1656,
+                "game-obj": "Spells",
+                "name": "ring of truth",
+                "type": "link"
+              },
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "sound body",
+                "aonid": 1679,
+                "game-obj": "Spells",
+                "name": "sound body",
+                "type": "link"
+              },
+              {
+                "alt": "mindlink",
+                "aonid": 1603,
+                "game-obj": "Spells",
+                "name": "mindlink",
+                "type": "link"
+              },
+              {
+                "alt": "sanctuary",
+                "aonid": 1660,
+                "game-obj": "Spells",
+                "name": "sanctuary",
+                "type": "link"
+              },
+              {
+                "alt": "spirit link",
+                "aonid": 1686,
+                "game-obj": "Spells",
+                "name": "spirit link",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -392,170 +206,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young vizier dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mislead",
-                            "aonid": 1605,
-                            "game-obj": "Spells",
-                            "name": "mislead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mislead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "never mind",
-                            "aonid": 1614,
-                            "game-obj": "Spells",
-                            "name": "never mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "never mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of force",
-                            "aonid": 1749,
-                            "game-obj": "Spells",
-                            "name": "wall of force",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of force",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "subconscious suggestion",
-                            "aonid": 1692,
-                            "game-obj": "Spells",
-                            "name": "subconscious suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "subconscious suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Vizier Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mislead",
+                "aonid": 1605,
+                "game-obj": "Spells",
+                "name": "mislead",
+                "type": "link"
+              },
+              {
+                "alt": "never mind",
+                "aonid": 1614,
+                "game-obj": "Spells",
+                "name": "never mind",
+                "type": "link"
+              },
+              {
+                "alt": "wall of force",
+                "aonid": 1749,
+                "game-obj": "Spells",
+                "name": "wall of force",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
+              },
+              {
+                "alt": "subconscious suggestion",
+                "aonid": 1692,
+                "game-obj": "Spells",
+                "name": "subconscious suggestion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -571,223 +270,76 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult vizier dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "quandary",
-                            "aonid": 1644,
-                            "game-obj": "Spells",
-                            "name": "quandary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "quandary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unrelenting observation",
-                            "aonid": 1734,
-                            "game-obj": "Spells",
-                            "name": "unrelenting observation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unrelenting observation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 1640,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true target",
-                            "aonid": 1726,
-                            "game-obj": "Spells",
-                            "name": "true target",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true target",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Vizier Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "quandary",
+                "aonid": 1644,
+                "game-obj": "Spells",
+                "name": "quandary",
+                "type": "link"
+              },
+              {
+                "alt": "unrelenting observation",
+                "aonid": 1734,
+                "game-obj": "Spells",
+                "name": "unrelenting observation",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "project image",
+                "aonid": 1640,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
+              },
+              {
+                "alt": "true target",
+                "aonid": 1726,
+                "game-obj": "Spells",
+                "name": "true target",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -803,125 +355,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient vizier dragon"
-                ],
-                "saving_throw": {
-                  "dc": 46,
-                  "subtype": "save_dc",
-                  "text": "DC 46",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fabricated truth",
-                            "aonid": 1520,
-                            "game-obj": "Spells",
-                            "name": "fabricated truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fabricated truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revival",
-                            "aonid": 1654,
-                            "game-obj": "Spells",
-                            "name": "revival",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revival",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resplendent mansion",
-                            "aonid": 2018,
-                            "game-obj": "Spells",
-                            "name": "resplendent mansion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resplendent mansion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Vizier Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fabricated truth",
+                "aonid": 1520,
+                "game-obj": "Spells",
+                "name": "fabricated truth",
+                "type": "link"
+              },
+              {
+                "alt": "revival",
+                "aonid": 1654,
+                "game-obj": "Spells",
+                "name": "revival",
+                "type": "link"
+              },
+              {
+                "alt": "resplendent mansion",
+                "aonid": 2018,
+                "game-obj": "Spells",
+                "name": "resplendent mansion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -936,48 +397,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -988,263 +412,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1254,7 +462,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1280,6 +487,1155 @@
         }
       ],
       "text": "Vizier dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "honeyed words",
+          "aonid": 1558,
+          "game-obj": "Spells",
+          "name": "honeyed words",
+          "type": "link"
+        },
+        {
+          "alt": "nightmare",
+          "aonid": 1615,
+          "game-obj": "Spells",
+          "name": "nightmare",
+          "type": "link"
+        },
+        {
+          "alt": "enthrall",
+          "aonid": 1516,
+          "game-obj": "Spells",
+          "name": "enthrall",
+          "type": "link"
+        },
+        {
+          "alt": "locate",
+          "aonid": 1588,
+          "game-obj": "Spells",
+          "name": "locate",
+          "type": "link"
+        },
+        {
+          "alt": "ring of truth",
+          "aonid": 1656,
+          "game-obj": "Spells",
+          "name": "ring of truth",
+          "type": "link"
+        },
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "sound body",
+          "aonid": 1679,
+          "game-obj": "Spells",
+          "name": "sound body",
+          "type": "link"
+        },
+        {
+          "alt": "mindlink",
+          "aonid": 1603,
+          "game-obj": "Spells",
+          "name": "mindlink",
+          "type": "link"
+        },
+        {
+          "alt": "sanctuary",
+          "aonid": 1660,
+          "game-obj": "Spells",
+          "name": "sanctuary",
+          "type": "link"
+        },
+        {
+          "alt": "spirit link",
+          "aonid": 1686,
+          "game-obj": "Spells",
+          "name": "spirit link",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Young Vizier Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 187",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 187",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 187,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "honeyed words",
+                      "aonid": 1558,
+                      "game-obj": "Spells",
+                      "name": "honeyed words",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "honeyed words",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nightmare",
+                      "aonid": 1615,
+                      "game-obj": "Spells",
+                      "name": "nightmare",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nightmare",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enthrall",
+                      "aonid": 1516,
+                      "game-obj": "Spells",
+                      "name": "enthrall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enthrall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "locate",
+                      "aonid": 1588,
+                      "game-obj": "Spells",
+                      "name": "locate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "locate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ring of truth",
+                      "aonid": 1656,
+                      "game-obj": "Spells",
+                      "name": "ring of truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ring of truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sound body",
+                      "aonid": 1679,
+                      "game-obj": "Spells",
+                      "name": "sound body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sound body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mindlink",
+                      "aonid": 1603,
+                      "game-obj": "Spells",
+                      "name": "mindlink",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mindlink",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sanctuary",
+                      "aonid": 1660,
+                      "game-obj": "Spells",
+                      "name": "sanctuary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sanctuary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit link",
+                      "aonid": 1686,
+                      "game-obj": "Spells",
+                      "name": "spirit link",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit link",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 30, attack +22; **4th** *confusion*, *honeyed words*, *nightmare*; **3rd** *enthrall*, *locate*, *ring of truth*; **2nd** *clear mind*, *dispel magic*, *sound body*; **1st** *mindlink*, *sanctuary*, *spirit link*; **Cantrips (4th)** *figment*, *guidance*, *message*, *prestidigitation*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "mislead",
+          "aonid": 1605,
+          "game-obj": "Spells",
+          "name": "mislead",
+          "type": "link"
+        },
+        {
+          "alt": "never mind",
+          "aonid": 1614,
+          "game-obj": "Spells",
+          "name": "never mind",
+          "type": "link"
+        },
+        {
+          "alt": "wall of force",
+          "aonid": 1749,
+          "game-obj": "Spells",
+          "name": "wall of force",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        },
+        {
+          "alt": "subconscious suggestion",
+          "aonid": 1692,
+          "game-obj": "Spells",
+          "name": "subconscious suggestion",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Vizier Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 187",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 187",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 187,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young vizier dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mislead",
+                      "aonid": 1605,
+                      "game-obj": "Spells",
+                      "name": "mislead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mislead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "never mind",
+                      "aonid": 1614,
+                      "game-obj": "Spells",
+                      "name": "never mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "never mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of force",
+                      "aonid": 1749,
+                      "game-obj": "Spells",
+                      "name": "wall of force",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of force",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "subconscious suggestion",
+                      "aonid": 1692,
+                      "game-obj": "Spells",
+                      "name": "subconscious suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "subconscious suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 36, attack +28; As young vizier dragon, plus **6th** *mislead*, *never mind*, *wall of force*; **5th** *banishment*, *sending*, *subconscious suggestion*; **Cantrips (6th)** *figment*, *guidance*, *message*, *prestidigitation*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "quandary",
+          "aonid": 1644,
+          "game-obj": "Spells",
+          "name": "quandary",
+          "type": "link"
+        },
+        {
+          "alt": "unrelenting observation",
+          "aonid": 1734,
+          "game-obj": "Spells",
+          "name": "unrelenting observation",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "project image",
+          "aonid": 1640,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        },
+        {
+          "alt": "true target",
+          "aonid": 1726,
+          "game-obj": "Spells",
+          "name": "true target",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Vizier Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 187",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 187",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 187,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult vizier dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "quandary",
+                      "aonid": 1644,
+                      "game-obj": "Spells",
+                      "name": "quandary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "quandary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unrelenting observation",
+                      "aonid": 1734,
+                      "game-obj": "Spells",
+                      "name": "unrelenting observation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unrelenting observation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 1640,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true target",
+                      "aonid": 1726,
+                      "game-obj": "Spells",
+                      "name": "true target",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true target",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 42, attack +34; As adult vizier dragon, plus **9th** *foresight*, *overwhelming presence*, *phantasmagoria*; **8th** *hidden mind*, *quandary*, *unrelenting observation*; **7th** *energy aegis*, *project image*, *true target*; **Cantrips (9th)** *figment*, *guidance*, *message*, *prestidigitation*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fabricated truth",
+          "aonid": 1520,
+          "game-obj": "Spells",
+          "name": "fabricated truth",
+          "type": "link"
+        },
+        {
+          "alt": "revival",
+          "aonid": 1654,
+          "game-obj": "Spells",
+          "name": "revival",
+          "type": "link"
+        },
+        {
+          "alt": "resplendent mansion",
+          "aonid": 2018,
+          "game-obj": "Spells",
+          "name": "resplendent mansion",
+          "type": "link"
+        }
+      ],
+      "name": "Vizier Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 187",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 187",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 187,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient vizier dragon"
+          ],
+          "saving_throw": {
+            "dc": 46,
+            "subtype": "save_dc",
+            "text": "DC 46",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fabricated truth",
+                      "aonid": 1520,
+                      "game-obj": "Spells",
+                      "name": "fabricated truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fabricated truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revival",
+                      "aonid": 1654,
+                      "game-obj": "Spells",
+                      "name": "revival",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revival",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resplendent mansion",
+                      "aonid": 2018,
+                      "game-obj": "Spells",
+                      "name": "resplendent mansion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resplendent mansion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 46, attack +38; As ancient vizier dragon, plus **10th** *fabricated truth*, *revival*; **9th** *resplendent mansion*; **Cantrips (10th)** *figment*, *guidance*, *message*, *prestidigitation*, *sigil*",
       "type": "section"
     },
     {
@@ -1594,6 +1950,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 187",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 187",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 187,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1741,6 +2153,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 187",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 187",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 187,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_vorpal.json
+++ b/monster_families/draconic_codex/dragon_vorpal.json
@@ -68,288 +68,118 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairvoyance",
-                            "aonid": 1466,
-                            "game-obj": "Spells",
-                            "name": "clairvoyance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairvoyance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairaudience",
-                            "aonid": 1465,
-                            "game-obj": "Spells",
-                            "name": "clairaudience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairaudience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mending",
-                            "aonid": 1597,
-                            "game-obj": "Spells",
-                            "name": "mending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create food",
-                            "aonid": 1475,
-                            "game-obj": "Spells",
-                            "name": "create food",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create food",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ventriloquism",
-                            "aonid": 1740,
-                            "game-obj": "Spells",
-                            "name": "ventriloquism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ventriloquism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "alarm",
-                            "aonid": 1439,
-                            "game-obj": "Spells",
-                            "name": "alarm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "alarm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count_text": "\u00d72",
-                        "links": [
-                          {
-                            "alt": "sure strike",
-                            "aonid": 1709,
-                            "game-obj": "Spells",
-                            "name": "sure strike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sure strike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "live wire",
-                            "aonid": 2008,
-                            "game-obj": "Spells",
-                            "name": "live wire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "live wire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Vorpal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "clairvoyance",
+                "aonid": 1466,
+                "game-obj": "Spells",
+                "name": "clairvoyance",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "clairaudience",
+                "aonid": 1465,
+                "game-obj": "Spells",
+                "name": "clairaudience",
+                "type": "link"
+              },
+              {
+                "alt": "mending",
+                "aonid": 1597,
+                "game-obj": "Spells",
+                "name": "mending",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "create food",
+                "aonid": 1475,
+                "game-obj": "Spells",
+                "name": "create food",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "ventriloquism",
+                "aonid": 1740,
+                "game-obj": "Spells",
+                "name": "ventriloquism",
+                "type": "link"
+              },
+              {
+                "alt": "alarm",
+                "aonid": 1439,
+                "game-obj": "Spells",
+                "name": "alarm",
+                "type": "link"
+              },
+              {
+                "alt": "sure strike",
+                "aonid": 1709,
+                "game-obj": "Spells",
+                "name": "sure strike",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "live wire",
+                "aonid": 2008,
+                "game-obj": "Spells",
+                "name": "live wire",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -365,169 +195,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "as young vorpal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 35,
-                  "subtype": "save_dc",
-                  "text": "DC 35",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 27,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enlarge",
-                            "aonid": 1514,
-                            "game-obj": "Spells",
-                            "name": "enlarge",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enlarge",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "impaling spike",
-                            "aonid": 1571,
-                            "game-obj": "Spells",
-                            "name": "impaling spike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "impaling spike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "thoughtful gift",
-                            "aonid": 2037,
-                            "game-obj": "Spells",
-                            "name": "thoughtful gift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "thoughtful gift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wave of despair",
-                            "aonid": 1757,
-                            "game-obj": "Spells",
-                            "name": "wave of despair",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wave of despair",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory disguise",
-                            "aonid": 1568,
-                            "game-obj": "Spells",
-                            "name": "illusory disguise",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "illusory disguise",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "live wire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Vorpal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "enlarge",
+                "aonid": 1514,
+                "game-obj": "Spells",
+                "name": "enlarge",
+                "type": "link"
+              },
+              {
+                "alt": "impaling spike",
+                "aonid": 1571,
+                "game-obj": "Spells",
+                "name": "impaling spike",
+                "type": "link"
+              },
+              {
+                "alt": "thoughtful gift",
+                "aonid": 2037,
+                "game-obj": "Spells",
+                "name": "thoughtful gift",
+                "type": "link"
+              },
+              {
+                "alt": "wave of despair",
+                "aonid": 1757,
+                "game-obj": "Spells",
+                "name": "wave of despair",
+                "type": "link"
+              },
+              {
+                "alt": "illusory disguise",
+                "aonid": 1568,
+                "game-obj": "Spells",
+                "name": "illusory disguise",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -542,88 +251,56 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "arctic rift",
-                    "aonid": 1444,
-                    "game-obj": "Spells",
-                    "name": "arctic rift",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "dream council",
-                    "aonid": 1988,
-                    "game-obj": "Spells",
-                    "name": "dream council",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unrelenting observation",
-                    "aonid": 1734,
-                    "game-obj": "Spells",
-                    "name": "unrelenting observation",
-                    "type": "link"
-                  }
-                ],
-                "name": "8th",
-                "subtype": "ability",
-                "text": "*arctic rift*, *dream council*, *unrelenting observation*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "haste",
-                    "aonid": 1553,
-                    "game-obj": "Spells",
-                    "name": "haste",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "spell riposte",
-                    "aonid": 2027,
-                    "game-obj": "Spells",
-                    "name": "spell riposte",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "true target",
-                    "aonid": 1726,
-                    "game-obj": "Spells",
-                    "name": "true target",
-                    "type": "link"
-                  }
-                ],
-                "name": "7th",
-                "subtype": "ability",
-                "text": "*haste*, *spell riposte*, *true target*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "6th",
-                "subtype": "ability",
-                "text": "*create food*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Cantrips (8th)",
-                "subtype": "ability",
-                "text": "*detect magic*, *live wire*, *message*, *read aura*, *telekinetic hand*",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Ancient Vorpal Dragon')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arctic rift",
+                "aonid": 1444,
+                "game-obj": "Spells",
+                "name": "arctic rift",
+                "type": "link"
+              },
+              {
+                "alt": "dream council",
+                "aonid": 1988,
+                "game-obj": "Spells",
+                "name": "dream council",
+                "type": "link"
+              },
+              {
+                "alt": "unrelenting observation",
+                "aonid": 1734,
+                "game-obj": "Spells",
+                "name": "unrelenting observation",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "spell riposte",
+                "aonid": 2027,
+                "game-obj": "Spells",
+                "name": "spell riposte",
+                "type": "link"
+              },
+              {
+                "alt": "true target",
+                "aonid": 1726,
+                "game-obj": "Spells",
+                "name": "true target",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -633,162 +310,54 @@
         ],
         "name": "Ancient Vorpal Dragon",
         "subtype": "monster_family",
-        "text": "Arcane Prepared Spells DC 40, attack +32; as adult vorpal dragon, plus",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "as ancient vorpal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "magnetic dominion",
-                            "aonid": 1372,
-                            "game-obj": "Spells",
-                            "name": "magnetic dominion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "magnetic dominion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "live wire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Vorpal Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "magnetic dominion",
+                "aonid": 1372,
+                "game-obj": "Spells",
+                "name": "magnetic dominion",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -803,48 +372,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -855,263 +387,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1121,7 +437,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1147,6 +462,983 @@
         }
       ],
       "text": "Vorpal dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "clairvoyance",
+          "aonid": 1466,
+          "game-obj": "Spells",
+          "name": "clairvoyance",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "clairaudience",
+          "aonid": 1465,
+          "game-obj": "Spells",
+          "name": "clairaudience",
+          "type": "link"
+        },
+        {
+          "alt": "mending",
+          "aonid": 1597,
+          "game-obj": "Spells",
+          "name": "mending",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "create food",
+          "aonid": 1475,
+          "game-obj": "Spells",
+          "name": "create food",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "ventriloquism",
+          "aonid": 1740,
+          "game-obj": "Spells",
+          "name": "ventriloquism",
+          "type": "link"
+        },
+        {
+          "alt": "alarm",
+          "aonid": 1439,
+          "game-obj": "Spells",
+          "name": "alarm",
+          "type": "link"
+        },
+        {
+          "alt": "sure strike",
+          "aonid": 1709,
+          "game-obj": "Spells",
+          "name": "sure strike",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "live wire",
+          "aonid": 2008,
+          "game-obj": "Spells",
+          "name": "live wire",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Young Vorpal Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 191",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 191",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 191,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairvoyance",
+                      "aonid": 1466,
+                      "game-obj": "Spells",
+                      "name": "clairvoyance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairvoyance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairaudience",
+                      "aonid": 1465,
+                      "game-obj": "Spells",
+                      "name": "clairaudience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairaudience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mending",
+                      "aonid": 1597,
+                      "game-obj": "Spells",
+                      "name": "mending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create food",
+                      "aonid": 1475,
+                      "game-obj": "Spells",
+                      "name": "create food",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create food",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ventriloquism",
+                      "aonid": 1740,
+                      "game-obj": "Spells",
+                      "name": "ventriloquism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ventriloquism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "alarm",
+                      "aonid": 1439,
+                      "game-obj": "Spells",
+                      "name": "alarm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "alarm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count_text": "\u00d72",
+                  "links": [
+                    {
+                      "alt": "sure strike",
+                      "aonid": 1709,
+                      "game-obj": "Spells",
+                      "name": "sure strike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sure strike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "live wire",
+                      "aonid": 2008,
+                      "game-obj": "Spells",
+                      "name": "live wire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "live wire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 28, attack +20; **4th** *clairvoyance*, *unfettered movement*; **3rd** *clairaudience*, *mending*, *slow*; **2nd** *create food*, *revealing light*, *ventriloquism*; **1st** *alarm*, *sure strike* (\u00d72); **Cantrips** (4th) *detect magic*, *live wire*, *message*, *read aura*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "enlarge",
+          "aonid": 1514,
+          "game-obj": "Spells",
+          "name": "enlarge",
+          "type": "link"
+        },
+        {
+          "alt": "impaling spike",
+          "aonid": 1571,
+          "game-obj": "Spells",
+          "name": "impaling spike",
+          "type": "link"
+        },
+        {
+          "alt": "thoughtful gift",
+          "aonid": 2037,
+          "game-obj": "Spells",
+          "name": "thoughtful gift",
+          "type": "link"
+        },
+        {
+          "alt": "wave of despair",
+          "aonid": 1757,
+          "game-obj": "Spells",
+          "name": "wave of despair",
+          "type": "link"
+        },
+        {
+          "alt": "illusory disguise",
+          "aonid": 1568,
+          "game-obj": "Spells",
+          "name": "illusory disguise",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Vorpal Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 191",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 191",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 191,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "as young vorpal dragon"
+          ],
+          "saving_throw": {
+            "dc": 35,
+            "subtype": "save_dc",
+            "text": "DC 35",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 27,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enlarge",
+                      "aonid": 1514,
+                      "game-obj": "Spells",
+                      "name": "enlarge",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enlarge",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "impaling spike",
+                      "aonid": 1571,
+                      "game-obj": "Spells",
+                      "name": "impaling spike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "impaling spike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "thoughtful gift",
+                      "aonid": 2037,
+                      "game-obj": "Spells",
+                      "name": "thoughtful gift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "thoughtful gift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wave of despair",
+                      "aonid": 1757,
+                      "game-obj": "Spells",
+                      "name": "wave of despair",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wave of despair",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory disguise",
+                      "aonid": 1568,
+                      "game-obj": "Spells",
+                      "name": "illusory disguise",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "illusory disguise",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "live wire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 35, attack +27; as young vorpal dragon, plus **6th** *enlarge*, *slow*; **5th** *impaling spike*, *thoughtful gift*, *wave of despair*; **4th** *illusory disguise*; **Cantrips (6th)** *detect magic*, *live wire*, *message*, *read aura*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "arctic rift",
+              "aonid": 1444,
+              "game-obj": "Spells",
+              "name": "arctic rift",
+              "type": "link"
+            },
+            {
+              "alt": "dream council",
+              "aonid": 1988,
+              "game-obj": "Spells",
+              "name": "dream council",
+              "type": "link"
+            },
+            {
+              "alt": "unrelenting observation",
+              "aonid": 1734,
+              "game-obj": "Spells",
+              "name": "unrelenting observation",
+              "type": "link"
+            }
+          ],
+          "name": "8th",
+          "subtype": "ability",
+          "text": "*arctic rift*, *dream council*, *unrelenting observation*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "haste",
+              "aonid": 1553,
+              "game-obj": "Spells",
+              "name": "haste",
+              "type": "link"
+            },
+            {
+              "alt": "spell riposte",
+              "aonid": 2027,
+              "game-obj": "Spells",
+              "name": "spell riposte",
+              "type": "link"
+            },
+            {
+              "alt": "true target",
+              "aonid": 1726,
+              "game-obj": "Spells",
+              "name": "true target",
+              "type": "link"
+            }
+          ],
+          "name": "7th",
+          "subtype": "ability",
+          "text": "*haste*, *spell riposte*, *true target*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "6th",
+          "subtype": "ability",
+          "text": "*create food*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Cantrips (8th)",
+          "subtype": "ability",
+          "text": "*detect magic*, *live wire*, *message*, *read aura*, *telekinetic hand*",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arctic rift",
+          "aonid": 1444,
+          "game-obj": "Spells",
+          "name": "arctic rift",
+          "type": "link"
+        },
+        {
+          "alt": "dream council",
+          "aonid": 1988,
+          "game-obj": "Spells",
+          "name": "dream council",
+          "type": "link"
+        },
+        {
+          "alt": "unrelenting observation",
+          "aonid": 1734,
+          "game-obj": "Spells",
+          "name": "unrelenting observation",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "spell riposte",
+          "aonid": 2027,
+          "game-obj": "Spells",
+          "name": "spell riposte",
+          "type": "link"
+        },
+        {
+          "alt": "true target",
+          "aonid": 1726,
+          "game-obj": "Spells",
+          "name": "true target",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Vorpal Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 191",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 191",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 191,
+          "type": "source"
+        }
+      ],
+      "text": "Arcane Prepared Spells DC 40, attack +32; as adult vorpal dragon, plus **8th** *arctic rift*, *dream council*, *unrelenting observation*; **7th** *haste*, *spell riposte*, *true target*; **6th** *create food*; **Cantrips (8th)** *detect magic*, *live wire*, *message*, *read aura*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "magnetic dominion",
+          "aonid": 1372,
+          "game-obj": "Spells",
+          "name": "magnetic dominion",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        }
+      ],
+      "name": "Vorpal Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 191",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 191",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 191,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "as ancient vorpal dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "magnetic dominion",
+                      "aonid": 1372,
+                      "game-obj": "Spells",
+                      "name": "magnetic dominion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "magnetic dominion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "live wire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 44, attack +36; as ancient vorpal dragon, plus **10th** *falling stars*, *manifestation*; **9th** *detonate magic*, *magnetic dominion*, *phantasmagoria*; **Cantrips (10th)** *detect magic*, *live wire*, *message*, *read aura*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -1461,6 +1753,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 191",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 191",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 191,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1608,6 +1956,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 191",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 191",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 191,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_wailing.json
+++ b/monster_families/draconic_codex/dragon_wailing.json
@@ -59,256 +59,104 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 24,
-                  "subtype": "save_dc",
-                  "text": "DC 24",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 16,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairaudience",
-                            "aonid": 1465,
-                            "game-obj": "Spells",
-                            "name": "clairaudience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairaudience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translate",
-                            "aonid": 1723,
-                            "game-obj": "Spells",
-                            "name": "translate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of wind",
-                            "aonid": 1753,
-                            "game-obj": "Spells",
-                            "name": "wall of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sure strike",
-                            "aonid": 1709,
-                            "game-obj": "Spells",
-                            "name": "sure strike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sure strike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tailwind",
-                            "aonid": 1711,
-                            "game-obj": "Spells",
-                            "name": "tailwind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tailwind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bullhorn",
-                            "aonid": 1971,
-                            "game-obj": "Spells",
-                            "name": "bullhorn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haunting hymn",
-                            "aonid": 1999,
-                            "game-obj": "Spells",
-                            "name": "haunting hymn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Wailing Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "clairaudience",
+                "aonid": 1465,
+                "game-obj": "Spells",
+                "name": "clairaudience",
+                "type": "link"
+              },
+              {
+                "alt": "translate",
+                "aonid": 1723,
+                "game-obj": "Spells",
+                "name": "translate",
+                "type": "link"
+              },
+              {
+                "alt": "wall of wind",
+                "aonid": 1753,
+                "game-obj": "Spells",
+                "name": "wall of wind",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "sure strike",
+                "aonid": 1709,
+                "game-obj": "Spells",
+                "name": "sure strike",
+                "type": "link"
+              },
+              {
+                "alt": "tailwind",
+                "aonid": 1711,
+                "game-obj": "Spells",
+                "name": "tailwind",
+                "type": "link"
+              },
+              {
+                "alt": "bullhorn",
+                "aonid": 1971,
+                "game-obj": "Spells",
+                "name": "bullhorn",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "haunting hymn",
+                "aonid": 1999,
+                "game-obj": "Spells",
+                "name": "haunting hymn",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -324,161 +172,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young wailing dragon"
-                ],
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusing cry",
-                            "aonid": 1950,
-                            "game-obj": "Spells",
-                            "name": "confusing cry",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusing cry",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "seal fate",
-                            "aonid": 2024,
-                            "game-obj": "Spells",
-                            "name": "seal fate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "seal fate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "whispers of the void",
-                            "aonid": 2046,
-                            "game-obj": "Spells",
-                            "name": "whispers of the void",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "whispers of the void",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Wailing Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "confusing cry",
+                "aonid": 1950,
+                "game-obj": "Spells",
+                "name": "confusing cry",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
+              },
+              {
+                "alt": "seal fate",
+                "aonid": 2024,
+                "game-obj": "Spells",
+                "name": "seal fate",
+                "type": "link"
+              },
+              {
+                "alt": "whispers of the void",
+                "aonid": 2046,
+                "game-obj": "Spells",
+                "name": "whispers of the void",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -494,199 +229,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult wailing dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "canticle of everlasting grief",
-                            "aonid": 1459,
-                            "game-obj": "Spells",
-                            "name": "canticle of everlasting grief",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "canticle of everlasting grief",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit song",
-                            "aonid": 2029,
-                            "game-obj": "Spells",
-                            "name": "spirit song",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit song",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "contingency",
-                            "aonid": 1472,
-                            "game-obj": "Spells",
-                            "name": "contingency",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "contingency",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spell riposte",
-                            "aonid": 2027,
-                            "game-obj": "Spells",
-                            "name": "spell riposte",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spell riposte",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantom orchestra",
-                            "aonid": 1317,
-                            "game-obj": "Spells",
-                            "name": "phantom orchestra",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantom orchestra",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "repulsion",
-                            "aonid": 1650,
-                            "game-obj": "Spells",
-                            "name": "repulsion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "repulsion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "whispers of the void",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Wailing Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "canticle of everlasting grief",
+                "aonid": 1459,
+                "game-obj": "Spells",
+                "name": "canticle of everlasting grief",
+                "type": "link"
+              },
+              {
+                "alt": "spirit song",
+                "aonid": 2029,
+                "game-obj": "Spells",
+                "name": "spirit song",
+                "type": "link"
+              },
+              {
+                "alt": "contingency",
+                "aonid": 1472,
+                "game-obj": "Spells",
+                "name": "contingency",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "spell riposte",
+                "aonid": 2027,
+                "game-obj": "Spells",
+                "name": "spell riposte",
+                "type": "link"
+              },
+              {
+                "alt": "phantom orchestra",
+                "aonid": 1317,
+                "game-obj": "Spells",
+                "name": "phantom orchestra",
+                "type": "link"
+              },
+              {
+                "alt": "repulsion",
+                "aonid": 1650,
+                "game-obj": "Spells",
+                "name": "repulsion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -701,60 +299,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "massacre",
-                    "aonid": 1596,
-                    "game-obj": "Spells",
-                    "name": "massacre",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "metamorphosis",
-                    "aonid": 1599,
-                    "game-obj": "Spells",
-                    "name": "metamorphosis",
-                    "type": "link"
-                  }
-                ],
-                "name": "9th",
-                "subtype": "ability",
-                "text": "*massacre*, *metamorphosis*, *phantom orchestra*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "uncontrollable dance",
-                    "aonid": 1730,
-                    "game-obj": "Spells",
-                    "name": "uncontrollable dance",
-                    "type": "link"
-                  }
-                ],
-                "name": "8th",
-                "subtype": "ability",
-                "text": "*uncontrollable dance*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Cantrips (9th)",
-                "subtype": "ability",
-                "text": "*bullhorn*, *detect magic*, *haunting hymn*, *read aura*, *sigil*",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Wailing Archdragon')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
+              },
+              {
+                "alt": "metamorphosis",
+                "aonid": 1599,
+                "game-obj": "Spells",
+                "name": "metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "uncontrollable dance",
+                "aonid": 1730,
+                "game-obj": "Spells",
+                "name": "uncontrollable dance",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -764,54 +337,16 @@
         ],
         "name": "Wailing Archdragon",
         "subtype": "monster_family",
-        "text": "Arcane Prepared Spells DC 40, attack +32; As ancient wailing dragon, plus",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -822,263 +357,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1088,7 +407,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1114,6 +432,938 @@
         }
       ],
       "text": "Wailing dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "clairaudience",
+          "aonid": 1465,
+          "game-obj": "Spells",
+          "name": "clairaudience",
+          "type": "link"
+        },
+        {
+          "alt": "translate",
+          "aonid": 1723,
+          "game-obj": "Spells",
+          "name": "translate",
+          "type": "link"
+        },
+        {
+          "alt": "wall of wind",
+          "aonid": 1753,
+          "game-obj": "Spells",
+          "name": "wall of wind",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "sure strike",
+          "aonid": 1709,
+          "game-obj": "Spells",
+          "name": "sure strike",
+          "type": "link"
+        },
+        {
+          "alt": "tailwind",
+          "aonid": 1711,
+          "game-obj": "Spells",
+          "name": "tailwind",
+          "type": "link"
+        },
+        {
+          "alt": "bullhorn",
+          "aonid": 1971,
+          "game-obj": "Spells",
+          "name": "bullhorn",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "haunting hymn",
+          "aonid": 1999,
+          "game-obj": "Spells",
+          "name": "haunting hymn",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Young Wailing Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 195",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 195",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 195,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 24,
+            "subtype": "save_dc",
+            "text": "DC 24",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 16,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairaudience",
+                      "aonid": 1465,
+                      "game-obj": "Spells",
+                      "name": "clairaudience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairaudience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translate",
+                      "aonid": 1723,
+                      "game-obj": "Spells",
+                      "name": "translate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of wind",
+                      "aonid": 1753,
+                      "game-obj": "Spells",
+                      "name": "wall of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sure strike",
+                      "aonid": 1709,
+                      "game-obj": "Spells",
+                      "name": "sure strike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sure strike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tailwind",
+                      "aonid": 1711,
+                      "game-obj": "Spells",
+                      "name": "tailwind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tailwind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bullhorn",
+                      "aonid": 1971,
+                      "game-obj": "Spells",
+                      "name": "bullhorn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haunting hymn",
+                      "aonid": 1999,
+                      "game-obj": "Spells",
+                      "name": "haunting hymn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 24, attack +16; **3rd** *clairaudience*, *translate*, *wall of wind*; **2nd** *dispel magic*, *mist*, *translate*; **1st** *command*, *sure strike*, *tailwind*; **Cantrips (3rd)** *bullhorn*, *detect magic*, *haunting hymn*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "confusing cry",
+          "aonid": 1950,
+          "game-obj": "Spells",
+          "name": "confusing cry",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        },
+        {
+          "alt": "seal fate",
+          "aonid": 2024,
+          "game-obj": "Spells",
+          "name": "seal fate",
+          "type": "link"
+        },
+        {
+          "alt": "whispers of the void",
+          "aonid": 2046,
+          "game-obj": "Spells",
+          "name": "whispers of the void",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Wailing Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 195",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 195",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 195,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young wailing dragon"
+          ],
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusing cry",
+                      "aonid": 1950,
+                      "game-obj": "Spells",
+                      "name": "confusing cry",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusing cry",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "seal fate",
+                      "aonid": 2024,
+                      "game-obj": "Spells",
+                      "name": "seal fate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "seal fate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "whispers of the void",
+                      "aonid": 2046,
+                      "game-obj": "Spells",
+                      "name": "whispers of the void",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "whispers of the void",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 29, attack +21; As young wailing dragon, plus **5th** *banishment*, *confusing cry*, *truespeech*; **4th** *dispel magic*, **seal fate**, *whispers of the void*; **Cantrips (5th)** *bullhorn*, *detect magic*, *haunting hymn*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "canticle of everlasting grief",
+          "aonid": 1459,
+          "game-obj": "Spells",
+          "name": "canticle of everlasting grief",
+          "type": "link"
+        },
+        {
+          "alt": "spirit song",
+          "aonid": 2029,
+          "game-obj": "Spells",
+          "name": "spirit song",
+          "type": "link"
+        },
+        {
+          "alt": "contingency",
+          "aonid": 1472,
+          "game-obj": "Spells",
+          "name": "contingency",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "spell riposte",
+          "aonid": 2027,
+          "game-obj": "Spells",
+          "name": "spell riposte",
+          "type": "link"
+        },
+        {
+          "alt": "phantom orchestra",
+          "aonid": 1317,
+          "game-obj": "Spells",
+          "name": "phantom orchestra",
+          "type": "link"
+        },
+        {
+          "alt": "repulsion",
+          "aonid": 1650,
+          "game-obj": "Spells",
+          "name": "repulsion",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Wailing Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 195",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 195",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 195,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult wailing dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "canticle of everlasting grief",
+                      "aonid": 1459,
+                      "game-obj": "Spells",
+                      "name": "canticle of everlasting grief",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "canticle of everlasting grief",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit song",
+                      "aonid": 2029,
+                      "game-obj": "Spells",
+                      "name": "spirit song",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit song",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "contingency",
+                      "aonid": 1472,
+                      "game-obj": "Spells",
+                      "name": "contingency",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "contingency",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spell riposte",
+                      "aonid": 2027,
+                      "game-obj": "Spells",
+                      "name": "spell riposte",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spell riposte",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantom orchestra",
+                      "aonid": 1317,
+                      "game-obj": "Spells",
+                      "name": "phantom orchestra",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantom orchestra",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "repulsion",
+                      "aonid": 1650,
+                      "game-obj": "Spells",
+                      "name": "repulsion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "repulsion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "whispers of the void",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 36, attack +28; As adult wailing dragon, plus **8th** *canticle of everlasting grief*, *spirit song*; **7th** *contingency*, *energy aegis*, *spell riposte*; **6th** *phantom orchestra*, *repulsion*, *whispers of the void*; **Cantrips (8th)** *bullhorn*, *detect magic*, *haunting hymn*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "massacre",
+              "aonid": 1596,
+              "game-obj": "Spells",
+              "name": "massacre",
+              "type": "link"
+            },
+            {
+              "alt": "metamorphosis",
+              "aonid": 1599,
+              "game-obj": "Spells",
+              "name": "metamorphosis",
+              "type": "link"
+            }
+          ],
+          "name": "9th",
+          "subtype": "ability",
+          "text": "*massacre*, *metamorphosis*, *phantom orchestra*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "uncontrollable dance",
+              "aonid": 1730,
+              "game-obj": "Spells",
+              "name": "uncontrollable dance",
+              "type": "link"
+            }
+          ],
+          "name": "8th",
+          "subtype": "ability",
+          "text": "*uncontrollable dance*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Cantrips (9th)",
+          "subtype": "ability",
+          "text": "*bullhorn*, *detect magic*, *haunting hymn*, *read aura*, *sigil*",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        },
+        {
+          "alt": "metamorphosis",
+          "aonid": 1599,
+          "game-obj": "Spells",
+          "name": "metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "uncontrollable dance",
+          "aonid": 1730,
+          "game-obj": "Spells",
+          "name": "uncontrollable dance",
+          "type": "link"
+        }
+      ],
+      "name": "Wailing Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 195",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 195",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 195,
+          "type": "source"
+        }
+      ],
+      "text": "Arcane Prepared Spells DC 40, attack +32; As ancient wailing dragon, plus **9th** *massacre*, *metamorphosis*, *phantom orchestra*; **8th** *uncontrollable dance*; **Cantrips (9th)** *bullhorn*, *detect magic*, *haunting hymn*, *read aura*, *sigil*",
       "type": "section"
     },
     {
@@ -1428,6 +1678,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 195",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 195",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 195,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1575,6 +1881,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 195",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 195",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 195,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragon_wish.json
+++ b/monster_families/draconic_codex/dragon_wish.json
@@ -59,318 +59,132 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "suggestion",
-                            "aonid": 1693,
-                            "game-obj": "Spells",
-                            "name": "suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translocate",
-                            "aonid": 1724,
-                            "game-obj": "Spells",
-                            "name": "translocate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translocate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 1506,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "lightning bolt",
-                            "aonid": 1586,
-                            "game-obj": "Spells",
-                            "name": "lightning bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "lightning bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mind reading",
-                            "aonid": 1602,
-                            "game-obj": "Spells",
-                            "name": "mind reading",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mind reading",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "charitable urge",
-                            "aonid": 1974,
-                            "game-obj": "Spells",
-                            "name": "charitable urge",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "charitable urge",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal treasure",
-                            "aonid": 2013,
-                            "game-obj": "Spells",
-                            "name": "phantasmal treasure",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal treasure",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "d\u00e9j\u00e0 vu",
-                            "aonid": 1986,
-                            "game-obj": "Spells",
-                            "name": "d\u00e9j\u00e0 vu",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "d\u00e9j\u00e0 vu",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "force barrage",
-                            "aonid": 1536,
-                            "game-obj": "Spells",
-                            "name": "force barrage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "item facade",
-                            "aonid": 1579,
-                            "game-obj": "Spells",
-                            "name": "item facade",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "item facade",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bullhorn",
-                            "aonid": 1971,
-                            "game-obj": "Spells",
-                            "name": "bullhorn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Wish Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "suggestion",
+                "aonid": 1693,
+                "game-obj": "Spells",
+                "name": "suggestion",
+                "type": "link"
+              },
+              {
+                "alt": "translocate",
+                "aonid": 1724,
+                "game-obj": "Spells",
+                "name": "translocate",
+                "type": "link"
+              },
+              {
+                "alt": "earthbind",
+                "aonid": 1506,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "lightning bolt",
+                "aonid": 1586,
+                "game-obj": "Spells",
+                "name": "lightning bolt",
+                "type": "link"
+              },
+              {
+                "alt": "mind reading",
+                "aonid": 1602,
+                "game-obj": "Spells",
+                "name": "mind reading",
+                "type": "link"
+              },
+              {
+                "alt": "charitable urge",
+                "aonid": 1974,
+                "game-obj": "Spells",
+                "name": "charitable urge",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal treasure",
+                "aonid": 2013,
+                "game-obj": "Spells",
+                "name": "phantasmal treasure",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "d\u00e9j\u00e0 vu",
+                "aonid": 1986,
+                "game-obj": "Spells",
+                "name": "d\u00e9j\u00e0 vu",
+                "type": "link"
+              },
+              {
+                "alt": "force barrage",
+                "aonid": 1536,
+                "game-obj": "Spells",
+                "name": "force barrage",
+                "type": "link"
+              },
+              {
+                "alt": "item facade",
+                "aonid": 1579,
+                "game-obj": "Spells",
+                "name": "item facade",
+                "type": "link"
+              },
+              {
+                "alt": "bullhorn",
+                "aonid": 1971,
+                "game-obj": "Spells",
+                "name": "bullhorn",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -386,170 +200,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young wish dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cursed metamorphosis",
-                            "aonid": 1479,
-                            "game-obj": "Spells",
-                            "name": "cursed metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cursed metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "never mind",
-                            "aonid": 1614,
-                            "game-obj": "Spells",
-                            "name": "never mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "never mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scrying",
-                            "aonid": 1662,
-                            "game-obj": "Spells",
-                            "name": "scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucination",
-                            "aonid": 1551,
-                            "game-obj": "Spells",
-                            "name": "hallucination",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucination",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "magic passage",
-                            "aonid": 1591,
-                            "game-obj": "Spells",
-                            "name": "magic passage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "magic passage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "subconscious suggestion",
-                            "aonid": 1692,
-                            "game-obj": "Spells",
-                            "name": "subconscious suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "subconscious suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Wish Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cursed metamorphosis",
+                "aonid": 1479,
+                "game-obj": "Spells",
+                "name": "cursed metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "never mind",
+                "aonid": 1614,
+                "game-obj": "Spells",
+                "name": "never mind",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 1662,
+                "game-obj": "Spells",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "hallucination",
+                "aonid": 1551,
+                "game-obj": "Spells",
+                "name": "hallucination",
+                "type": "link"
+              },
+              {
+                "alt": "magic passage",
+                "aonid": 1591,
+                "game-obj": "Spells",
+                "name": "magic passage",
+                "type": "link"
+              },
+              {
+                "alt": "subconscious suggestion",
+                "aonid": 1692,
+                "game-obj": "Spells",
+                "name": "subconscious suggestion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -565,170 +264,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult wish dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusing colors",
-                            "aonid": 1980,
-                            "game-obj": "Spells",
-                            "name": "confusing colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusing colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dream council",
-                            "aonid": 1988,
-                            "game-obj": "Spells",
-                            "name": "dream council",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dream council",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "uncontrollable dance",
-                            "aonid": 1730,
-                            "game-obj": "Spells",
-                            "name": "uncontrollable dance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "uncontrollable dance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "duplicate foe",
-                            "aonid": 1505,
-                            "game-obj": "Spells",
-                            "name": "duplicate foe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "duplicate foe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "true target",
-                            "aonid": 1726,
-                            "game-obj": "Spells",
-                            "name": "true target",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "true target",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Wish Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "confusing colors",
+                "aonid": 1980,
+                "game-obj": "Spells",
+                "name": "confusing colors",
+                "type": "link"
+              },
+              {
+                "alt": "dream council",
+                "aonid": 1988,
+                "game-obj": "Spells",
+                "name": "dream council",
+                "type": "link"
+              },
+              {
+                "alt": "uncontrollable dance",
+                "aonid": 1730,
+                "game-obj": "Spells",
+                "name": "uncontrollable dance",
+                "type": "link"
+              },
+              {
+                "alt": "duplicate foe",
+                "aonid": 1505,
+                "game-obj": "Spells",
+                "name": "duplicate foe",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "true target",
+                "aonid": 1726,
+                "game-obj": "Spells",
+                "name": "true target",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -744,155 +328,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult wish dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "remake",
-                            "aonid": 1649,
-                            "game-obj": "Spells",
-                            "name": "remake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "remake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resplendent mansion",
-                            "aonid": 2018,
-                            "game-obj": "Spells",
-                            "name": "resplendent mansion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resplendent mansion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "bullhorn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Wish Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "remake",
+                "aonid": 1649,
+                "game-obj": "Spells",
+                "name": "remake",
+                "type": "link"
+              },
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
+              },
+              {
+                "alt": "resplendent mansion",
+                "aonid": 2018,
+                "game-obj": "Spells",
+                "name": "resplendent mansion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -907,48 +384,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -959,263 +399,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1225,7 +449,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1251,6 +474,1125 @@
         }
       ],
       "text": "Wish dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "suggestion",
+          "aonid": 1693,
+          "game-obj": "Spells",
+          "name": "suggestion",
+          "type": "link"
+        },
+        {
+          "alt": "translocate",
+          "aonid": 1724,
+          "game-obj": "Spells",
+          "name": "translocate",
+          "type": "link"
+        },
+        {
+          "alt": "earthbind",
+          "aonid": 1506,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "lightning bolt",
+          "aonid": 1586,
+          "game-obj": "Spells",
+          "name": "lightning bolt",
+          "type": "link"
+        },
+        {
+          "alt": "mind reading",
+          "aonid": 1602,
+          "game-obj": "Spells",
+          "name": "mind reading",
+          "type": "link"
+        },
+        {
+          "alt": "charitable urge",
+          "aonid": 1974,
+          "game-obj": "Spells",
+          "name": "charitable urge",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal treasure",
+          "aonid": 2013,
+          "game-obj": "Spells",
+          "name": "phantasmal treasure",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "d\u00e9j\u00e0 vu",
+          "aonid": 1986,
+          "game-obj": "Spells",
+          "name": "d\u00e9j\u00e0 vu",
+          "type": "link"
+        },
+        {
+          "alt": "force barrage",
+          "aonid": 1536,
+          "game-obj": "Spells",
+          "name": "force barrage",
+          "type": "link"
+        },
+        {
+          "alt": "item facade",
+          "aonid": 1579,
+          "game-obj": "Spells",
+          "name": "item facade",
+          "type": "link"
+        },
+        {
+          "alt": "bullhorn",
+          "aonid": 1971,
+          "game-obj": "Spells",
+          "name": "bullhorn",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Young Wish Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 199",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 199",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 199,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "suggestion",
+                      "aonid": 1693,
+                      "game-obj": "Spells",
+                      "name": "suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translocate",
+                      "aonid": 1724,
+                      "game-obj": "Spells",
+                      "name": "translocate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translocate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 1506,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "lightning bolt",
+                      "aonid": 1586,
+                      "game-obj": "Spells",
+                      "name": "lightning bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "lightning bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mind reading",
+                      "aonid": 1602,
+                      "game-obj": "Spells",
+                      "name": "mind reading",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mind reading",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "charitable urge",
+                      "aonid": 1974,
+                      "game-obj": "Spells",
+                      "name": "charitable urge",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "charitable urge",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal treasure",
+                      "aonid": 2013,
+                      "game-obj": "Spells",
+                      "name": "phantasmal treasure",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal treasure",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "d\u00e9j\u00e0 vu",
+                      "aonid": 1986,
+                      "game-obj": "Spells",
+                      "name": "d\u00e9j\u00e0 vu",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "d\u00e9j\u00e0 vu",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "force barrage",
+                      "aonid": 1536,
+                      "game-obj": "Spells",
+                      "name": "force barrage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "item facade",
+                      "aonid": 1579,
+                      "game-obj": "Spells",
+                      "name": "item facade",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "item facade",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bullhorn",
+                      "aonid": 1971,
+                      "game-obj": "Spells",
+                      "name": "bullhorn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 29; attack +21; **4th** *confusion*, *suggestion*, *translocate*; **3rd** *earthbind*, *lightning bolt*, *mind reading*; **2nd** *charitable urge*, *phantasmal treasure*, *revealing light*; **1st** *d\u00e9j\u00e0 vu*, *force barrage*, *item facade*; **Cantrips (4th)** *bullhorn*, *daze*, *figment*, *light*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cursed metamorphosis",
+          "aonid": 1479,
+          "game-obj": "Spells",
+          "name": "cursed metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "never mind",
+          "aonid": 1614,
+          "game-obj": "Spells",
+          "name": "never mind",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 1662,
+          "game-obj": "Spells",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "hallucination",
+          "aonid": 1551,
+          "game-obj": "Spells",
+          "name": "hallucination",
+          "type": "link"
+        },
+        {
+          "alt": "magic passage",
+          "aonid": 1591,
+          "game-obj": "Spells",
+          "name": "magic passage",
+          "type": "link"
+        },
+        {
+          "alt": "subconscious suggestion",
+          "aonid": 1692,
+          "game-obj": "Spells",
+          "name": "subconscious suggestion",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Wish Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 199",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 199",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 199,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young wish dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cursed metamorphosis",
+                      "aonid": 1479,
+                      "game-obj": "Spells",
+                      "name": "cursed metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cursed metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "never mind",
+                      "aonid": 1614,
+                      "game-obj": "Spells",
+                      "name": "never mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "never mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scrying",
+                      "aonid": 1662,
+                      "game-obj": "Spells",
+                      "name": "scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucination",
+                      "aonid": 1551,
+                      "game-obj": "Spells",
+                      "name": "hallucination",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucination",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "magic passage",
+                      "aonid": 1591,
+                      "game-obj": "Spells",
+                      "name": "magic passage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "magic passage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "subconscious suggestion",
+                      "aonid": 1692,
+                      "game-obj": "Spells",
+                      "name": "subconscious suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "subconscious suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 34; attack +26; As young wish dragon, plus **6th** *cursed metamorphosis*, *never mind*, *scrying*; **5th** *hallucination*, *magic passage*, *subconscious suggestion*; **Cantrips (6th)** *bullhorn*, *daze*, *figment*, *light*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "confusing colors",
+          "aonid": 1980,
+          "game-obj": "Spells",
+          "name": "confusing colors",
+          "type": "link"
+        },
+        {
+          "alt": "dream council",
+          "aonid": 1988,
+          "game-obj": "Spells",
+          "name": "dream council",
+          "type": "link"
+        },
+        {
+          "alt": "uncontrollable dance",
+          "aonid": 1730,
+          "game-obj": "Spells",
+          "name": "uncontrollable dance",
+          "type": "link"
+        },
+        {
+          "alt": "duplicate foe",
+          "aonid": 1505,
+          "game-obj": "Spells",
+          "name": "duplicate foe",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "true target",
+          "aonid": 1726,
+          "game-obj": "Spells",
+          "name": "true target",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Wish Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 199",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 199",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 199,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult wish dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusing colors",
+                      "aonid": 1980,
+                      "game-obj": "Spells",
+                      "name": "confusing colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusing colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dream council",
+                      "aonid": 1988,
+                      "game-obj": "Spells",
+                      "name": "dream council",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dream council",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "uncontrollable dance",
+                      "aonid": 1730,
+                      "game-obj": "Spells",
+                      "name": "uncontrollable dance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "uncontrollable dance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "duplicate foe",
+                      "aonid": 1505,
+                      "game-obj": "Spells",
+                      "name": "duplicate foe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "duplicate foe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "true target",
+                      "aonid": 1726,
+                      "game-obj": "Spells",
+                      "name": "true target",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "true target",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 41; attack +33; As adult wish dragon, plus **8th** *confusing colors*, *dream council*, *uncontrollable dance*; **7th** *duplicate foe*, *mask of terror*, *true target*; **Cantrips (8th)** *bullhorn*, *daze*, *figment*, *light*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "remake",
+          "aonid": 1649,
+          "game-obj": "Spells",
+          "name": "remake",
+          "type": "link"
+        },
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        },
+        {
+          "alt": "resplendent mansion",
+          "aonid": 2018,
+          "game-obj": "Spells",
+          "name": "resplendent mansion",
+          "type": "link"
+        }
+      ],
+      "name": "Wish Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Draconic Codex pg. 199",
+            "aonid": 277,
+            "game-obj": "Sources",
+            "name": "Draconic Codex pg. 199",
+            "type": "link"
+          },
+          "name": "Draconic Codex",
+          "page": 199,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult wish dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "remake",
+                      "aonid": 1649,
+                      "game-obj": "Spells",
+                      "name": "remake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "remake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resplendent mansion",
+                      "aonid": 2018,
+                      "game-obj": "Spells",
+                      "name": "resplendent mansion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resplendent mansion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "bullhorn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 45; attack +37; As adult wish dragon, plus **10th** *manifestation*, *remake*; **9th** *foresight*, *phantasmagoria*, *resplendent mansion*; **Cantrips (10th)** *bullhorn*, *daze*, *figment*, *light*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -1565,6 +1907,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 199",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 199",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 199,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1712,6 +2110,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 199",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 199",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 199,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/dragonet.json
+++ b/monster_families/draconic_codex/dragonet.json
@@ -81,48 +81,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -133,263 +96,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -399,7 +146,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -720,6 +466,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 128",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 128",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 128,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -867,6 +669,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 128",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 128",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 128,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/draconic_codex/wyrmwraith.json
+++ b/monster_families/draconic_codex/wyrmwraith.json
@@ -64,48 +64,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -116,263 +79,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -382,7 +129,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -703,6 +449,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 202",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 202",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 202,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -850,6 +652,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Draconic Codex pg. 202",
+                "aonid": 277,
+                "game-obj": "Sources",
+                "name": "Draconic Codex pg. 202",
+                "type": "link"
+              },
+              "name": "Draconic Codex",
+              "page": 202,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/gamemastery_guide/devotees.json
+++ b/monster_families/gamemastery_guide/devotees.json
@@ -30,170 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "bind undead",
-                    "aonid": 22,
-                    "game-obj": "Spells",
-                    "name": "bind undead",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "circle of protection",
-                    "aonid": 38,
-                    "game-obj": "Spells",
-                    "name": "circle of protection",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "harm",
-                    "aonid": 146,
-                    "game-obj": "Spells",
-                    "name": "harm",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "vampiric touch",
-                    "aonid": 354,
-                    "game-obj": "Spells",
-                    "name": "vampiric touch",
-                    "type": "link"
-                  }
-                ],
-                "name": "3rd",
-                "subtype": "ability",
-                "text": "*bind undead*, *circle of protection*, *harm* (\u00d73), *vampiric touch*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "dispel magic",
-                    "aonid": 78,
-                    "game-obj": "Spells",
-                    "name": "dispel magic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "false life",
-                    "aonid": 108,
-                    "game-obj": "Spells",
-                    "name": "false life",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ghoulish cravings",
-                    "aonid": 134,
-                    "game-obj": "Spells",
-                    "name": "ghoulish cravings",
-                    "type": "link"
-                  }
-                ],
-                "name": "2nd",
-                "subtype": "ability",
-                "text": "*dispel magic*, *false life*, *ghoulish cravings*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "bane",
-                    "aonid": 18,
-                    "game-obj": "Spells",
-                    "name": "bane",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fear",
-                    "aonid": 110,
-                    "game-obj": "Spells",
-                    "name": "fear",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ray of enfeeblement",
-                    "aonid": 244,
-                    "game-obj": "Spells",
-                    "name": "ray of enfeeblement",
-                    "type": "link"
-                  }
-                ],
-                "name": "1st",
-                "subtype": "ability",
-                "text": "*bane*, *fear*, *ray of enfeeblement*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "chill touch",
-                    "aonid": 35,
-                    "game-obj": "Spells",
-                    "name": "chill touch",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "detect magic",
-                    "aonid": 66,
-                    "game-obj": "Spells",
-                    "name": "detect magic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "divine lance",
-                    "aonid": 84,
-                    "game-obj": "Spells",
-                    "name": "divine lance",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "guidance",
-                    "aonid": 142,
-                    "game-obj": "Spells",
-                    "name": "guidance",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "shield",
-                    "aonid": 280,
-                    "game-obj": "Spells",
-                    "name": "shield",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cantrips",
-                "subtype": "ability",
-                "text": "*chill touch*, *detect magic*, *divine lance*, *guidance*, *shield*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "undeath's blessing",
-                    "aonid": 518,
-                    "game-obj": "Spells",
-                    "name": "undeath's blessing",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cleric Domain Spell",
-                "subtype": "ability",
-                "text": "*undeath's blessing*",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Spell Swap Example')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -218,6 +59,118 @@
                 "game-obj": "Deities",
                 "name": "Urgathoa",
                 "type": "link"
+              },
+              {
+                "alt": "bind undead",
+                "aonid": 22,
+                "game-obj": "Spells",
+                "name": "bind undead",
+                "type": "link"
+              },
+              {
+                "alt": "circle of protection",
+                "aonid": 38,
+                "game-obj": "Spells",
+                "name": "circle of protection",
+                "type": "link"
+              },
+              {
+                "alt": "harm",
+                "aonid": 146,
+                "game-obj": "Spells",
+                "name": "harm",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric touch",
+                "aonid": 354,
+                "game-obj": "Spells",
+                "name": "vampiric touch",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 78,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "false life",
+                "aonid": 108,
+                "game-obj": "Spells",
+                "name": "false life",
+                "type": "link"
+              },
+              {
+                "alt": "ghoulish cravings",
+                "aonid": 134,
+                "game-obj": "Spells",
+                "name": "ghoulish cravings",
+                "type": "link"
+              },
+              {
+                "alt": "bane",
+                "aonid": 18,
+                "game-obj": "Spells",
+                "name": "bane",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 110,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "ray of enfeeblement",
+                "aonid": 244,
+                "game-obj": "Spells",
+                "name": "ray of enfeeblement",
+                "type": "link"
+              },
+              {
+                "alt": "chill touch",
+                "aonid": 35,
+                "game-obj": "Spells",
+                "name": "chill touch",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 66,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 84,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 142,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 280,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "undeath's blessing",
+                "aonid": 518,
+                "game-obj": "Spells",
+                "name": "undeath's blessing",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -227,7 +180,6 @@
         ],
         "name": "Spell Swap Example",
         "subtype": "monster_family",
-        "text": "To make a NE acolyte or priest of Urgathoa, you can use these spells.",
         "type": "stat_block_section"
       }
     ],
@@ -236,6 +188,319 @@
   "name": "Devotees",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "bind undead",
+              "aonid": 22,
+              "game-obj": "Spells",
+              "name": "bind undead",
+              "type": "link"
+            },
+            {
+              "alt": "circle of protection",
+              "aonid": 38,
+              "game-obj": "Spells",
+              "name": "circle of protection",
+              "type": "link"
+            },
+            {
+              "alt": "harm",
+              "aonid": 146,
+              "game-obj": "Spells",
+              "name": "harm",
+              "type": "link"
+            },
+            {
+              "alt": "vampiric touch",
+              "aonid": 354,
+              "game-obj": "Spells",
+              "name": "vampiric touch",
+              "type": "link"
+            }
+          ],
+          "name": "3rd",
+          "subtype": "ability",
+          "text": "*bind undead*, *circle of protection*, *harm* (\u00d73), *vampiric touch*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "dispel magic",
+              "aonid": 78,
+              "game-obj": "Spells",
+              "name": "dispel magic",
+              "type": "link"
+            },
+            {
+              "alt": "false life",
+              "aonid": 108,
+              "game-obj": "Spells",
+              "name": "false life",
+              "type": "link"
+            },
+            {
+              "alt": "ghoulish cravings",
+              "aonid": 134,
+              "game-obj": "Spells",
+              "name": "ghoulish cravings",
+              "type": "link"
+            }
+          ],
+          "name": "2nd",
+          "subtype": "ability",
+          "text": "*dispel magic*, *false life*, *ghoulish cravings*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "bane",
+              "aonid": 18,
+              "game-obj": "Spells",
+              "name": "bane",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 110,
+              "game-obj": "Spells",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "ray of enfeeblement",
+              "aonid": 244,
+              "game-obj": "Spells",
+              "name": "ray of enfeeblement",
+              "type": "link"
+            }
+          ],
+          "name": "1st",
+          "subtype": "ability",
+          "text": "*bane*, *fear*, *ray of enfeeblement*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "chill touch",
+              "aonid": 35,
+              "game-obj": "Spells",
+              "name": "chill touch",
+              "type": "link"
+            },
+            {
+              "alt": "detect magic",
+              "aonid": 66,
+              "game-obj": "Spells",
+              "name": "detect magic",
+              "type": "link"
+            },
+            {
+              "alt": "divine lance",
+              "aonid": 84,
+              "game-obj": "Spells",
+              "name": "divine lance",
+              "type": "link"
+            },
+            {
+              "alt": "guidance",
+              "aonid": 142,
+              "game-obj": "Spells",
+              "name": "guidance",
+              "type": "link"
+            },
+            {
+              "alt": "shield",
+              "aonid": 280,
+              "game-obj": "Spells",
+              "name": "shield",
+              "type": "link"
+            }
+          ],
+          "name": "Cantrips",
+          "subtype": "ability",
+          "text": "*chill touch*, *detect magic*, *divine lance*, *guidance*, *shield*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "undeath's blessing",
+              "aonid": 518,
+              "game-obj": "Spells",
+              "name": "undeath's blessing",
+              "type": "link"
+            }
+          ],
+          "name": "Cleric Domain Spell",
+          "subtype": "ability",
+          "text": "*undeath's blessing*",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "acolyte",
+          "aonid": 893,
+          "game-obj": "NPCs",
+          "name": "acolyte",
+          "type": "link"
+        },
+        {
+          "alt": "priest",
+          "aonid": 896,
+          "game-obj": "NPCs",
+          "name": "priest",
+          "type": "link"
+        },
+        {
+          "alt": "Urgathoa",
+          "aonid": 19,
+          "game-obj": "Deities",
+          "name": "Urgathoa",
+          "type": "link"
+        },
+        {
+          "alt": "bind undead",
+          "aonid": 22,
+          "game-obj": "Spells",
+          "name": "bind undead",
+          "type": "link"
+        },
+        {
+          "alt": "circle of protection",
+          "aonid": 38,
+          "game-obj": "Spells",
+          "name": "circle of protection",
+          "type": "link"
+        },
+        {
+          "alt": "harm",
+          "aonid": 146,
+          "game-obj": "Spells",
+          "name": "harm",
+          "type": "link"
+        },
+        {
+          "alt": "vampiric touch",
+          "aonid": 354,
+          "game-obj": "Spells",
+          "name": "vampiric touch",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 78,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "false life",
+          "aonid": 108,
+          "game-obj": "Spells",
+          "name": "false life",
+          "type": "link"
+        },
+        {
+          "alt": "ghoulish cravings",
+          "aonid": 134,
+          "game-obj": "Spells",
+          "name": "ghoulish cravings",
+          "type": "link"
+        },
+        {
+          "alt": "bane",
+          "aonid": 18,
+          "game-obj": "Spells",
+          "name": "bane",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 110,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "ray of enfeeblement",
+          "aonid": 244,
+          "game-obj": "Spells",
+          "name": "ray of enfeeblement",
+          "type": "link"
+        },
+        {
+          "alt": "chill touch",
+          "aonid": 35,
+          "game-obj": "Spells",
+          "name": "chill touch",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 66,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 84,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 142,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 280,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "undeath's blessing",
+          "aonid": 518,
+          "game-obj": "Spells",
+          "name": "undeath's blessing",
+          "type": "link"
+        }
+      ],
+      "name": "Spell Swap Example",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 212",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 212",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 212,
+          "type": "source"
+        }
+      ],
+      "text": "To make a NE acolyte or priest of Urgathoa, you can use these spells. **3rd** *bind undead*, *circle of protection*, *harm* (\u00d73), *vampiric touch*; **2nd** *dispel magic*, *false life*, *ghoulish cravings*; **1st** *bane*, *fear*, *ray of enfeeblement*; **Cantrips** *chill touch*, *detect magic*, *divine lance*, *guidance*, *shield*; **Cleric Domain Spell** *undeath's blessing*",
+      "type": "section"
+    },
     {
       "links": [
         {

--- a/monster_families/gamemastery_guide/foresters.json
+++ b/monster_families/gamemastery_guide/foresters.json
@@ -24,73 +24,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Verduran Forest",
-                "subtype": "ability",
-                "text": "is the largest woodland on the continent of Avistan; the druids and rangers of the Wildwood Lodge earned the forest great autonomy through a thousand-year treaty. The",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "kami",
-                    "aonid": 243,
-                    "game-obj": "MonsterFamilies",
-                    "name": "kami",
-                    "type": "link"
-                  }
-                ],
-                "name": "Forest of Spirits",
-                "subtype": "ability",
-                "text": "stretches over a thousand miles of Tian Xia and is the primeval birthplace of the nature spirits known as kami.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "green dragons",
-                    "aonid": 167,
-                    "game-obj": "MonsterFamilies",
-                    "name": "green dragons",
-                    "type": "link"
-                  }
-                ],
-                "name": "The Fangwood",
-                "subtype": "ability",
-                "text": "in Nirmathas and the Gravelands is home to a secret village of druids, named Crystalhurst, and to one of the most powerful green dragons in the world. The terrible Darkblight devastated the 7,000-year-old fey court that once guarded the wood. The",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Treerazer",
-                    "aonid": 26,
-                    "game-obj": "Deities",
-                    "name": "Treerazer",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fierani Forest",
-                "subtype": "ability",
-                "text": "covers the majority of the elven nation of Kyonin and borders Tanglebriar, home to the Fierani rangers' great nemesis, the demon Treerazer.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Famed Forests')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "kami",
+                "aonid": 243,
+                "game-obj": "MonsterFamilies",
+                "name": "kami",
+                "type": "link"
+              },
+              {
+                "alt": "green dragons",
+                "aonid": 167,
+                "game-obj": "MonsterFamilies",
+                "name": "green dragons",
+                "type": "link"
+              },
+              {
+                "alt": "Treerazer",
+                "aonid": 26,
+                "game-obj": "Deities",
+                "name": "Treerazer",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -100,7 +62,6 @@
         ],
         "name": "Famed Forests",
         "subtype": "monster_family",
-        "text": "The",
         "type": "stat_block_section"
       }
     ],
@@ -108,6 +69,111 @@
   },
   "name": "Foresters",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Verduran Forest",
+          "subtype": "ability",
+          "text": "is the largest woodland on the continent of Avistan; the druids and rangers of the Wildwood Lodge earned the forest great autonomy through a thousand-year treaty. The",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "kami",
+              "aonid": 243,
+              "game-obj": "MonsterFamilies",
+              "name": "kami",
+              "type": "link"
+            }
+          ],
+          "name": "Forest of Spirits",
+          "subtype": "ability",
+          "text": "stretches over a thousand miles of Tian Xia and is the primeval birthplace of the nature spirits known as kami.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "green dragons",
+              "aonid": 167,
+              "game-obj": "MonsterFamilies",
+              "name": "green dragons",
+              "type": "link"
+            }
+          ],
+          "name": "The Fangwood",
+          "subtype": "ability",
+          "text": "in Nirmathas and the Gravelands is home to a secret village of druids, named Crystalhurst, and to one of the most powerful green dragons in the world. The terrible Darkblight devastated the 7,000-year-old fey court that once guarded the wood. The",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Treerazer",
+              "aonid": 26,
+              "game-obj": "Deities",
+              "name": "Treerazer",
+              "type": "link"
+            }
+          ],
+          "name": "Fierani Forest",
+          "subtype": "ability",
+          "text": "covers the majority of the elven nation of Kyonin and borders Tanglebriar, home to the Fierani rangers' great nemesis, the demon Treerazer.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "kami",
+          "aonid": 243,
+          "game-obj": "MonsterFamilies",
+          "name": "kami",
+          "type": "link"
+        },
+        {
+          "alt": "green dragons",
+          "aonid": 167,
+          "game-obj": "MonsterFamilies",
+          "name": "green dragons",
+          "type": "link"
+        },
+        {
+          "alt": "Treerazer",
+          "aonid": 26,
+          "game-obj": "Deities",
+          "name": "Treerazer",
+          "type": "link"
+        }
+      ],
+      "name": "Famed Forests",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 218",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 218",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 218,
+          "type": "source"
+        }
+      ],
+      "text": "The **Verduran Forest** is the largest woodland on the continent of Avistan; the druids and rangers of the Wildwood Lodge earned the forest great autonomy through a thousand-year treaty. The **Forest of Spirits** stretches over a thousand miles of Tian Xia and is the primeval birthplace of the nature spirits known as kami. **The Fangwood** in Nirmathas and the Gravelands is home to a secret village of druids, named Crystalhurst, and to one of the most powerful green dragons in the world. The terrible Darkblight devastated the 7,000-year-old fey court that once guarded the wood. The **Fierani Forest** covers the majority of the elven nation of Kyonin and borders Tanglebriar, home to the Fierani rangers' great nemesis, the demon Treerazer.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/gamemastery_guide/healers.json
+++ b/monster_families/gamemastery_guide/healers.json
@@ -30,62 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Identify Affliction",
-                "subtype": "ability",
-                "text": ": 1 sp.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Treat Wounds",
-                  "aonid": 57,
-                  "game-obj": "Actions",
-                  "name": "Treat Wounds",
-                  "type": "link"
-                },
-                "name": "Treat Wounds",
-                "subtype": "ability",
-                "text": ": 2 sp.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Treat Disease",
-                  "aonid": 55,
-                  "game-obj": "Actions",
-                  "name": "Treat Disease",
-                  "type": "link"
-                },
-                "name": "Treat Disease",
-                "subtype": "ability",
-                "text": ": 1 gp.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "First Aid",
-                  "aonid": 54,
-                  "game-obj": "Actions",
-                  "name": "First Aid",
-                  "type": "link"
-                },
-                "name": "First Aid or Treating a Poison",
-                "subtype": "ability",
-                "text": ": 1 sp.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Medical Service Prices')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -124,6 +73,34 @@
                 "game-obj": "NPCs",
                 "name": "plague doctor",
                 "type": "link"
+              },
+              {
+                "alt": "Treat Wounds",
+                "aonid": 57,
+                "game-obj": "Actions",
+                "name": "Treat Wounds",
+                "type": "link"
+              },
+              {
+                "alt": "Treat Disease",
+                "aonid": 55,
+                "game-obj": "Actions",
+                "name": "Treat Disease",
+                "type": "link"
+              },
+              {
+                "alt": "First Aid",
+                "aonid": 54,
+                "game-obj": "Actions",
+                "name": "First Aid",
+                "type": "link"
+              },
+              {
+                "alt": "Treating a Poison",
+                "aonid": 56,
+                "game-obj": "Actions",
+                "name": "Treating a Poison",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -133,7 +110,6 @@
         ],
         "name": "Medical Service Prices",
         "subtype": "monster_family",
-        "text": "The physician and surgeon are masters of Medicine; the apothecary and plague doctor are experts. Plague doctors charge five times this rate, and surgeons 10 times.",
         "type": "stat_block_section"
       }
     ],
@@ -181,6 +157,141 @@
         }
       ],
       "text": "Common diseases are located here. These can be treated by most healers, though they may have longer-term physiological impacts. For unusual conditions, like ghoul fever or mummy rot, you might impose penalties on a normal healer attempting to remedy them.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Identify Affliction",
+          "subtype": "ability",
+          "text": ": 1 sp.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "Treat Wounds",
+            "aonid": 57,
+            "game-obj": "Actions",
+            "name": "Treat Wounds",
+            "type": "link"
+          },
+          "name": "Treat Wounds",
+          "subtype": "ability",
+          "text": ": 2 sp.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "Treat Disease",
+            "aonid": 55,
+            "game-obj": "Actions",
+            "name": "Treat Disease",
+            "type": "link"
+          },
+          "name": "Treat Disease",
+          "subtype": "ability",
+          "text": ": 1 gp.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "First Aid",
+            "aonid": 54,
+            "game-obj": "Actions",
+            "name": "First Aid",
+            "type": "link"
+          },
+          "name": "First Aid or Treating a Poison",
+          "subtype": "ability",
+          "text": ": 1 sp.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "physician",
+          "aonid": 909,
+          "game-obj": "NPCs",
+          "name": "physician",
+          "type": "link"
+        },
+        {
+          "alt": "surgeon",
+          "aonid": 910,
+          "game-obj": "NPCs",
+          "name": "surgeon",
+          "type": "link"
+        },
+        {
+          "alt": "Medicine",
+          "aonid": 9,
+          "game-obj": "Skills",
+          "name": "Medicine",
+          "type": "link"
+        },
+        {
+          "alt": "apothecary",
+          "aonid": 908,
+          "game-obj": "NPCs",
+          "name": "apothecary",
+          "type": "link"
+        },
+        {
+          "alt": "plague doctor",
+          "aonid": 911,
+          "game-obj": "NPCs",
+          "name": "plague doctor",
+          "type": "link"
+        },
+        {
+          "alt": "Treat Wounds",
+          "aonid": 57,
+          "game-obj": "Actions",
+          "name": "Treat Wounds",
+          "type": "link"
+        },
+        {
+          "alt": "Treat Disease",
+          "aonid": 55,
+          "game-obj": "Actions",
+          "name": "Treat Disease",
+          "type": "link"
+        },
+        {
+          "alt": "First Aid",
+          "aonid": 54,
+          "game-obj": "Actions",
+          "name": "First Aid",
+          "type": "link"
+        },
+        {
+          "alt": "Treating a Poison",
+          "aonid": 56,
+          "game-obj": "Actions",
+          "name": "Treating a Poison",
+          "type": "link"
+        }
+      ],
+      "name": "Medical Service Prices",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 220",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 220",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 220,
+          "type": "source"
+        }
+      ],
+      "text": "The physician and surgeon are masters of Medicine; the apothecary and plague doctor are experts. Plague doctors charge five times this rate, and surgeons 10 times.   \n  \n**Identify Affliction**: 1 sp.   \n**Treat Wounds**: 2 sp.   \n**Treat Disease**: 1 gp.   \n**First Aid or Treating a Poison**: 1 sp.",
       "type": "section"
     }
   ],

--- a/monster_families/gamemastery_guide/magistrates.json
+++ b/monster_families/gamemastery_guide/magistrates.json
@@ -24,146 +24,119 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Harbormaster",
-                  "aonid": 919,
-                  "game-obj": "NPCs",
-                  "name": "Harbormaster",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "Bosun",
-                    "aonid": 953,
-                    "game-obj": "NPCs",
-                    "name": "Bosun",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "dockhand",
-                    "aonid": 913,
-                    "game-obj": "NPCs",
-                    "name": "dockhand",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "guard",
-                    "aonid": 933,
-                    "game-obj": "NPCs",
-                    "name": "guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ship captain",
-                    "aonid": 954,
-                    "game-obj": "NPCs",
-                    "name": "ship captain",
-                    "type": "link"
-                  }
-                ],
-                "name": "Harbormaster",
-                "subtype": "ability",
-                "text": ": Bosun, dockhand, guard, ship captain.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Judge",
-                  "aonid": 917,
-                  "game-obj": "NPCs",
-                  "name": "Judge",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "Captain of the guard",
-                    "aonid": 937,
-                    "game-obj": "NPCs",
-                    "name": "Captain of the guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "executioner",
-                    "aonid": 938,
-                    "game-obj": "NPCs",
-                    "name": "executioner",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "guard",
-                    "aonid": 933,
-                    "game-obj": "NPCs",
-                    "name": "guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "jailer",
-                    "aonid": 935,
-                    "game-obj": "NPCs",
-                    "name": "jailer",
-                    "type": "link"
-                  }
-                ],
-                "name": "Judge",
-                "subtype": "ability",
-                "text": ": Captain of the guard, executioner, guard, jailer",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Tax Collector",
-                  "aonid": 918,
-                  "game-obj": "NPCs",
-                  "name": "Tax Collector",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "Captain of the guard",
-                    "aonid": 937,
-                    "game-obj": "NPCs",
-                    "name": "Captain of the guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "guard",
-                    "aonid": 933,
-                    "game-obj": "NPCs",
-                    "name": "guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "jailer",
-                    "aonid": 935,
-                    "game-obj": "NPCs",
-                    "name": "jailer",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "watch officer",
-                    "aonid": 936,
-                    "game-obj": "NPCs",
-                    "name": "watch officer",
-                    "type": "link"
-                  }
-                ],
-                "name": "Tax Collector",
-                "subtype": "ability",
-                "text": ": Captain of the guard, guard, jailer, watch officer",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='At Your Service')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Harbormaster",
+                "aonid": 919,
+                "game-obj": "NPCs",
+                "name": "Harbormaster",
+                "type": "link"
+              },
+              {
+                "alt": "Bosun",
+                "aonid": 953,
+                "game-obj": "NPCs",
+                "name": "Bosun",
+                "type": "link"
+              },
+              {
+                "alt": "dockhand",
+                "aonid": 913,
+                "game-obj": "NPCs",
+                "name": "dockhand",
+                "type": "link"
+              },
+              {
+                "alt": "guard",
+                "aonid": 933,
+                "game-obj": "NPCs",
+                "name": "guard",
+                "type": "link"
+              },
+              {
+                "alt": "ship captain",
+                "aonid": 954,
+                "game-obj": "NPCs",
+                "name": "ship captain",
+                "type": "link"
+              },
+              {
+                "alt": "Judge",
+                "aonid": 917,
+                "game-obj": "NPCs",
+                "name": "Judge",
+                "type": "link"
+              },
+              {
+                "alt": "Captain of the guard",
+                "aonid": 937,
+                "game-obj": "NPCs",
+                "name": "Captain of the guard",
+                "type": "link"
+              },
+              {
+                "alt": "executioner",
+                "aonid": 938,
+                "game-obj": "NPCs",
+                "name": "executioner",
+                "type": "link"
+              },
+              {
+                "alt": "guard",
+                "aonid": 933,
+                "game-obj": "NPCs",
+                "name": "guard",
+                "type": "link"
+              },
+              {
+                "alt": "jailer",
+                "aonid": 935,
+                "game-obj": "NPCs",
+                "name": "jailer",
+                "type": "link"
+              },
+              {
+                "alt": "Tax Collector",
+                "aonid": 918,
+                "game-obj": "NPCs",
+                "name": "Tax Collector",
+                "type": "link"
+              },
+              {
+                "alt": "Captain of the guard",
+                "aonid": 937,
+                "game-obj": "NPCs",
+                "name": "Captain of the guard",
+                "type": "link"
+              },
+              {
+                "alt": "guard",
+                "aonid": 933,
+                "game-obj": "NPCs",
+                "name": "guard",
+                "type": "link"
+              },
+              {
+                "alt": "jailer",
+                "aonid": 935,
+                "game-obj": "NPCs",
+                "name": "jailer",
+                "type": "link"
+              },
+              {
+                "alt": "watch officer",
+                "aonid": 936,
+                "game-obj": "NPCs",
+                "name": "watch officer",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -173,7 +146,6 @@
         ],
         "name": "At Your Service",
         "subtype": "monster_family",
-        "text": "Magistrates can conscript others into service in a variety of positions.",
         "type": "stat_block_section"
       }
     ],
@@ -182,6 +154,266 @@
   "name": "Magistrates",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "Harbormaster",
+            "aonid": 919,
+            "game-obj": "NPCs",
+            "name": "Harbormaster",
+            "type": "link"
+          },
+          "links": [
+            {
+              "alt": "Bosun",
+              "aonid": 953,
+              "game-obj": "NPCs",
+              "name": "Bosun",
+              "type": "link"
+            },
+            {
+              "alt": "dockhand",
+              "aonid": 913,
+              "game-obj": "NPCs",
+              "name": "dockhand",
+              "type": "link"
+            },
+            {
+              "alt": "guard",
+              "aonid": 933,
+              "game-obj": "NPCs",
+              "name": "guard",
+              "type": "link"
+            },
+            {
+              "alt": "ship captain",
+              "aonid": 954,
+              "game-obj": "NPCs",
+              "name": "ship captain",
+              "type": "link"
+            }
+          ],
+          "name": "Harbormaster",
+          "subtype": "ability",
+          "text": ": Bosun, dockhand, guard, ship captain.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "Judge",
+            "aonid": 917,
+            "game-obj": "NPCs",
+            "name": "Judge",
+            "type": "link"
+          },
+          "links": [
+            {
+              "alt": "Captain of the guard",
+              "aonid": 937,
+              "game-obj": "NPCs",
+              "name": "Captain of the guard",
+              "type": "link"
+            },
+            {
+              "alt": "executioner",
+              "aonid": 938,
+              "game-obj": "NPCs",
+              "name": "executioner",
+              "type": "link"
+            },
+            {
+              "alt": "guard",
+              "aonid": 933,
+              "game-obj": "NPCs",
+              "name": "guard",
+              "type": "link"
+            },
+            {
+              "alt": "jailer",
+              "aonid": 935,
+              "game-obj": "NPCs",
+              "name": "jailer",
+              "type": "link"
+            }
+          ],
+          "name": "Judge",
+          "subtype": "ability",
+          "text": ": Captain of the guard, executioner, guard, jailer",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "Tax Collector",
+            "aonid": 918,
+            "game-obj": "NPCs",
+            "name": "Tax Collector",
+            "type": "link"
+          },
+          "links": [
+            {
+              "alt": "Captain of the guard",
+              "aonid": 937,
+              "game-obj": "NPCs",
+              "name": "Captain of the guard",
+              "type": "link"
+            },
+            {
+              "alt": "guard",
+              "aonid": 933,
+              "game-obj": "NPCs",
+              "name": "guard",
+              "type": "link"
+            },
+            {
+              "alt": "jailer",
+              "aonid": 935,
+              "game-obj": "NPCs",
+              "name": "jailer",
+              "type": "link"
+            },
+            {
+              "alt": "watch officer",
+              "aonid": 936,
+              "game-obj": "NPCs",
+              "name": "watch officer",
+              "type": "link"
+            }
+          ],
+          "name": "Tax Collector",
+          "subtype": "ability",
+          "text": ": Captain of the guard, guard, jailer, watch officer",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Harbormaster",
+          "aonid": 919,
+          "game-obj": "NPCs",
+          "name": "Harbormaster",
+          "type": "link"
+        },
+        {
+          "alt": "Bosun",
+          "aonid": 953,
+          "game-obj": "NPCs",
+          "name": "Bosun",
+          "type": "link"
+        },
+        {
+          "alt": "dockhand",
+          "aonid": 913,
+          "game-obj": "NPCs",
+          "name": "dockhand",
+          "type": "link"
+        },
+        {
+          "alt": "guard",
+          "aonid": 933,
+          "game-obj": "NPCs",
+          "name": "guard",
+          "type": "link"
+        },
+        {
+          "alt": "ship captain",
+          "aonid": 954,
+          "game-obj": "NPCs",
+          "name": "ship captain",
+          "type": "link"
+        },
+        {
+          "alt": "Judge",
+          "aonid": 917,
+          "game-obj": "NPCs",
+          "name": "Judge",
+          "type": "link"
+        },
+        {
+          "alt": "Captain of the guard",
+          "aonid": 937,
+          "game-obj": "NPCs",
+          "name": "Captain of the guard",
+          "type": "link"
+        },
+        {
+          "alt": "executioner",
+          "aonid": 938,
+          "game-obj": "NPCs",
+          "name": "executioner",
+          "type": "link"
+        },
+        {
+          "alt": "guard",
+          "aonid": 933,
+          "game-obj": "NPCs",
+          "name": "guard",
+          "type": "link"
+        },
+        {
+          "alt": "jailer",
+          "aonid": 935,
+          "game-obj": "NPCs",
+          "name": "jailer",
+          "type": "link"
+        },
+        {
+          "alt": "Tax Collector",
+          "aonid": 918,
+          "game-obj": "NPCs",
+          "name": "Tax Collector",
+          "type": "link"
+        },
+        {
+          "alt": "Captain of the guard",
+          "aonid": 937,
+          "game-obj": "NPCs",
+          "name": "Captain of the guard",
+          "type": "link"
+        },
+        {
+          "alt": "guard",
+          "aonid": 933,
+          "game-obj": "NPCs",
+          "name": "guard",
+          "type": "link"
+        },
+        {
+          "alt": "jailer",
+          "aonid": 935,
+          "game-obj": "NPCs",
+          "name": "jailer",
+          "type": "link"
+        },
+        {
+          "alt": "watch officer",
+          "aonid": 936,
+          "game-obj": "NPCs",
+          "name": "watch officer",
+          "type": "link"
+        }
+      ],
+      "name": "At Your Service",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 224",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 224",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 224,
+          "type": "source"
+        }
+      ],
+      "text": "Magistrates can conscript others into service in a variety of positions.   \n  \n**Harbormaster**: Bosun, dockhand, guard, ship captain.   \n**Judge**: Captain of the guard, executioner, guard, jailer   \n**Tax Collector**: Captain of the guard, guard, jailer, watch officer",
+      "type": "section"
+    },
     {
       "links": [
         {

--- a/monster_families/gamemastery_guide/mercenaries.json
+++ b/monster_families/gamemastery_guide/mercenaries.json
@@ -30,77 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Crackster",
-                "subtype": "ability",
-                "text": ": Someone adept at breaking locks or safes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Diving",
-                "subtype": "ability",
-                "text": ": Theft or smuggling below ground, often through tunnels.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Foxing",
-                "subtype": "ability",
-                "text": ": To play at being asleep, usually for an ambush.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Medic",
-                "subtype": "ability",
-                "text": ": A healer.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Ram",
-                "subtype": "ability",
-                "text": ": A hard-hitting warrior.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Slinger",
-                "subtype": "ability",
-                "text": ": A spellcaster.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Sway of Coin",
-                "subtype": "ability",
-                "text": ": Swearing allegiance to whoever pays the most.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Waterline",
-                "subtype": "ability",
-                "text": ": A mercenary troupe's money: \u201cTake time in town while the waterline's high, everyone.\u201d",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Whisperstep",
-                "subtype": "ability",
-                "text": ": Anyone who can move stealthily.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Mercenary Banter')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -111,7 +45,6 @@
         ],
         "name": "Mercenary Banter",
         "subtype": "monster_family",
-        "text": "Here's some parlance commonly used by mercenaries.",
         "type": "stat_block_section"
       }
     ],
@@ -146,6 +79,91 @@
         }
       ],
       "text": "Unless a mercenary prides themself on their name or reputation, the PCs might be able to bribe them to switch sides, or at least stand aside. You can estimate a bribe by taking roughly 5% of the Party Currency value from the row corresponding to the NPC's level on Table 10\u20139.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Crackster",
+          "subtype": "ability",
+          "text": ": Someone adept at breaking locks or safes.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Diving",
+          "subtype": "ability",
+          "text": ": Theft or smuggling below ground, often through tunnels.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Foxing",
+          "subtype": "ability",
+          "text": ": To play at being asleep, usually for an ambush.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Medic",
+          "subtype": "ability",
+          "text": ": A healer.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Ram",
+          "subtype": "ability",
+          "text": ": A hard-hitting warrior.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Slinger",
+          "subtype": "ability",
+          "text": ": A spellcaster.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Sway of Coin",
+          "subtype": "ability",
+          "text": ": Swearing allegiance to whoever pays the most.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Waterline",
+          "subtype": "ability",
+          "text": ": A mercenary troupe's money: \u201cTake time in town while the waterline's high, everyone.\u201d",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Whisperstep",
+          "subtype": "ability",
+          "text": ": Anyone who can move stealthily.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Mercenary Banter",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 226",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 226",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 226,
+          "type": "source"
+        }
+      ],
+      "text": "Here's some parlance commonly used by mercenaries.   \n  \n**Crackster**: Someone adept at breaking locks or safes.   \n**Diving**: Theft or smuggling below ground, often through tunnels.   \n**Foxing**: To play at being asleep, usually for an ambush.   \n**Medic**: A healer.   \n**Ram**: A hard-hitting warrior.   \n**Slinger**: A spellcaster.   \n**Sway of Coin**: Swearing allegiance to whoever pays the most.   \n**Waterline**: A mercenary troupe's money: \u201cTake time in town while the waterline's high, everyone.\u201d   \n**Whisperstep**: Anyone who can move stealthily.",
       "type": "section"
     }
   ],

--- a/monster_families/gamemastery_guide/mystics.json
+++ b/monster_families/gamemastery_guide/mystics.json
@@ -30,76 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Anthomancy",
-                "subtype": "ability",
-                "text": ": Flowers.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Astrology",
-                "subtype": "ability",
-                "text": ": The cosmic caravan.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Demonomancy",
-                "subtype": "ability",
-                "text": ": Asking demons.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Harrowing",
-                "subtype": "ability",
-                "text": ": Harrow card readings.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Haruspicy",
-                "subtype": "ability",
-                "text": ": Entrails.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Ichthyomancy",
-                "subtype": "ability",
-                "text": ": The next fish caught.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Mazomancy",
-                "subtype": "ability",
-                "text": ": A nursing babe.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Oneiromancy",
-                "subtype": "ability",
-                "text": ": Dreams.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Tyromancy",
-                "subtype": "ability",
-                "text": ": Coagulation of cheese.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Forms Of Fortune-Telling')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -115,44 +50,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "The Church of Razmir",
-                "subtype": "ability",
-                "text": "offers a plan of 31 steps to divinity. The",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Esoteric Order of the Palatine Eye",
-                "subtype": "ability",
-                "text": "seeks celestial truths said to be granted by an ancient angel.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Knights of the Aeon Star",
-                "subtype": "ability",
-                "text": "search for secret lore. Followers of",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Rivethun",
-                "subtype": "ability",
-                "text": ", dwarven animism, reach out to spirits to gain knowledge and earn favors.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Mystic Cadres')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -163,7 +65,6 @@
         ],
         "name": "Mystic Cadres",
         "subtype": "monster_family",
-        "text": "Golarion has several mystic groups.",
         "type": "stat_block_section"
       }
     ],
@@ -189,6 +90,142 @@
         }
       ],
       "text": "Most rituals have a simple gp cost and skills. But what if a desperate NPC is willing to offer something darker, such as lives, souls, or worse? Such a nefarious ritual uses a normal ritual as a baseline, but the DCs and proficiency requirements might be reduced or waived entirely, as might any gp cost.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Anthomancy",
+          "subtype": "ability",
+          "text": ": Flowers.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Astrology",
+          "subtype": "ability",
+          "text": ": The cosmic caravan.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Demonomancy",
+          "subtype": "ability",
+          "text": ": Asking demons.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Harrowing",
+          "subtype": "ability",
+          "text": ": Harrow card readings.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Haruspicy",
+          "subtype": "ability",
+          "text": ": Entrails.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Ichthyomancy",
+          "subtype": "ability",
+          "text": ": The next fish caught.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Mazomancy",
+          "subtype": "ability",
+          "text": ": A nursing babe.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Oneiromancy",
+          "subtype": "ability",
+          "text": ": Dreams.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Tyromancy",
+          "subtype": "ability",
+          "text": ": Coagulation of cheese.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Forms Of Fortune-Telling",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 228",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 228",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 228,
+          "type": "source"
+        }
+      ],
+      "text": "**Anthomancy**: Flowers.   \n**Astrology**: The cosmic caravan.   \n**Demonomancy**: Asking demons.   \n**Harrowing**: Harrow card readings.   \n**Haruspicy**: Entrails.   \n**Ichthyomancy**: The next fish caught.   \n**Mazomancy**: A nursing babe.   \n**Oneiromancy**: Dreams.   \n**Tyromancy**: Coagulation of cheese.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "The Church of Razmir",
+          "subtype": "ability",
+          "text": "offers a plan of 31 steps to divinity. The",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Esoteric Order of the Palatine Eye",
+          "subtype": "ability",
+          "text": "seeks celestial truths said to be granted by an ancient angel.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Knights of the Aeon Star",
+          "subtype": "ability",
+          "text": "search for secret lore. Followers of",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Rivethun",
+          "subtype": "ability",
+          "text": ", dwarven animism, reach out to spirits to gain knowledge and earn favors.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Mystic Cadres",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 228",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 228",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 228,
+          "type": "source"
+        }
+      ],
+      "text": "Golarion has several mystic groups. **The Church of Razmir** offers a plan of 31 steps to divinity. The **Esoteric Order of the Palatine Eye** seeks celestial truths said to be granted by an ancient angel. **Knights of the Aeon Star** search for secret lore. Followers of **Rivethun**, dwarven animism, reach out to spirits to gain knowledge and earn favors.",
       "type": "section"
     },
     {

--- a/monster_families/gamemastery_guide/performers.json
+++ b/monster_families/gamemastery_guide/performers.json
@@ -30,61 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Circus",
-                "subtype": "ability",
-                "text": "1 sp;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Dance",
-                "subtype": "ability",
-                "text": "2 cp social, 6 cp stage performance, 1 gp high-society ball;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Stage Play",
-                "subtype": "ability",
-                "text": "6 cp small theater, 1 sp major theater;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Opera",
-                "subtype": "ability",
-                "text": "5 gp general admission, 20 gp box seats;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Music",
-                "subtype": "ability",
-                "text": "5 cp troubadours, 2 sp orchestra;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Street Performance",
-                "subtype": "ability",
-                "text": "tips of 1\u20132 cp.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Let\\'s See A Show')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -95,7 +45,6 @@
         ],
         "name": "Let's See A Show",
         "subtype": "monster_family",
-        "text": "Prices for a night's entertainment are per head and can be far higher for world-class performers.",
         "type": "stat_block_section"
       }
     ],
@@ -103,6 +52,77 @@
   },
   "name": "Performers",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Circus",
+          "subtype": "ability",
+          "text": "1 sp;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Dance",
+          "subtype": "ability",
+          "text": "2 cp social, 6 cp stage performance, 1 gp high-society ball;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Stage Play",
+          "subtype": "ability",
+          "text": "6 cp small theater, 1 sp major theater;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Opera",
+          "subtype": "ability",
+          "text": "5 gp general admission, 20 gp box seats;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Music",
+          "subtype": "ability",
+          "text": "5 cp troubadours, 2 sp orchestra;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Street Performance",
+          "subtype": "ability",
+          "text": "tips of 1\u20132 cp.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Let's See A Show",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 236",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 236",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 236,
+          "type": "source"
+        }
+      ],
+      "text": "Prices for a night's entertainment are per head and can be far higher for world-class performers. **Circus** 1 sp; **Dance** 2 cp social, 6 cp stage performance, 1 gp high-society ball; **Stage Play** 6 cp small theater, 1 sp major theater; **Opera** 5 gp general admission, 20 gp box seats; **Music** 5 cp troubadours, 2 sp orchestra; **Street Performance** tips of 1\u20132 cp.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/gamemastery_guide/publicans.json
+++ b/monster_families/gamemastery_guide/publicans.json
@@ -24,41 +24,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Ale",
-                "subtype": "ability",
-                "text": ": Andoren beer, Boulderhead bock, Cheerful Delver stout, Liquid Ghosts, Luglurch ale, Thileu lager.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Cider and Mead",
-                "subtype": "ability",
-                "text": ": Hardroot cider, Qadiran cider, Two Knight Brewery mead, Wineberry mead.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Wine",
-                "subtype": "ability",
-                "text": ": Irrisen icewine, sarain, syrinelle, Whiterose Abbey wine",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Spirits",
-                "subtype": "ability",
-                "text": ": Daggermark drip, dragon punch whiskey, Old Erebus, vjarik.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Tap List')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -110,6 +80,55 @@
         }
       ],
       "text": "Bar fights work better without a grid. Use the stat blocks here or in the Downtrodden section for notable participants, everyone else attacking nonlethally with fists or improvised weapons. Roll one or two attacks at the end of each round against each PC in the fight (+4 attack modifier, 1d4+2 bludgeoning damage). Alcohol rules can be found here",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Ale",
+          "subtype": "ability",
+          "text": ": Andoren beer, Boulderhead bock, Cheerful Delver stout, Liquid Ghosts, Luglurch ale, Thileu lager.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Cider and Mead",
+          "subtype": "ability",
+          "text": ": Hardroot cider, Qadiran cider, Two Knight Brewery mead, Wineberry mead.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Wine",
+          "subtype": "ability",
+          "text": ": Irrisen icewine, sarain, syrinelle, Whiterose Abbey wine",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Spirits",
+          "subtype": "ability",
+          "text": ": Daggermark drip, dragon punch whiskey, Old Erebus, vjarik.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Tap List",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 238",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 238",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 238,
+          "type": "source"
+        }
+      ],
+      "text": "**Ale**: Andoren beer, Boulderhead bock, Cheerful Delver stout, Liquid Ghosts, Luglurch ale, Thileu lager.   \n**Cider and Mead**: Hardroot cider, Qadiran cider, Two Knight Brewery mead, Wineberry mead.   \n**Wine**: Irrisen icewine, sarain, syrinelle, Whiterose Abbey wine   \n**Spirits**: Daggermark drip, dragon punch whiskey, Old Erebus, vjarik.",
       "type": "section"
     }
   ],

--- a/monster_families/gamemastery_guide/scholars.json
+++ b/monster_families/gamemastery_guide/scholars.json
@@ -30,34 +30,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Kitharodian Academy (Taldor)",
-                "subtype": "ability",
-                "text": ": Famed bardic college teaching students of all social classes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Magaambya (Nantambu)",
-                "subtype": "ability",
-                "text": ": Ancient school with some of the world's greatest stores of arcane knowledge.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "University of Lepidstadt (Ustalav)",
-                "subtype": "ability",
-                "text": ": School primarily focusing on alchemy, medicine, and scientific study.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Centers Of Learning')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -76,6 +53,48 @@
   "name": "Scholars",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Kitharodian Academy (Taldor)",
+          "subtype": "ability",
+          "text": ": Famed bardic college teaching students of all social classes.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Magaambya (Nantambu)",
+          "subtype": "ability",
+          "text": ": Ancient school with some of the world's greatest stores of arcane knowledge.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "University of Lepidstadt (Ustalav)",
+          "subtype": "ability",
+          "text": ": School primarily focusing on alchemy, medicine, and scientific study.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Centers Of Learning",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 240",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 240",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 240,
+          "type": "source"
+        }
+      ],
+      "text": "**Kitharodian Academy (Taldor)**: Famed bardic college teaching students of all social classes.   \n**Magaambya (Nantambu)**: Ancient school with some of the world's greatest stores of arcane knowledge.   \n**University of Lepidstadt (Ustalav)**: School primarily focusing on alchemy, medicine, and scientific study.",
+      "type": "section"
+    },
     {
       "name": "Uncommon Scholastic Disciplines",
       "sources": [

--- a/monster_families/gamemastery_guide/seafarers.json
+++ b/monster_families/gamemastery_guide/seafarers.json
@@ -31,6 +31,13 @@
         "changes": [
           {
             "change_category": "abilities",
+            "effects": [
+              {
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Shipboard Spells')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
             "links": [
               {
                 "alt": "captain",
@@ -45,210 +52,76 @@
                 "game-obj": "NPCs",
                 "name": "bosun",
                 "type": "link"
-              }
-            ],
-            "spells": [
+              },
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "spell attack (+10 bosun)",
-                  "(2nd, 1st for bosun)"
-                ],
-                "saving_throw": {
-                  "dc": 24,
-                  "modifiers": [
-                    {
-                      "name": "DC 18 bosun",
-                      "subtype": "modifier",
-                      "type": "stat_block_section"
-                    }
-                  ],
-                  "subtype": "save_dc",
-                  "text": "DC 24 (DC 18 bosun)",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 16,
-                "spell_list": [
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "summon elemental",
-                            "aonid": 320,
-                            "game-obj": "Spells",
-                            "name": "summon elemental",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "summon elemental",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water breathing",
-                            "aonid": 370,
-                            "game-obj": "Spells",
-                            "name": "water breathing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water breathing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water walk",
-                            "aonid": 371,
-                            "game-obj": "Spells",
-                            "name": "water walk",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water walk",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "feather fall",
-                            "aonid": 111,
-                            "game-obj": "Spells",
-                            "name": "feather fall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "feather fall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count_text": "\u00d72",
-                        "links": [
-                          {
-                            "alt": "gust of wind",
-                            "aonid": 143,
-                            "game-obj": "Spells",
-                            "name": "gust of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gust of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 2,
-                    "level_text": "(2nd, 1st for bosun)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 97,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 142,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know direction",
-                            "aonid": 169,
-                            "game-obj": "Spells",
-                            "name": "know direction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know direction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 171,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tanglefoot",
-                            "aonid": 330,
-                            "game-obj": "Spells",
-                            "name": "tanglefoot",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tanglefoot",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "alt": "summon elemental",
+                "aonid": 320,
+                "game-obj": "Spells",
+                "name": "summon elemental",
+                "type": "link"
+              },
+              {
+                "alt": "water breathing",
+                "aonid": 370,
+                "game-obj": "Spells",
+                "name": "water breathing",
+                "type": "link"
+              },
+              {
+                "alt": "water walk",
+                "aonid": 371,
+                "game-obj": "Spells",
+                "name": "water walk",
+                "type": "link"
+              },
+              {
+                "alt": "feather fall",
+                "aonid": 111,
+                "game-obj": "Spells",
+                "name": "feather fall",
+                "type": "link"
+              },
+              {
+                "alt": "gust of wind",
+                "aonid": 143,
+                "game-obj": "Spells",
+                "name": "gust of wind",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 97,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 142,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "know direction",
+                "aonid": 169,
+                "game-obj": "Spells",
+                "name": "know direction",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 171,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "tanglefoot",
+                "aonid": 330,
+                "game-obj": "Spells",
+                "name": "tanglefoot",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -258,7 +131,6 @@
         ],
         "name": "Shipboard Spells",
         "subtype": "monster_family",
-        "text": "The captain can gain all these spells in place of Dual Disarm. The bosun can exchange Pike and Strike to gain the cantrips and 1st-level spells.",
         "type": "stat_block_section"
       }
     ],
@@ -284,6 +156,315 @@
         }
       ],
       "text": "* Never use phrases like \u201cgood luck,\u201d \u201cdrowned,\u201d or \u201cgoodbye.\u201d\n* No whistling onboard.\n* Never kill certain creatures, such as albatrosses or dolphins.\n* Never change the name of a vessel without protective rites.\n* Never set sail on certain days of the week.\n* Tengus absorb bad luck into themselves to create good luck.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "captain",
+          "aonid": 954,
+          "game-obj": "NPCs",
+          "name": "captain",
+          "type": "link"
+        },
+        {
+          "alt": "bosun",
+          "aonid": 953,
+          "game-obj": "NPCs",
+          "name": "bosun",
+          "type": "link"
+        },
+        {
+          "alt": "summon elemental",
+          "aonid": 320,
+          "game-obj": "Spells",
+          "name": "summon elemental",
+          "type": "link"
+        },
+        {
+          "alt": "water breathing",
+          "aonid": 370,
+          "game-obj": "Spells",
+          "name": "water breathing",
+          "type": "link"
+        },
+        {
+          "alt": "water walk",
+          "aonid": 371,
+          "game-obj": "Spells",
+          "name": "water walk",
+          "type": "link"
+        },
+        {
+          "alt": "feather fall",
+          "aonid": 111,
+          "game-obj": "Spells",
+          "name": "feather fall",
+          "type": "link"
+        },
+        {
+          "alt": "gust of wind",
+          "aonid": 143,
+          "game-obj": "Spells",
+          "name": "gust of wind",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 97,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 142,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "know direction",
+          "aonid": 169,
+          "game-obj": "Spells",
+          "name": "know direction",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 171,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "tanglefoot",
+          "aonid": 330,
+          "game-obj": "Spells",
+          "name": "tanglefoot",
+          "type": "link"
+        }
+      ],
+      "name": "Shipboard Spells",
+      "sources": [
+        {
+          "link": {
+            "alt": "Gamemastery Guide pg. 242",
+            "aonid": 22,
+            "game-obj": "Sources",
+            "name": "Gamemastery Guide pg. 242",
+            "type": "link"
+          },
+          "name": "Gamemastery Guide",
+          "page": 242,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "spell attack (+10 bosun)",
+            "(2nd, 1st for bosun)"
+          ],
+          "saving_throw": {
+            "dc": 24,
+            "modifiers": [
+              {
+                "name": "DC 18 bosun",
+                "subtype": "modifier",
+                "type": "stat_block_section"
+              }
+            ],
+            "subtype": "save_dc",
+            "text": "DC 24 (DC 18 bosun)",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 16,
+          "spell_list": [
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "summon elemental",
+                      "aonid": 320,
+                      "game-obj": "Spells",
+                      "name": "summon elemental",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "summon elemental",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water breathing",
+                      "aonid": 370,
+                      "game-obj": "Spells",
+                      "name": "water breathing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water breathing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water walk",
+                      "aonid": 371,
+                      "game-obj": "Spells",
+                      "name": "water walk",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water walk",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "feather fall",
+                      "aonid": 111,
+                      "game-obj": "Spells",
+                      "name": "feather fall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "feather fall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count_text": "\u00d72",
+                  "links": [
+                    {
+                      "alt": "gust of wind",
+                      "aonid": 143,
+                      "game-obj": "Spells",
+                      "name": "gust of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gust of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 2,
+              "level_text": "(2nd, 1st for bosun)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 97,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 142,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know direction",
+                      "aonid": 169,
+                      "game-obj": "Spells",
+                      "name": "know direction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know direction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 171,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tanglefoot",
+                      "aonid": 330,
+                      "game-obj": "Spells",
+                      "name": "tanglefoot",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tanglefoot",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "The captain can gain all these spells in place of Dual Disarm. The bosun can exchange Pike and Strike to gain the cantrips and 1st-level spells. **Primal Prepared Spells** DC 24 (DC 18 bosun), attack +16 (+10 bosun); **2nd** *summon elemental*, *water breathing*, *water walk*; **1st** *feather fall*, *gust of wind* (\u00d72); **Cantrips** (2nd, 1st for bosun) *electric arc*, *guidance*, *know direction*, *light*, *tanglefoot*",
       "type": "section"
     }
   ],

--- a/monster_families/gatewalkers_hardcover/blackfrost_dead.json
+++ b/monster_families/gatewalkers_hardcover/blackfrost_dead.json
@@ -68,270 +68,133 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 5,
-                    "subtype": "area",
-                    "text": "5-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concealed",
-                    "aonid": 62,
-                    "game-obj": "Conditions",
-                    "name": "concealed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blackfrost Breath",
-                "subtype": "ability",
-                "text": "The blackfrost dead gasps sharply, then exhales a mist of dark-blue blackfrost particles in a 5-foot emanation. All creatures within the mist become concealed, and all creatures outside the mist become concealed to creatures within it. The mist persists for 1 minute. A creature that ends its turn in the mist is exposed to blackfrost. The blackfrost dead can\u2019t use Blackfrost Breath again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "climb Speed",
-                    "aonid": 2349,
-                    "game-obj": "Rules",
-                    "name": "climb Speed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ignores difficult terrain and greater difficult terrain",
-                    "aonid": 2367,
-                    "game-obj": "Rules",
-                    "name": "ignores difficult terrain and greater difficult terrain",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ice",
-                    "aonid": 2774,
-                    "game-obj": "Rules",
-                    "name": "ice",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "snow",
-                    "aonid": 2775,
-                    "game-obj": "Rules",
-                    "name": "snow",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ice Climb",
-                "subtype": "ability",
-                "text": "The blackfrost dead can climb on ice as though it had the listed climb Speed. It ignores difficult terrain and greater difficult terrain from ice and snow and doesn\u2019t risk falling when crossing ice.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "mental",
-                    "formula": "1d4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mindburning Gaze",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The blackfrost dead fixes its terrifying gaze on a creature within 60 feet. The creature takes 1d4 mental damage per level of the blackfrost dead (minimum 2d4), with a basic Will save. On a critical failure, the creature is frightened 1.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 10,
-                    "subtype": "area",
-                    "text": "10-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "cold",
-                    "formula": "1d8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "bleed",
-                    "formula": "1d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent bleed damage",
-                    "aonid": 86,
-                    "game-obj": "Conditions",
-                    "name": "persistent bleed damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Shattering Death",
-                "subtype": "ability",
-                "text": "When the blackfrost dead is destroyed, its body shatters like brittle ice, filling the air around it with a cloud of frigid, razor\u2011sharp ice shards. Creatures in a 10-foot emanation take 1d8 cold damage per level of the blackfrost dead (minimum 3d8), with a basic Reflex save. Creatures that critically fail this save also take 1d6 persistent bleed damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "cold",
-                      "aonid": 555,
-                      "game-obj": "Traits",
-                      "name": "cold",
-                      "type": "link"
-                    },
-                    "name": "cold",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Blackfrost Dead Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "concealed",
+                "aonid": 62,
+                "game-obj": "Conditions",
+                "name": "concealed",
+                "type": "link"
+              },
+              {
+                "alt": "climb Speed",
+                "aonid": 2349,
+                "game-obj": "Rules",
+                "name": "climb Speed",
+                "type": "link"
+              },
+              {
+                "alt": "ignores difficult terrain and greater difficult terrain",
+                "aonid": 2367,
+                "game-obj": "Rules",
+                "name": "ignores difficult terrain and greater difficult terrain",
+                "type": "link"
+              },
+              {
+                "alt": "ice",
+                "aonid": 2774,
+                "game-obj": "Rules",
+                "name": "ice",
+                "type": "link"
+              },
+              {
+                "alt": "snow",
+                "aonid": 2775,
+                "game-obj": "Rules",
+                "name": "snow",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "frightened",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 555,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "persistent bleed damage",
+                "aonid": 86,
+                "game-obj": "Conditions",
+                "name": "persistent bleed damage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -341,7 +204,6 @@
         ],
         "name": "Blackfrost Dead Abilities",
         "subtype": "monster_family",
-        "text": "You can modify an existing undead creature to become blackfrost dead using the following abilities. All blackfrost dead bear the curse of blackfrost and have some way to inflict it, usually using one of their existing Strikes. Most blackfrost dead have one other ability from this list as well. As blackfrost dead stem from blackfrost itself, all blackfrost dead have the rare trait.",
         "type": "stat_block_section"
       }
     ],
@@ -349,6 +211,478 @@
   },
   "name": "Blackfrost Dead",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 5,
+              "subtype": "area",
+              "text": "5-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "frequency": "1d4 rounds",
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "concealed",
+              "aonid": 62,
+              "game-obj": "Conditions",
+              "name": "concealed",
+              "type": "link"
+            }
+          ],
+          "name": "Blackfrost Breath",
+          "subtype": "ability",
+          "text": "The blackfrost dead gasps sharply, then exhales a mist of dark-blue blackfrost particles in a 5-foot emanation. All creatures within the mist become concealed, and all creatures outside the mist become concealed to creatures within it. The mist persists for 1 minute. A creature that ends its turn in the mist is exposed to blackfrost. The blackfrost dead can\u2019t use Blackfrost Breath again for 1d4 rounds.",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "climb Speed",
+              "aonid": 2349,
+              "game-obj": "Rules",
+              "name": "climb Speed",
+              "type": "link"
+            },
+            {
+              "alt": "ignores difficult terrain and greater difficult terrain",
+              "aonid": 2367,
+              "game-obj": "Rules",
+              "name": "ignores difficult terrain and greater difficult terrain",
+              "type": "link"
+            },
+            {
+              "alt": "ice",
+              "aonid": 2774,
+              "game-obj": "Rules",
+              "name": "ice",
+              "type": "link"
+            },
+            {
+              "alt": "snow",
+              "aonid": 2775,
+              "game-obj": "Rules",
+              "name": "snow",
+              "type": "link"
+            }
+          ],
+          "name": "Ice Climb",
+          "subtype": "ability",
+          "text": "The blackfrost dead can climb on ice as though it had the listed climb Speed. It ignores difficult terrain and greater difficult terrain from ice and snow and doesn\u2019t risk falling when crossing ice.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "mental",
+              "formula": "1d4",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "frightened",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened",
+              "type": "link"
+            }
+          ],
+          "name": "Mindburning Gaze",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "within 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The blackfrost dead fixes its terrifying gaze on a creature within 60 feet. The creature takes 1d4 mental damage per level of the blackfrost dead (minimum 2d4), with a basic Will save. On a critical failure, the creature is frightened 1.",
+          "traits": [
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 10,
+              "subtype": "area",
+              "text": "10-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "cold",
+              "formula": "1d8",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            },
+            {
+              "damage_type": "bleed",
+              "formula": "1d6",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "persistent bleed damage",
+              "aonid": 86,
+              "game-obj": "Conditions",
+              "name": "persistent bleed damage",
+              "type": "link"
+            }
+          ],
+          "name": "Shattering Death",
+          "subtype": "ability",
+          "text": "When the blackfrost dead is destroyed, its body shatters like brittle ice, filling the air around it with a cloud of frigid, razor\u2011sharp ice shards. Creatures in a 10-foot emanation take 1d8 cold damage per level of the blackfrost dead (minimum 3d8), with a basic Reflex save. Creatures that critically fail this save also take 1d6 persistent bleed damage.",
+          "traits": [
+            {
+              "link": {
+                "alt": "cold",
+                "aonid": 555,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              "name": "cold",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "concealed",
+          "aonid": 62,
+          "game-obj": "Conditions",
+          "name": "concealed",
+          "type": "link"
+        },
+        {
+          "alt": "climb Speed",
+          "aonid": 2349,
+          "game-obj": "Rules",
+          "name": "climb Speed",
+          "type": "link"
+        },
+        {
+          "alt": "ignores difficult terrain and greater difficult terrain",
+          "aonid": 2367,
+          "game-obj": "Rules",
+          "name": "ignores difficult terrain and greater difficult terrain",
+          "type": "link"
+        },
+        {
+          "alt": "ice",
+          "aonid": 2774,
+          "game-obj": "Rules",
+          "name": "ice",
+          "type": "link"
+        },
+        {
+          "alt": "snow",
+          "aonid": 2775,
+          "game-obj": "Rules",
+          "name": "snow",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 2297,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "frightened",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened",
+          "type": "link"
+        },
+        {
+          "alt": "cold",
+          "aonid": 555,
+          "game-obj": "Traits",
+          "name": "cold",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 2297,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "persistent bleed damage",
+          "aonid": 86,
+          "game-obj": "Conditions",
+          "name": "persistent bleed damage",
+          "type": "link"
+        }
+      ],
+      "name": "Blackfrost Dead Abilities",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "zombie",
+              "aonid": 487,
+              "game-obj": "MonsterFamilies",
+              "name": "zombie",
+              "type": "link"
+            },
+            {
+              "alt": "mummy",
+              "aonid": 445,
+              "game-obj": "MonsterFamilies",
+              "name": "mummy",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 555,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            }
+          ],
+          "name": "Creating Blackfrost Dead",
+          "sources": [
+            {
+              "link": {
+                "alt": "Gatewalkers (Hardcover) pg. 248",
+                "aonid": 290,
+                "game-obj": "Sources",
+                "name": "Gatewalkers (Hardcover) pg. 248",
+                "type": "link"
+              },
+              "name": "Gatewalkers (Hardcover)",
+              "page": 248,
+              "type": "source"
+            }
+          ],
+          "text": "The simplest way to create a blackfrost dead is to use an existing undead, such as a zombie or a mummy, as your base creature. Replace the creature\u2019s abilities with abilities from the list on this page. All blackfrost dead gain the cold trait and have at least one way to inflict blackfrost, often using one of their Strikes.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "blackfrost",
+              "aonid": 51,
+              "game-obj": "Curses",
+              "name": "blackfrost",
+              "type": "link"
+            }
+          ],
+          "name": "Curse of the Crown",
+          "sources": [
+            {
+              "link": {
+                "alt": "Gatewalkers (Hardcover) pg. 248",
+                "aonid": 290,
+                "game-obj": "Sources",
+                "name": "Gatewalkers (Hardcover) pg. 248",
+                "type": "link"
+              },
+              "name": "Gatewalkers (Hardcover)",
+              "page": 248,
+              "type": "source"
+            }
+          ],
+          "text": "Blackfrost dead are found only around the Nameless Spires, under which a massive alien being named Osoyo remains imprisoned. Only recently has this ancient being stirred from its slumber, causing blackfrost to foam out of fissures in the ice and afflict unfortunate explorers. The spread of the blackfrost curse has been mercifully slow thus far, but with each creature afflicted, Osoyo\u2019s reach expands ever outward.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Gatewalkers (Hardcover) pg. 248",
+            "aonid": 290,
+            "game-obj": "Sources",
+            "name": "Gatewalkers (Hardcover) pg. 248",
+            "type": "link"
+          },
+          "name": "Gatewalkers (Hardcover)",
+          "page": 248,
+          "type": "source"
+        }
+      ],
+      "text": "You can modify an existing undead creature to become blackfrost dead using the following abilities. All blackfrost dead bear the curse of blackfrost and have some way to inflict it, usually using one of their existing Strikes. Most blackfrost dead have one other ability from this list as well. As blackfrost dead stem from blackfrost itself, all blackfrost dead have the rare trait.  \n  \n**Blackfrost Breath** [##] (occult) The blackfrost dead gasps sharply, then exhales a mist of dark-blue blackfrost particles in a 5-foot emanation. All creatures within the mist become concealed, and all creatures outside the mist become concealed to creatures within it. The mist persists for 1 minute. A creature that ends its turn in the mist is exposed to blackfrost. The blackfrost dead can\u2019t use Blackfrost Breath again for 1d4 rounds.  \n  \n**Ice Climb** The blackfrost dead can climb on ice as though it had the listed climb Speed. It ignores difficult terrain and greater difficult terrain from ice and snow and doesn\u2019t risk falling when crossing ice.  \n  \n**Mindburning Gaze** [##] (emotion, fear, occult, visual) The blackfrost dead fixes its terrifying gaze on a creature within 60 feet. The creature takes 1d4 mental damage per level of the blackfrost dead (minimum 2d4), with a basic Will save. On a critical failure, the creature is frightened 1.  \n  \n**Shattering Death** (cold) When the blackfrost dead is destroyed, its body shatters like brittle ice, filling the air around it with a cloud of frigid, razor\u2011sharp ice shards. Creatures in a 10-foot emanation take 1d8 cold damage per level of the blackfrost dead (minimum 3d8), with a basic Reflex save. Creatures that critically fail this save also take 1d6 persistent bleed damage.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/howl_of_the_wild/chimera.json
+++ b/monster_families/howl_of_the_wild/chimera.json
@@ -53,109 +53,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "acid",
-                    "formula": "2d10+9",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "range increment 30 feet",
-                    "aonid": 248,
-                    "game-obj": "Traits",
-                    "name": "range increment 30 feet",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ranged",
-                "subtype": "ability",
-                "text": "acid spit +20 (range increment 30 feet),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "acid",
-                    "formula": "9d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Spray Acid",
-                "saving_throw": [
-                  {
-                    "basic": true,
-                    "dc": 26,
-                    "save_type": "Ref",
-                    "subtype": "save_dc",
-                    "text": "DC 26 basic Reflex save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The chimera spews acid in a 30-foot cone, dealing 9d6 acid damage to all creatures in the area (DC 26 basic Reflex save). The chimera can't use Spray Acid again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "acid",
-                      "aonid": 524,
-                      "game-obj": "Traits",
-                      "name": "acid",
-                      "type": "link"
-                    },
-                    "name": "acid",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Chimera Heads')].sections[?(@.name=='Ankhrav Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "range increment 30 feet",
+                "aonid": 248,
+                "game-obj": "Traits",
+                "name": "range increment 30 feet",
+                "type": "link"
+              },
+              {
+                "alt": "acid",
+                "aonid": 524,
+                "game-obj": "Traits",
+                "name": "acid",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -170,102 +96,28 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d6+9",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "fatal d10",
-                    "aonid": 597,
-                    "game-obj": "Traits",
-                    "name": "fatal d10",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "hippogriff beak +22 (fatal d10),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Rend",
-                  "aonid": 73,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Rend",
-                  "type": "link"
-                },
-                "name": "Rend",
-                "subtype": "ability",
-                "text": "hippogriff beak",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 73,
-                  "edition": "remastered",
-                  "effect": "The monster automatically deals that Strike's damage again to the enemy.",
-                  "game-id": "d5b010b5b150634db59b75339222f87b",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Rend",
-                  "requirement": "The monster hit the same enemy with two consecutive Strikes of the listed type in the same round",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A Rend entry lists a Strike the monster has;",
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Chimera Heads')].sections[?(@.name=='Hippogriff Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fatal d10",
+                "aonid": 597,
+                "game-obj": "Traits",
+                "name": "fatal d10",
+                "type": "link"
+              },
+              {
+                "alt": "Rend",
+                "aonid": 73,
+                "game-obj": "MonsterAbilities",
+                "name": "Rend",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -280,49 +132,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "poison",
-                    "formula": "3d8+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "effect": "chimeric rot",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ranged",
-                "subtype": "ability",
-                "text": "virulent spit +18 (poison),",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Chimera Heads')].sections[?(@.name=='Rotting Animal Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -337,145 +175,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d8+7",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "effect": "Grab",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 526,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 684,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grab",
-                    "aonid": 45,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "snake fangs +20 (agile, reach 10 feet),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Constrict",
-                  "aonid": 57,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Constrict",
-                  "type": "link"
-                },
-                "name": "Constrict",
-                "saving_throw": [
-                  {
-                    "dc": 24,
-                    "subtype": "save_dc",
-                    "text": "DC 24",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "2d8 bludgeoning, DC 24",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 57,
-                  "edition": "remastered",
-                  "game-id": "a97c86171b6efc6d76d64b73d480ca20",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "grabbed",
-                      "aonid": 77,
-                      "game-obj": "Conditions",
-                      "name": "grabbed",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "restrained",
-                      "aonid": 90,
-                      "game-obj": "Conditions",
-                      "name": "restrained",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "basic",
-                      "aonid": 329,
-                      "game-obj": "Rules",
-                      "name": "basic",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Constrict",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster deals the listed amount of damage to any number of creatures grabbed or restrained by it. Each of those creatures can attempt a basic Fortitude save with the listed DC.",
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Chimera Heads')].sections[?(@.name=='Snake Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "agile",
+                "aonid": 526,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 684,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 45,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "Constrict",
+                "aonid": 57,
+                "game-obj": "MonsterAbilities",
+                "name": "Constrict",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -490,52 +225,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d10+9",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "snapping jaws +20,",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "hold its breath",
-                    "aonid": 2436,
-                    "game-obj": "Rules",
-                    "name": "hold its breath",
-                    "type": "link"
-                  }
-                ],
-                "name": "Deep Breath",
-                "subtype": "ability",
-                "text": "The chimera can hold its breath for 1 hour.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Chimera Heads')].sections[?(@.name=='Snapping Turtle Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "hold its breath",
+                "aonid": 2436,
+                "game-obj": "Rules",
+                "name": "hold its breath",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -550,73 +254,28 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d8+9",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "effect": "Knockdown",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "Knockdown",
-                    "aonid": 46,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Knockdown",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "wolf jaws +20,",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "prone",
-                    "aonid": 88,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  }
-                ],
-                "name": "Leader of the Pack",
-                "subtype": "ability",
-                "text": "The chimera's wolf jaws attacks deal 1d6 extra damage to prone creatures.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Chimera Heads')].sections[?(@.name=='Wolf Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Knockdown",
+                "aonid": 46,
+                "game-obj": "MonsterAbilities",
+                "name": "Knockdown",
+                "type": "link"
+              },
+              {
+                "alt": "prone",
+                "aonid": 88,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -631,107 +290,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "4d6+8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "energy",
-                    "formula": "4d6",
-                    "notes": "see Draconic Bite",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "dragon jaws +27,",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "formula": "4d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Draconic Bite",
-                "subtype": "ability",
-                "text": "A greater chimera's dragon head deals and extra 4d6 damage of a type matching the damage dealt by its Dragon Breath.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "formula": "12d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dragon Breath",
-                "saving_throw": [
-                  {
-                    "basic": true,
-                    "dc": 33,
-                    "save_type": "Ref",
-                    "subtype": "save_dc",
-                    "text": "DC 33 basic Reflex",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The greater chimera deals 12d6 damage to all creatures in a 30-foot cone (DC 33 basic Reflex). This breath deals either acid, cold, electricity, fire, force, mental, sonic, or spirit, depending on the kind of dragon head the greater chimera possesses. The greater chimera can't use Dragon Breath again for 1d4 rounds.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Greater Chimera Heads')].sections[?(@.name=='Adult Dragon Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -746,223 +319,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "3d10+8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "effect": "Grab",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 684,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grab",
-                    "aonid": 45,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "worm jaws +27 (reach 10 feet),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Swallow Whole",
-                  "aonid": 77,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Swallow Whole",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 77,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Swallow Whole",
-                "subtype": "ability",
-                "text": "(attack) Large, 3d10+8 bludgeoning, Rupture 24; the target must be grabbed by the greater chimera's worm jaws",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 77,
-                  "edition": "remastered",
-                  "game-id": "4b6e038f83c4c35d932969c1fbdf7e15",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "grabbed",
-                      "aonid": 77,
-                      "game-obj": "Conditions",
-                      "name": "grabbed",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "restrained",
-                      "aonid": 90,
-                      "game-obj": "Conditions",
-                      "name": "restrained",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Athletics",
-                      "aonid": 36,
-                      "game-obj": "Skills",
-                      "name": "Athletics",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Grab",
-                      "aonid": 45,
-                      "game-obj": "MonsterAbilities",
-                      "name": "Grab",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "slowed 1",
-                      "aonid": 92,
-                      "game-obj": "Conditions",
-                      "name": "slowed 1",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "suffocating",
-                      "aonid": 468,
-                      "game-obj": "Rules",
-                      "name": "suffocating",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Escapes",
-                      "aonid": 2296,
-                      "game-obj": "Actions",
-                      "name": "Escapes",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "unarmed",
-                      "aonid": 719,
-                      "game-obj": "Traits",
-                      "name": "unarmed",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "off-guard",
-                      "aonid": 58,
-                      "game-obj": "Conditions",
-                      "name": "off-guard",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Swallow Whole",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster attempts to swallow a creature of the listed size or smaller that it has grabbed or restrained in its jaws or mouth. If a swallowed creature is of the maximum size listed, the monster can't use Swallow Whole again. If the creature is smaller than the maximum, the monster can usually swallow more creatures; the GM determines the maximum. The monster attempts an Athletics check opposed by the target's Reflex DC. If it succeeds, it swallows the creature. The monster's mouth or jaws no longer clutch a creature it has swallowed, so the monster is free to use them to Strike or Grab once again. The monster can't attack creatures it has swallowed.  \n  \n A swallowed creature is grabbed, is slowed 1, and has to hold its breath or start suffocating. The swallowed creature takes the listed amount of damage when first swallowed and at the end of each of its turns while it's swallowed. If the victim Escapes this ability's grabbed condition, it exits through the monster's mouth. This frees any other creature captured in the monster's mouth or jaws. A swallowed creature can attack the monster that has swallowed it, but only with unarmed attacks or with weapons of light Bulk or less. The swallowing creature is off-guard against the attack. If the monster takes piercing or slashing damage equaling or exceeding the listed Rupture value from a single attack or spell, the swallowed creature cuts itself free. A creature that gets free by either Escaping or cutting itself free can immediately breathe and exits the swallowing monster's space.  \n  \n If the monster dies, a swallowed creature can be freed by creatures adjacent to the corpse if they spend a combined total of 3 actions cutting the monster open with a weapon or unarmed attack that deals piercing or slashing damage.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 15,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "23c17a4eee189983083f41b20ff9ff92",
-                      "game-obj": "Traits",
-                      "name": "Attack",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 452",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 452",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 452,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An ability with this trait involves an attack. For each attack you make beyond the first on your turn, you take a multiple attack penalty.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Greater Chimera Heads')].sections[?(@.name=='Cave Worm Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "reach 10 feet",
+                "aonid": 684,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 45,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "Swallow Whole",
+                "aonid": 77,
+                "game-obj": "MonsterAbilities",
+                "name": "Swallow Whole",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 77,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -977,80 +369,28 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "3d8+12",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "effect": "chimeric venom",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "emperor cobra fangs +27,",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "poison",
-                    "formula": "6d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "persistent poison damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent poison damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Chimeric Venom",
-                "subtype": "ability",
-                "text": "When the greater chimera critically hits a creature with emperor cobra fangs, it deals an additional 6d6 persistent poison damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "poison",
-                      "aonid": 669,
-                      "game-obj": "Traits",
-                      "name": "poison",
-                      "type": "link"
-                    },
-                    "name": "poison",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Greater Chimera Heads')].sections[?(@.name=='Emperor Cobra Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "persistent poison damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent poison damage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1065,89 +405,56 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "void",
-                    "formula": "3d8+8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 526,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "finesse",
-                    "aonid": 602,
-                    "game-obj": "Traits",
-                    "name": "finesse",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magical",
-                    "aonid": 644,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "phantom slam +27 (agile, finesse, magical),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "force",
-                    "aonid": 610,
-                    "game-obj": "Traits",
-                    "name": "force",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "spirit",
-                    "aonid": 737,
-                    "game-obj": "Traits",
-                    "name": "spirit",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ghost touch",
-                    "aonid": 2840,
-                    "game-obj": "Equipment",
-                    "name": "ghost touch",
-                    "type": "link"
-                  }
-                ],
-                "name": "Incorporeal Features",
-                "subtype": "ability",
-                "text": "The greater chimera gains resistance 5 to all damage (except force, spirit, and damage from Strikes with the *ghost touch* property rune).",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Greater Chimera Heads')].sections[?(@.name=='Phantasmal Beast Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "agile",
+                "aonid": 526,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "finesse",
+                "aonid": 602,
+                "game-obj": "Traits",
+                "name": "finesse",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 644,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "force",
+                "aonid": 610,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              {
+                "alt": "ghost touch",
+                "aonid": 2840,
+                "game-obj": "Equipment",
+                "name": "ghost touch",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1162,129 +469,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "3d10+8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "deadly d10",
-                    "aonid": 570,
-                    "game-obj": "Traits",
-                    "name": "deadly d10",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "beak +26 (deadly d10),",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "sonic",
-                    "formula": "9d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ear-splitting Screech",
-                "saving_throw": [
-                  {
-                    "basic": true,
-                    "dc": 26,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 26 basic Fortitude save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The screeching roc head emits a harsh cry that deals 9d6 sonic damage (DC 26 basic Fortitude save) in a 30-foot emanation. It can't use Ear-splitting Screech again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 541,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "sonic",
-                      "aonid": 697,
-                      "game-obj": "Traits",
-                      "name": "sonic",
-                      "type": "link"
-                    },
-                    "name": "sonic",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Powerful Wings",
-                "subtype": "ability",
-                "text": "The greater chimera's fly Speed increases by 10 feet.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Greater Chimera Heads')].sections[?(@.name=='Screeching Roc Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "deadly d10",
+                "aonid": 570,
+                "game-obj": "Traits",
+                "name": "deadly d10",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "sonic",
+                "aonid": 697,
+                "game-obj": "Traits",
+                "name": "sonic",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1299,132 +519,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d12+8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "cold",
-                    "formula": "1d12",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "effect": "Knockdown",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "Knockdown",
-                    "aonid": 46,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Knockdown",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "witchwarg jaws +25,",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 15,
-                    "subtype": "area",
-                    "text": "15-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "cold",
-                    "formula": "9d10",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Freezing Breath",
-                "saving_throw": [
-                  {
-                    "basic": true,
-                    "dc": 33,
-                    "save_type": "Ref",
-                    "subtype": "save_dc",
-                    "text": "DC 33 basic Reflex save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The greater chimera breathes a cloud of frost in a 15-foot cone that deals 9d10 cold damage (DC 33 basic Reflex save). The greater chimera can't use Freezing Breath again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "cold",
-                      "aonid": 555,
-                      "game-obj": "Traits",
-                      "name": "cold",
-                      "type": "link"
-                    },
-                    "name": "cold",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Greater Chimera Heads')].sections[?(@.name=='Witchwarg Head')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Knockdown",
+                "aonid": 46,
+                "game-obj": "MonsterAbilities",
+                "name": "Knockdown",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 555,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1444,6 +574,739 @@
   "sections": [
     {
       "name": "Chimera Heads",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "acid",
+                  "formula": "2d10+9",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "range increment 30 feet",
+                  "aonid": 248,
+                  "game-obj": "Traits",
+                  "name": "range increment 30 feet",
+                  "type": "link"
+                }
+              ],
+              "name": "Ranged",
+              "subtype": "ability",
+              "text": "acid spit +20 (range increment 30 feet),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "cone",
+                  "size": 30,
+                  "subtype": "area",
+                  "text": "30-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "damage_type": "acid",
+                  "formula": "9d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Spray Acid",
+              "saving_throw": [
+                {
+                  "basic": true,
+                  "dc": 26,
+                  "save_type": "Ref",
+                  "subtype": "save_dc",
+                  "text": "DC 26 basic Reflex save",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "The chimera spews acid in a 30-foot cone, dealing 9d6 acid damage to all creatures in the area (DC 26 basic Reflex save). The chimera can't use Spray Acid again for 1d4 rounds.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "acid",
+                    "aonid": 524,
+                    "game-obj": "Traits",
+                    "name": "acid",
+                    "type": "link"
+                  },
+                  "name": "acid",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "range increment 30 feet",
+              "aonid": 248,
+              "game-obj": "Traits",
+              "name": "range increment 30 feet",
+              "type": "link"
+            },
+            {
+              "alt": "acid",
+              "aonid": 524,
+              "game-obj": "Traits",
+              "name": "acid",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Ankhrav Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Ranged** [#] acid spit +20 (range increment 30 feet), **Damage** 2d10+9 acid  \n  \n**Spray Acid** [##] (acid) The chimera spews acid in a 30-foot cone, dealing 9d6 acid damage to all creatures in the area (DC 26 basic Reflex save). The chimera can't use Spray Acid again for 1d4 rounds.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "2d6+9",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "fatal d10",
+                  "aonid": 597,
+                  "game-obj": "Traits",
+                  "name": "fatal d10",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "hippogriff beak +22 (fatal d10),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Rend",
+                "aonid": 73,
+                "game-obj": "MonsterAbilities",
+                "name": "Rend",
+                "type": "link"
+              },
+              "name": "Rend",
+              "subtype": "ability",
+              "text": "hippogriff beak",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 73,
+                "edition": "remastered",
+                "effect": "The monster automatically deals that Strike's damage again to the enemy.",
+                "game-id": "d5b010b5b150634db59b75339222f87b",
+                "game-obj": "MonsterAbilities",
+                "name": "Rend",
+                "requirement": "The monster hit the same enemy with two consecutive Strikes of the listed type in the same round",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 360",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 360",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 360,
+                    "type": "source"
+                  }
+                ],
+                "text": "A Rend entry lists a Strike the monster has;",
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "fatal d10",
+              "aonid": 597,
+              "game-obj": "Traits",
+              "name": "fatal d10",
+              "type": "link"
+            },
+            {
+              "alt": "Rend",
+              "aonid": 73,
+              "game-obj": "MonsterAbilities",
+              "name": "Rend",
+              "type": "link"
+            }
+          ],
+          "name": "Hippogriff Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] hippogriff beak +22 (fatal d10), **Damage** 2d6+9 piercing  \n  \n**Rend** [#] hippogriff beak",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "poison",
+                  "formula": "3d8+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "effect": "chimeric rot",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "poison",
+                  "aonid": 669,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                }
+              ],
+              "name": "Ranged",
+              "subtype": "ability",
+              "text": "virulent spit +18 (poison),",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 1",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Rotting Animal Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Ranged** [#] virulent spit +18 (poison), **Damage** 3d8+4 poison plus chimeric rot  \n  \n Chimeric Rot (disease) When the chimera hits a creature with virulent spit they must succeed a DC 26 Fortitude saving throw or become sickened 1.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "2d8+7",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "effect": "Grab",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 526,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 684,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "Grab",
+                  "aonid": 45,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Grab",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "snake fangs +20 (agile, reach 10 feet),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Constrict",
+                "aonid": 57,
+                "game-obj": "MonsterAbilities",
+                "name": "Constrict",
+                "type": "link"
+              },
+              "name": "Constrict",
+              "saving_throw": [
+                {
+                  "dc": 24,
+                  "subtype": "save_dc",
+                  "text": "DC 24",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "2d8 bludgeoning, DC 24",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 57,
+                "edition": "remastered",
+                "game-id": "a97c86171b6efc6d76d64b73d480ca20",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "grabbed",
+                    "aonid": 77,
+                    "game-obj": "Conditions",
+                    "name": "grabbed",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "restrained",
+                    "aonid": 90,
+                    "game-obj": "Conditions",
+                    "name": "restrained",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "basic",
+                    "aonid": 329,
+                    "game-obj": "Rules",
+                    "name": "basic",
+                    "type": "link"
+                  }
+                ],
+                "name": "Constrict",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster deals the listed amount of damage to any number of creatures grabbed or restrained by it. Each of those creatures can attempt a basic Fortitude save with the listed DC.",
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 526,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 45,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            },
+            {
+              "alt": "Constrict",
+              "aonid": 57,
+              "game-obj": "MonsterAbilities",
+              "name": "Constrict",
+              "type": "link"
+            }
+          ],
+          "name": "Snake Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] snake fangs +20 (agile, reach 10 feet), **Damage** 2d8+7 piercing plus Grab  \n  \n**Constrict** [#] 2d8 bludgeoning, DC 24",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "2d10+9",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "snapping jaws +20,",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "hold its breath",
+                  "aonid": 2436,
+                  "game-obj": "Rules",
+                  "name": "hold its breath",
+                  "type": "link"
+                }
+              ],
+              "name": "Deep Breath",
+              "subtype": "ability",
+              "text": "The chimera can hold its breath for 1 hour.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "hold its breath",
+              "aonid": 2436,
+              "game-obj": "Rules",
+              "name": "hold its breath",
+              "type": "link"
+            }
+          ],
+          "name": "Snapping Turtle Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] snapping jaws +20, **Damage** 2d10+9 piercing   \n  \n**Deep Breath** The chimera can hold its breath for 1 hour.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "2d8+9",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "effect": "Knockdown",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "Knockdown",
+                  "aonid": 46,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Knockdown",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "wolf jaws +20,",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "prone",
+                  "aonid": 88,
+                  "game-obj": "Conditions",
+                  "name": "prone",
+                  "type": "link"
+                }
+              ],
+              "name": "Leader of the Pack",
+              "subtype": "ability",
+              "text": "The chimera's wolf jaws attacks deal 1d6 extra damage to prone creatures.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Knockdown",
+              "aonid": 46,
+              "game-obj": "MonsterAbilities",
+              "name": "Knockdown",
+              "type": "link"
+            },
+            {
+              "alt": "prone",
+              "aonid": 88,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            }
+          ],
+          "name": "Wolf Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] wolf jaws +20, **Damage** 2d8+9 piercing plus Knockdown  \n  \n**Leader of the Pack** The chimera's wolf jaws attacks deal 1d6 extra damage to prone creatures.",
+          "type": "section"
+        }
+      ],
       "sources": [
         {
           "errata": {
@@ -1469,6 +1332,1011 @@
     },
     {
       "name": "Greater Chimera Heads",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "4d6+8",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "energy",
+                  "formula": "4d6",
+                  "notes": "see Draconic Bite",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "dragon jaws +27,",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "formula": "4d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Draconic Bite",
+              "subtype": "ability",
+              "text": "A greater chimera's dragon head deals and extra 4d6 damage of a type matching the damage dealt by its Dragon Breath.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "cone",
+                  "size": 30,
+                  "subtype": "area",
+                  "text": "30-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "formula": "12d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Dragon Breath",
+              "saving_throw": [
+                {
+                  "basic": true,
+                  "dc": 33,
+                  "save_type": "Ref",
+                  "subtype": "save_dc",
+                  "text": "DC 33 basic Reflex",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "The greater chimera deals 12d6 damage to all creatures in a 30-foot cone (DC 33 basic Reflex). This breath deals either acid, cold, electricity, fire, force, mental, sonic, or spirit, depending on the kind of dragon head the greater chimera possesses. The greater chimera can't use Dragon Breath again for 1d4 rounds.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Adult Dragon Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] dragon jaws +27, **Damage** 4d6+8 piercing plus 4d6 energy damage (see Draconic Bite)  \n  \n**Draconic Bite** A greater chimera's dragon head deals and extra 4d6 damage of a type matching the damage dealt by its Dragon Breath.  \n  \n**Dragon Breath** [##] The greater chimera deals 12d6 damage to all creatures in a 30-foot cone (DC 33 basic Reflex). This breath deals either acid, cold, electricity, fire, force, mental, sonic, or spirit, depending on the kind of dragon head the greater chimera possesses. The greater chimera can't use Dragon Breath again for 1d4 rounds.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "3d10+8",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "effect": "Grab",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 684,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "Grab",
+                  "aonid": 45,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Grab",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "worm jaws +27 (reach 10 feet),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Swallow Whole",
+                "aonid": 77,
+                "game-obj": "MonsterAbilities",
+                "name": "Swallow Whole",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "grabbed",
+                  "aonid": 77,
+                  "game-obj": "Conditions",
+                  "name": "grabbed",
+                  "type": "link"
+                }
+              ],
+              "name": "Swallow Whole",
+              "subtype": "ability",
+              "text": "(attack) Large, 3d10+8 bludgeoning, Rupture 24; the target must be grabbed by the greater chimera's worm jaws",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 77,
+                "edition": "remastered",
+                "game-id": "4b6e038f83c4c35d932969c1fbdf7e15",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "grabbed",
+                    "aonid": 77,
+                    "game-obj": "Conditions",
+                    "name": "grabbed",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "restrained",
+                    "aonid": 90,
+                    "game-obj": "Conditions",
+                    "name": "restrained",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Athletics",
+                    "aonid": 36,
+                    "game-obj": "Skills",
+                    "name": "Athletics",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Grab",
+                    "aonid": 45,
+                    "game-obj": "MonsterAbilities",
+                    "name": "Grab",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "slowed 1",
+                    "aonid": 92,
+                    "game-obj": "Conditions",
+                    "name": "slowed 1",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "suffocating",
+                    "aonid": 468,
+                    "game-obj": "Rules",
+                    "name": "suffocating",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Escapes",
+                    "aonid": 2296,
+                    "game-obj": "Actions",
+                    "name": "Escapes",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "unarmed",
+                    "aonid": 719,
+                    "game-obj": "Traits",
+                    "name": "unarmed",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "off-guard",
+                    "aonid": 58,
+                    "game-obj": "Conditions",
+                    "name": "off-guard",
+                    "type": "link"
+                  }
+                ],
+                "name": "Swallow Whole",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 360",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 360",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 360,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster attempts to swallow a creature of the listed size or smaller that it has grabbed or restrained in its jaws or mouth. If a swallowed creature is of the maximum size listed, the monster can't use Swallow Whole again. If the creature is smaller than the maximum, the monster can usually swallow more creatures; the GM determines the maximum. The monster attempts an Athletics check opposed by the target's Reflex DC. If it succeeds, it swallows the creature. The monster's mouth or jaws no longer clutch a creature it has swallowed, so the monster is free to use them to Strike or Grab once again. The monster can't attack creatures it has swallowed.  \n  \n A swallowed creature is grabbed, is slowed 1, and has to hold its breath or start suffocating. The swallowed creature takes the listed amount of damage when first swallowed and at the end of each of its turns while it's swallowed. If the victim Escapes this ability's grabbed condition, it exits through the monster's mouth. This frees any other creature captured in the monster's mouth or jaws. A swallowed creature can attack the monster that has swallowed it, but only with unarmed attacks or with weapons of light Bulk or less. The swallowing creature is off-guard against the attack. If the monster takes piercing or slashing damage equaling or exceeding the listed Rupture value from a single attack or spell, the swallowed creature cuts itself free. A creature that gets free by either Escaping or cutting itself free can immediately breathe and exits the swallowing monster's space.  \n  \n If the monster dies, a swallowed creature can be freed by creatures adjacent to the corpse if they spend a combined total of 3 actions cutting the monster open with a weapon or unarmed attack that deals piercing or slashing damage.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 15,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "23c17a4eee189983083f41b20ff9ff92",
+                    "game-obj": "Traits",
+                    "name": "Attack",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 452",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 452",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 452,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An ability with this trait involves an attack. For each attack you make beyond the first on your turn, you take a multiple attack penalty.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "reach 10 feet",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 45,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            },
+            {
+              "alt": "Swallow Whole",
+              "aonid": 77,
+              "game-obj": "MonsterAbilities",
+              "name": "Swallow Whole",
+              "type": "link"
+            },
+            {
+              "alt": "grabbed",
+              "aonid": 77,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            }
+          ],
+          "name": "Cave Worm Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] worm jaws +27 (reach 10 feet), **Damage** 3d10+8 piercing plus Grab  \n  \n**Swallow Whole** [#] (attack) Large, 3d10+8 bludgeoning, Rupture 24; the target must be grabbed by the greater chimera's worm jaws",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "3d8+12",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "effect": "chimeric venom",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "emperor cobra fangs +27,",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "poison",
+                  "formula": "6d6",
+                  "persistent": true,
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "persistent poison damage",
+                  "aonid": 29,
+                  "game-obj": "Conditions",
+                  "name": "persistent poison damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Chimeric Venom",
+              "subtype": "ability",
+              "text": "When the greater chimera critically hits a creature with emperor cobra fangs, it deals an additional 6d6 persistent poison damage.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "poison",
+                    "aonid": 669,
+                    "game-obj": "Traits",
+                    "name": "poison",
+                    "type": "link"
+                  },
+                  "name": "poison",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "persistent poison damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent poison damage",
+              "type": "link"
+            }
+          ],
+          "name": "Emperor Cobra Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] emperor cobra fangs +27, **Damage** 3d8+12 piercing plus chimeric venom  \n  \n**Chimeric Venom** (poison) When the greater chimera critically hits a creature with emperor cobra fangs, it deals an additional 6d6 persistent poison damage.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "void",
+                  "formula": "3d8+8",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 526,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                },
+                {
+                  "alt": "finesse",
+                  "aonid": 602,
+                  "game-obj": "Traits",
+                  "name": "finesse",
+                  "type": "link"
+                },
+                {
+                  "alt": "magical",
+                  "aonid": 644,
+                  "game-obj": "Traits",
+                  "name": "magical",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "phantom slam +27 (agile, finesse, magical),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "force",
+                  "aonid": 610,
+                  "game-obj": "Traits",
+                  "name": "force",
+                  "type": "link"
+                },
+                {
+                  "alt": "spirit",
+                  "aonid": 737,
+                  "game-obj": "Traits",
+                  "name": "spirit",
+                  "type": "link"
+                },
+                {
+                  "alt": "ghost touch",
+                  "aonid": 2840,
+                  "game-obj": "Equipment",
+                  "name": "ghost touch",
+                  "type": "link"
+                }
+              ],
+              "name": "Incorporeal Features",
+              "subtype": "ability",
+              "text": "The greater chimera gains resistance 5 to all damage (except force, spirit, and damage from Strikes with the *ghost touch* property rune).",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 526,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "finesse",
+              "aonid": 602,
+              "game-obj": "Traits",
+              "name": "finesse",
+              "type": "link"
+            },
+            {
+              "alt": "magical",
+              "aonid": 644,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            },
+            {
+              "alt": "force",
+              "aonid": 610,
+              "game-obj": "Traits",
+              "name": "force",
+              "type": "link"
+            },
+            {
+              "alt": "spirit",
+              "aonid": 737,
+              "game-obj": "Traits",
+              "name": "spirit",
+              "type": "link"
+            },
+            {
+              "alt": "ghost touch",
+              "aonid": 2840,
+              "game-obj": "Equipment",
+              "name": "ghost touch",
+              "type": "link"
+            }
+          ],
+          "name": "Phantasmal Beast Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] phantom slam +27 (agile, finesse, magical), **Damage** 3d8+8 void  \n  \n**Incorporeal Features** The greater chimera gains resistance 5 to all damage (except force, spirit, and damage from Strikes with the *ghost touch* property rune).",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "3d10+8",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "deadly d10",
+                  "aonid": 570,
+                  "game-obj": "Traits",
+                  "name": "deadly d10",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "beak +26 (deadly d10),",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "emanation",
+                  "size": 30,
+                  "subtype": "area",
+                  "text": "30-foot emanation",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "damage_type": "sonic",
+                  "formula": "9d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Ear-splitting Screech",
+              "saving_throw": [
+                {
+                  "basic": true,
+                  "dc": 26,
+                  "save_type": "Fort",
+                  "subtype": "save_dc",
+                  "text": "DC 26 basic Fortitude save",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "The screeching roc head emits a harsh cry that deals 9d6 sonic damage (DC 26 basic Fortitude save) in a 30-foot emanation. It can't use Ear-splitting Screech again for 1d4 rounds.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "auditory",
+                    "aonid": 541,
+                    "game-obj": "Traits",
+                    "name": "auditory",
+                    "type": "link"
+                  },
+                  "name": "auditory",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "sonic",
+                    "aonid": 697,
+                    "game-obj": "Traits",
+                    "name": "sonic",
+                    "type": "link"
+                  },
+                  "name": "sonic",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Powerful Wings",
+              "subtype": "ability",
+              "text": "The greater chimera's fly Speed increases by 10 feet.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "deadly d10",
+              "aonid": 570,
+              "game-obj": "Traits",
+              "name": "deadly d10",
+              "type": "link"
+            },
+            {
+              "alt": "auditory",
+              "aonid": 541,
+              "game-obj": "Traits",
+              "name": "auditory",
+              "type": "link"
+            },
+            {
+              "alt": "sonic",
+              "aonid": 697,
+              "game-obj": "Traits",
+              "name": "sonic",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Screeching Roc Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] beak +26 (deadly d10), **Damage** 3d10+8 piercing  \n  \n**Ear-splitting Screech** [##] (auditory, sonic) The screeching roc head emits a harsh cry that deals 9d6 sonic damage (DC 26 basic Fortitude save) in a 30-foot emanation. It can't use Ear-splitting Screech again for 1d4 rounds.  \n  \n**Powerful Wings** The greater chimera's fly Speed increases by 10 feet.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "2d12+8",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "cold",
+                  "formula": "1d12",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "effect": "Knockdown",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "Knockdown",
+                  "aonid": 46,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Knockdown",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "witchwarg jaws +25,",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "cone",
+                  "size": 15,
+                  "subtype": "area",
+                  "text": "15-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "damage_type": "cold",
+                  "formula": "9d10",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Freezing Breath",
+              "saving_throw": [
+                {
+                  "basic": true,
+                  "dc": 33,
+                  "save_type": "Ref",
+                  "subtype": "save_dc",
+                  "text": "DC 33 basic Reflex save",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "The greater chimera breathes a cloud of frost in a 15-foot cone that deals 9d10 cold damage (DC 33 basic Reflex save). The greater chimera can't use Freezing Breath again for 1d4 rounds.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "cold",
+                    "aonid": 555,
+                    "game-obj": "Traits",
+                    "name": "cold",
+                    "type": "link"
+                  },
+                  "name": "cold",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 676,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Knockdown",
+              "aonid": 46,
+              "game-obj": "MonsterAbilities",
+              "name": "Knockdown",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 555,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 676,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Witchwarg Head",
+          "sources": [
+            {
+              "errata": {
+                "alt": "2.1",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "2.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Howl of the Wild pg. 132",
+                "aonid": 226,
+                "game-obj": "Sources",
+                "name": "Howl of the Wild pg. 132",
+                "type": "link"
+              },
+              "name": "Howl of the Wild",
+              "page": 132,
+              "type": "source"
+            }
+          ],
+          "text": "**Melee** [#] witchwarg jaws +25, **Damage** 2d12+8 piercing plus 1d12 cold and Knockdown  \n  \n**Freezing Breath** [##] (cold, primal) The greater chimera breathes a cloud of frost in a 15-foot cone that deals 9d10 cold damage (DC 33 basic Reflex save). The greater chimera can't use Freezing Breath again for 1d4 rounds.",
+          "type": "section"
+        }
+      ],
       "sources": [
         {
           "errata": {

--- a/monster_families/howl_of_the_wild/wardens_of_the_wild.json
+++ b/monster_families/howl_of_the_wild/wardens_of_the_wild.json
@@ -46,6 +46,71 @@
     "text": "This product is licensed under the ORC License to be held in the Library of Congress and available online at various locations including paizo.com/orclicense, azoralaw.com/orclicense, and others. All warranties are disclaimed as set forth therein.",
     "type": "section"
   },
+  "links": [
+    {
+      "alt": "animal",
+      "aonid": 531,
+      "game-obj": "Traits",
+      "name": "animal",
+      "type": "link"
+    },
+    {
+      "alt": "beast",
+      "aonid": 547,
+      "game-obj": "Traits",
+      "name": "beast",
+      "type": "link"
+    },
+    {
+      "alt": "plant",
+      "aonid": 668,
+      "game-obj": "Traits",
+      "name": "plant",
+      "type": "link"
+    },
+    {
+      "alt": "animal instinct",
+      "aonid": 1,
+      "game-obj": "Instincts",
+      "name": "animal instinct",
+      "type": "link"
+    },
+    {
+      "alt": "barbarians",
+      "aonid": 2,
+      "game-obj": "Classes",
+      "name": "barbarians",
+      "type": "link"
+    },
+    {
+      "alt": "druids",
+      "aonid": 6,
+      "game-obj": "Classes",
+      "name": "druids",
+      "type": "link"
+    },
+    {
+      "alt": "Wildsong",
+      "aonid": 116,
+      "game-obj": "Languages",
+      "name": "Wildsong",
+      "type": "link"
+    },
+    {
+      "alt": "friendly",
+      "aonid": 75,
+      "game-obj": "Conditions",
+      "name": "friendly",
+      "type": "link"
+    },
+    {
+      "alt": "hostile actions",
+      "aonid": 300,
+      "game-obj": "Rules",
+      "name": "hostile actions",
+      "type": "link"
+    }
+  ],
   "monster_family": {
     "abilities": [
       {
@@ -159,6 +224,6 @@
       "type": "source"
     }
   ],
-  "text": "*Nethys Note: No description was provided for this group of creatures. All Wardens of the Wild share the following two abilities:*",
+  "text": "*Nethys Note: No description was provided for this group of creatures. All Wardens of the Wild share the following two abilities:*  \n  \n**Voice of Nature** Though the Wardens of the Wild do not speak in words, they can communicate complex concepts flawlessly and wordlessly with any animal, beast, plant, or other creature of the natural world through prolonged eye contact. Sapient creatures with strong ties to the natural world, such as animal instinct barbarians or druids who speak the Wildsong, can somewhat understand a Warden of the Wild, though the meaning can be vague.  \n  \n**Warden's Crown** A Warden of the Wild's horned crown commands respect from wild creatures. Wild creatures native to a warden's biome automatically improve their attitude toward it by one step (up to friendly) and typically do not take hostile actions towards each other while in the warden's presence.",
   "type": "monster_family"
 }

--- a/monster_families/impossible_lands/mana_wastes_mutant.json
+++ b/monster_families/impossible_lands/mana_wastes_mutant.json
@@ -24,475 +24,203 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "acid",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Caustic Pustules",
-                "subtype": "ability",
-                "text": "Whenever the mutant takes piercing or slashing damage, creatures adjacent to the mutant take 1d6 acid damage (basic Reflex save). The damage increases to 2d6 if the mutant is at least 8th level and 3d6 if the mutant is at least 15th level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "cover",
-                    "aonid": 459,
-                    "game-obj": "Rules",
-                    "name": "cover",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concealment",
-                    "aonid": 4,
-                    "game-obj": "Conditions",
-                    "name": "concealment",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Hide",
-                    "aonid": 62,
-                    "game-obj": "Actions",
-                    "name": "Hide",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Stealth",
-                    "aonid": 15,
-                    "game-obj": "Skills",
-                    "name": "Stealth",
-                    "type": "link"
-                  }
-                ],
-                "name": "Chameleon Skin",
-                "subtype": "ability",
-                "text": "The mutant can change their coloration to match their surroundings. They don't need cover or concealment to attempt to Hide with a Stealth check.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "name": "Eldritch Attraction",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "A creature who casts a spell within 30 feet of the mutant must succeed at a Will save or spend its next action to Stride toward the mutant. It can't Delay or take any reactions until it has obeyed the compulsion.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "line",
-                    "size": 60,
-                    "subtype": "area",
-                    "text": "60-foot line",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  },
-                  {
-                    "shape": "cone",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Energy Blast",
-                "subtype": "ability",
-                "text": "Choose an energy type; this ability gains that energy type as a trait. The mutant gains some sort of physical alteration to their shape that suggests how they trigger their energy blast, be it numerous pustules on their body, an extra limb, or an additional opening in their throat to exhale the blast as a breath weapon. Choose whether the mutant creates a 60-foot line of energy or a 30-foot cone of energy when they activate this ability. The energy deals 1d6 damage per level with a basic Reflex save. The mutant can't use Energy Blast again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Energy Resistance",
-                "subtype": "ability",
-                "text": "The mutant has strangely colored skin or fur and gains resistance to a single type of energy damage. The amount of energy resistance gained depends on the mutant's level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unarmed",
-                    "aonid": 199,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grasping Tentacle",
-                "subtype": "ability",
-                "text": "The mutant grows a writhing, serpentine appendage, granting them a tentacle Strike (an agile unarmed attack that deals bludgeoning damage), and the Grab ability with that Strike. If they had any agile attacks, the damage dealt by their tentacle should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their tentacle should deal three-quarters that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "reach",
-                    "aonid": 192,
-                    "game-obj": "Traits",
-                    "name": "reach",
-                    "type": "link"
-                  }
-                ],
-                "name": "Hulking Form",
-                "subtype": "ability",
-                "text": "Increase the mutant's size by one category. Decrease their AC by 1, increase their HP by 1/10 their normal maximum HP, and increase the reach of all their melee Strikes by 5 feet.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "name": "Hungry Maw",
-                "subtype": "ability",
-                "text": "A mouth full of razor-sharp teeth opens somewhere on the mutant's body. They gain a maw Strike (an unarmed attack that does piercing damage roughly the same as the damage dealt by their most damaging melee attack), and they gain the Vengeful Bite reaction.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The mutant makes a maw Strike against the triggering creature.",
-                "links": [
-                  {
-                    "alt": "unarmed",
-                    "aonid": 199,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach",
-                    "aonid": 192,
-                    "game-obj": "Traits",
-                    "name": "reach",
-                    "type": "link"
-                  }
-                ],
-                "name": "Vengeful Bite",
-                "subtype": "ability",
-                "trigger": "A creature critically hits the mutant with a melee unarmed Strike or a non-reach melee **Strike**",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Increased Speed",
-                "subtype": "ability",
-                "text": "The mutant's limbs change, or they grow new limbs to accommodate their mutation. Either one of their existing Speeds increases by 20 feet or they gain a new Speed (such as fly or swim) of 15 feet.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Magic Hunger",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The mutant gains the ability to detect the source of any magic within 30 feet as an imprecise sense.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 91,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mirror Thing",
-                "subtype": "ability",
-                "text": "The mutant takes on the specific appearance of any Small or Medium humanoid they can currently see. This doesn't alter their statistics, but it might change the damage type of their Strikes.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 127,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mutant",
-                    "aonid": 229,
-                    "game-obj": "Traits",
-                    "name": "mutant",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sickened 2",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Revolting Appearance",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "Details of the mutant's appearance are disturbing and unnatural in the extreme. A non-mutant living creature who begins their turn within 60 feet of the mutant must succeed at a Fortitude save or become sickened 2. A creature who succeeds at its save is then temporarily immune to the aura for 24 hours.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Sprouted Limb",
-                "subtype": "ability",
-                "text": "The mutant grows an extra leg, increasing their Speed by 10 feet.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "all-around vision",
-                    "aonid": 1,
-                    "game-obj": "MonsterAbilities",
-                    "name": "all-around vision",
-                    "type": "link"
-                  }
-                ],
-                "name": "Too Many Eyes",
-                "subtype": "ability",
-                "text": "Countless eyes sprout on the mutant's skin. They gain all-around vision.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Mana Wastes Mutant Abilities')].sections[?(@.name=='Lost Omens Impossible Lands')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "cover",
+                "aonid": 459,
+                "game-obj": "Rules",
+                "name": "cover",
+                "type": "link"
+              },
+              {
+                "alt": "concealment",
+                "aonid": 4,
+                "game-obj": "Conditions",
+                "name": "concealment",
+                "type": "link"
+              },
+              {
+                "alt": "Hide",
+                "aonid": 62,
+                "game-obj": "Actions",
+                "name": "Hide",
+                "type": "link"
+              },
+              {
+                "alt": "Stealth",
+                "aonid": 15,
+                "game-obj": "Skills",
+                "name": "Stealth",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 199,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "reach",
+                "aonid": 192,
+                "game-obj": "Traits",
+                "name": "reach",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 199,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "reach",
+                "aonid": 192,
+                "game-obj": "Traits",
+                "name": "reach",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 127,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 91,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "mutant",
+                "aonid": 229,
+                "game-obj": "Traits",
+                "name": "mutant",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 2",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 2",
+                "type": "link"
+              },
+              {
+                "alt": "all-around vision",
+                "aonid": 1,
+                "game-obj": "MonsterAbilities",
+                "name": "all-around vision",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -507,159 +235,70 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "poison",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Afflicting Strike",
-                "subtype": "ability",
-                "text": "The mutant must have a jaws, claw, sting, or other melee Strike to gain this ability. That Strike now inflicts a disease, poison, or similar affliction on a hit, with a Fortitude save to resist. You can use the rules for existing monsters of the mutant's level for diseases, poisons, and similar afflictions to give to your mutant, or you can simply say the strike inflicts an additional 1d6 poison damage + an additional 1d6 points per 4 mutant levels on a hit, with a basic Fortitude save. This makes the Strike significantly more deadly, so reduce the damage in other ways to account for this increase.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Energy Resistance",
-                "subtype": "ability",
-                "text": "The mutant has strangely colored skin or fur and gains resistance to a single type of energy damage. The amount of energy resistance gained depends on the mutant's level:",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Energy Blast",
-                "subtype": "ability",
-                "text": "Choose an energy type; this ability gains that energy type as a trait. The mutant gains some sort of physical alteration to its shape that suggests how it triggers its energy blast, be it numerous pustules on its body, an additional limb, or additional opening in its throat to exhale the blast as a breath weapon. Choose whether the mutant creates a 60- foot line of energy or a 30-foot cone of energy when it activates this ability. The energy deals 1d6 damage per level with a basic Reflex save. The mutant can't use Energy Blast again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  }
-                ],
-                "name": "Inoculation",
-                "subtype": "ability",
-                "text": "The mutant's flesh is distorted with the addition of unexpected fur, scales, warts, or other growths. The creature gains a +2 status bonus to saves against disease and poison. In rare cases, you might choose to grant immunity instead.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Increased Speed",
-                "subtype": "ability",
-                "text": "The mutant's limbs change, or it grows new limbs to accommodate its mutation. Either one of its existing Speeds increases by 20 feet, or it gains a new Speed (such as fly or swim) of 15 feet.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Mana Wastes Mutant Abilities')].sections[?(@.name=='Cradle Of Quartz')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -710,6 +349,901 @@
       ],
       "name": "Mana Wastes Mutant Abilities",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "acid",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Caustic Pustules",
+              "subtype": "ability",
+              "text": "Whenever the mutant takes piercing or slashing damage, creatures adjacent to the mutant take 1d6 acid damage (basic Reflex save). The damage increases to 2d6 if the mutant is at least 8th level and 3d6 if the mutant is at least 15th level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "cover",
+                  "aonid": 459,
+                  "game-obj": "Rules",
+                  "name": "cover",
+                  "type": "link"
+                },
+                {
+                  "alt": "concealment",
+                  "aonid": 4,
+                  "game-obj": "Conditions",
+                  "name": "concealment",
+                  "type": "link"
+                },
+                {
+                  "alt": "Hide",
+                  "aonid": 62,
+                  "game-obj": "Actions",
+                  "name": "Hide",
+                  "type": "link"
+                },
+                {
+                  "alt": "Stealth",
+                  "aonid": 15,
+                  "game-obj": "Skills",
+                  "name": "Stealth",
+                  "type": "link"
+                }
+              ],
+              "name": "Chameleon Skin",
+              "subtype": "ability",
+              "text": "The mutant can change their coloration to match their surroundings. They don't need cover or concealment to attempt to Hide with a Stealth check.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "name": "Eldritch Attraction",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "within 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "A creature who casts a spell within 30 feet of the mutant must succeed at a Will save or spend its next action to Stride toward the mutant. It can't Delay or take any reactions until it has obeyed the compulsion.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "line",
+                  "size": 60,
+                  "subtype": "area",
+                  "text": "60-foot line",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                },
+                {
+                  "shape": "cone",
+                  "size": 30,
+                  "subtype": "area",
+                  "text": "30-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Energy Blast",
+              "subtype": "ability",
+              "text": "Choose an energy type; this ability gains that energy type as a trait. The mutant gains some sort of physical alteration to their shape that suggests how they trigger their energy blast, be it numerous pustules on their body, an extra limb, or an additional opening in their throat to exhale the blast as a breath weapon. Choose whether the mutant creates a 60-foot line of energy or a 30-foot cone of energy when they activate this ability. The energy deals 1d6 damage per level with a basic Reflex save. The mutant can't use Energy Blast again for 1d4 rounds.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "evocation",
+                    "aonid": 65,
+                    "game-obj": "Traits",
+                    "name": "evocation",
+                    "type": "link"
+                  },
+                  "name": "evocation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Energy Resistance",
+              "subtype": "ability",
+              "text": "The mutant has strangely colored skin or fur and gains resistance to a single type of energy damage. The amount of energy resistance gained depends on the mutant's level.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "agile",
+                  "aonid": 170,
+                  "game-obj": "Traits",
+                  "name": "agile",
+                  "type": "link"
+                },
+                {
+                  "alt": "unarmed",
+                  "aonid": 199,
+                  "game-obj": "Traits",
+                  "name": "unarmed",
+                  "type": "link"
+                },
+                {
+                  "alt": "Grab",
+                  "aonid": 18,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Grab",
+                  "type": "link"
+                }
+              ],
+              "name": "Grasping Tentacle",
+              "subtype": "ability",
+              "text": "The mutant grows a writhing, serpentine appendage, granting them a tentacle Strike (an agile unarmed attack that deals bludgeoning damage), and the Grab ability with that Strike. If they had any agile attacks, the damage dealt by their tentacle should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their tentacle should deal three-quarters that damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "reach",
+                  "aonid": 192,
+                  "game-obj": "Traits",
+                  "name": "reach",
+                  "type": "link"
+                }
+              ],
+              "name": "Hulking Form",
+              "subtype": "ability",
+              "text": "Increase the mutant's size by one category. Decrease their AC by 1, increase their HP by 1/10 their normal maximum HP, and increase the reach of all their melee Strikes by 5 feet.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "name": "Hungry Maw",
+              "subtype": "ability",
+              "text": "A mouth full of razor-sharp teeth opens somewhere on the mutant's body. They gain a maw Strike (an unarmed attack that does piercing damage roughly the same as the damage dealt by their most damaging melee attack), and they gain the Vengeful Bite reaction.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The mutant makes a maw Strike against the triggering creature.",
+              "links": [
+                {
+                  "alt": "unarmed",
+                  "aonid": 199,
+                  "game-obj": "Traits",
+                  "name": "unarmed",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach",
+                  "aonid": 192,
+                  "game-obj": "Traits",
+                  "name": "reach",
+                  "type": "link"
+                }
+              ],
+              "name": "Vengeful Bite",
+              "subtype": "ability",
+              "trigger": "A creature critically hits the mutant with a melee unarmed Strike or a non-reach melee **Strike**",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "name": "Increased Speed",
+              "subtype": "ability",
+              "text": "The mutant's limbs change, or they grow new limbs to accommodate their mutation. Either one of their existing Speeds increases by 20 feet or they gain a new Speed (such as fly or swim) of 15 feet.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Magic Hunger",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "within 30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The mutant gains the ability to detect the source of any magic within 30 feet as an imprecise sense.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 91,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Mirror Thing",
+              "subtype": "ability",
+              "text": "The mutant takes on the specific appearance of any Small or Medium humanoid they can currently see. This doesn't alter their statistics, but it might change the damage type of their Strikes.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 32,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 127,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "mutant",
+                  "aonid": 229,
+                  "game-obj": "Traits",
+                  "name": "mutant",
+                  "type": "link"
+                },
+                {
+                  "alt": "sickened 2",
+                  "aonid": 34,
+                  "game-obj": "Conditions",
+                  "name": "sickened 2",
+                  "type": "link"
+                }
+              ],
+              "name": "Revolting Appearance",
+              "range": {
+                "range": 60,
+                "subtype": "range",
+                "text": "within 60 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "Details of the mutant's appearance are disturbing and unnatural in the extreme. A non-mutant living creature who begins their turn within 60 feet of the mutant must succeed at a Fortitude save or become sickened 2. A creature who succeeds at its save is then temporarily immune to the aura for 24 hours.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "visual",
+                    "aonid": 163,
+                    "game-obj": "Traits",
+                    "name": "visual",
+                    "type": "link"
+                  },
+                  "name": "visual",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Sprouted Limb",
+              "subtype": "ability",
+              "text": "The mutant grows an extra leg, increasing their Speed by 10 feet.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "all-around vision",
+                  "aonid": 1,
+                  "game-obj": "MonsterAbilities",
+                  "name": "all-around vision",
+                  "type": "link"
+                }
+              ],
+              "name": "Too Many Eyes",
+              "subtype": "ability",
+              "text": "Countless eyes sprout on the mutant's skin. They gain all-around vision.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "cover",
+              "aonid": 459,
+              "game-obj": "Rules",
+              "name": "cover",
+              "type": "link"
+            },
+            {
+              "alt": "concealment",
+              "aonid": 4,
+              "game-obj": "Conditions",
+              "name": "concealment",
+              "type": "link"
+            },
+            {
+              "alt": "Hide",
+              "aonid": 62,
+              "game-obj": "Actions",
+              "name": "Hide",
+              "type": "link"
+            },
+            {
+              "alt": "Stealth",
+              "aonid": 15,
+              "game-obj": "Skills",
+              "name": "Stealth",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "evocation",
+              "aonid": 65,
+              "game-obj": "Traits",
+              "name": "evocation",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "unarmed",
+              "aonid": 199,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            },
+            {
+              "alt": "reach",
+              "aonid": 192,
+              "game-obj": "Traits",
+              "name": "reach",
+              "type": "link"
+            },
+            {
+              "alt": "unarmed",
+              "aonid": 199,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            },
+            {
+              "alt": "reach",
+              "aonid": 192,
+              "game-obj": "Traits",
+              "name": "reach",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 32,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 127,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 91,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "mutant",
+              "aonid": 229,
+              "game-obj": "Traits",
+              "name": "mutant",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 2",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 2",
+              "type": "link"
+            },
+            {
+              "alt": "all-around vision",
+              "aonid": 1,
+              "game-obj": "MonsterAbilities",
+              "name": "all-around vision",
+              "type": "link"
+            }
+          ],
+          "name": "Lost Omens Impossible Lands",
+          "sources": [
+            {
+              "link": {
+                "alt": "Impossible Lands pg. 332",
+                "href": "https://paizo.com/products/btq02dxx",
+                "name": "Impossible Lands pg. 332",
+                "type": "link"
+              },
+              "name": "Impossible Lands",
+              "page": 332,
+              "type": "source"
+            }
+          ],
+          "text": "**Caustic Pustules** Whenever the mutant takes piercing or slashing damage, creatures adjacent to the mutant take 1d6 acid damage (basic Reflex save). The damage increases to 2d6 if the mutant is at least 8th level and 3d6 if the mutant is at least 15th level.  \n  \n**Chameleon Skin** The mutant can change their coloration to match their surroundings. They don't need cover or concealment to attempt to Hide with a Stealth check.  \n  \n**Eldritch Attraction** (enchantment, mental) A creature who casts a spell within 30 feet of the mutant must succeed at a Will save or spend its next action to Stride toward the mutant. It can't Delay or take any reactions until it has obeyed the compulsion.  \n  \n**Energy Blast** [##] (evocation, primal) Choose an energy type; this ability gains that energy type as a trait. The mutant gains some sort of physical alteration to their shape that suggests how they trigger their energy blast, be it numerous pustules on their body, an extra limb, or an additional opening in their throat to exhale the blast as a breath weapon. Choose whether the mutant creates a 60-foot line of energy or a 30-foot cone of energy when they activate this ability. The energy deals 1d6 damage per level with a basic Reflex save. The mutant can't use Energy Blast again for 1d4 rounds.  \n  \n**Energy Resistance** The mutant has strangely colored skin or fur and gains resistance to a single type of energy damage. The amount of energy resistance gained depends on the mutant's level.  \n  \n**Grasping Tentacle** The mutant grows a writhing, serpentine appendage, granting them a tentacle Strike (an agile unarmed attack that deals bludgeoning damage), and the Grab ability with that Strike. If they had any agile attacks, the damage dealt by their tentacle should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their tentacle should deal three-quarters that damage.  \n  \n**Hulking Form** Increase the mutant's size by one category. Decrease their AC by 1, increase their HP by 1/10 their normal maximum HP, and increase the reach of all their melee Strikes by 5 feet.  \n  \n**Hungry Maw** A mouth full of razor-sharp teeth opens somewhere on the mutant's body. They gain a maw Strike (an unarmed attack that does piercing damage roughly the same as the damage dealt by their most damaging melee attack), and they gain the Vengeful Bite reaction.  \n**Vengeful Bite** [@] **Trigger** A creature critically hits the mutant with a melee unarmed Strike or a non-reach melee **Strike**; **Effect** The mutant makes a maw Strike against the triggering creature.  \n  \n**Increased Speed** The mutant's limbs change, or they grow new limbs to accommodate their mutation. Either one of their existing Speeds increases by 20 feet or they gain a new Speed (such as fly or swim) of 15 feet.  \n  \n**Magic Hunger** The mutant gains the ability to detect the source of any magic within 30 feet as an imprecise sense.  \n  \n**Mirror Thing** [#] (arcane, concentrate, polymorph, transmutation) The mutant takes on the specific appearance of any Small or Medium humanoid they can currently see. This doesn't alter their statistics, but it might change the damage type of their Strikes.  \n  \n**Revolting Appearance** (arcane, aura, visual) Details of the mutant's appearance are disturbing and unnatural in the extreme. A non-mutant living creature who begins their turn within 60 feet of the mutant must succeed at a Fortitude save or become sickened 2. A creature who succeeds at its save is then temporarily immune to the aura for 24 hours.  \n  \n**Sprouted Limb** The mutant grows an extra leg, increasing their Speed by 10 feet.  \n  \n**Too Many Eyes** Countless eyes sprout on the mutant's skin. They gain all-around vision.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "poison",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Afflicting Strike",
+              "subtype": "ability",
+              "text": "The mutant must have a jaws, claw, sting, or other melee Strike to gain this ability. That Strike now inflicts a disease, poison, or similar affliction on a hit, with a Fortitude save to resist. You can use the rules for existing monsters of the mutant's level for diseases, poisons, and similar afflictions to give to your mutant, or you can simply say the strike inflicts an additional 1d6 poison damage + an additional 1d6 points per 4 mutant levels on a hit, with a basic Fortitude save. This makes the Strike significantly more deadly, so reduce the damage in other ways to account for this increase.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Energy Resistance",
+              "subtype": "ability",
+              "text": "The mutant has strangely colored skin or fur and gains resistance to a single type of energy damage. The amount of energy resistance gained depends on the mutant's level:",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "cone",
+                  "size": 30,
+                  "subtype": "area",
+                  "text": "30-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Energy Blast",
+              "subtype": "ability",
+              "text": "Choose an energy type; this ability gains that energy type as a trait. The mutant gains some sort of physical alteration to its shape that suggests how it triggers its energy blast, be it numerous pustules on its body, an additional limb, or additional opening in its throat to exhale the blast as a breath weapon. Choose whether the mutant creates a 60- foot line of energy or a 30-foot cone of energy when it activates this ability. The energy deals 1d6 damage per level with a basic Reflex save. The mutant can't use Energy Blast again for 1d4 rounds.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "evocation",
+                    "aonid": 65,
+                    "game-obj": "Traits",
+                    "name": "evocation",
+                    "type": "link"
+                  },
+                  "name": "evocation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 134,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                }
+              ],
+              "name": "Inoculation",
+              "subtype": "ability",
+              "text": "The mutant's flesh is distorted with the addition of unexpected fur, scales, warts, or other growths. The creature gains a +2 status bonus to saves against disease and poison. In rare cases, you might choose to grant immunity instead.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "name": "Increased Speed",
+              "subtype": "ability",
+              "text": "The mutant's limbs change, or it grows new limbs to accommodate its mutation. Either one of its existing Speeds increases by 20 feet, or it gains a new Speed (such as fly or swim) of 15 feet.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "evocation",
+              "aonid": 65,
+              "game-obj": "Traits",
+              "name": "evocation",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 134,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            }
+          ],
+          "name": "Cradle Of Quartz",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #179: Cradle of Quartz pg. 84",
+                "href": "https://paizo.com/products/btq02am3",
+                "name": "Pathfinder #179: Cradle of Quartz pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #179: Cradle of Quartz",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "**Afflicting Strike** The mutant must have a jaws, claw, sting, or other melee Strike to gain this ability. That Strike now inflicts a disease, poison, or similar affliction on a hit, with a Fortitude save to resist. You can use the rules for existing monsters of the mutant's level for diseases, poisons, and similar afflictions to give to your mutant, or you can simply say the strike inflicts an additional 1d6 poison damage + an additional 1d6 points per 4 mutant levels on a hit, with a basic Fortitude save. This makes the Strike significantly more deadly, so reduce the damage in other ways to account for this increase.   \n  \n**Energy Resistance** The mutant has strangely colored skin or fur and gains resistance to a single type of energy damage. The amount of energy resistance gained depends on the mutant's level:   \n  \n**Energy Blast** [##] (evocation, primal) Choose an energy type; this ability gains that energy type as a trait. The mutant gains some sort of physical alteration to its shape that suggests how it triggers its energy blast, be it numerous pustules on its body, an additional limb, or additional opening in its throat to exhale the blast as a breath weapon. Choose whether the mutant creates a 60- foot line of energy or a 30-foot cone of energy when it activates this ability. The energy deals 1d6 damage per level with a basic Reflex save. The mutant can't use Energy Blast again for 1d4 rounds.   \n  \n**Inoculation** The mutant's flesh is distorted with the addition of unexpected fur, scales, warts, or other growths. The creature gains a +2 status bonus to saves against disease and poison. In rare cases, you might choose to grant immunity instead.   \n  \n**Increased Speed** The mutant's limbs change, or it grows new limbs to accommodate its mutation. Either one of its existing Speeds increases by 20 feet, or it gains a new Speed (such as fly or swim) of 15 feet.",
+          "type": "section"
+        },
         {
           "name": "Aberrant, not Ableist!",
           "sources": [

--- a/monster_families/kingmaker_adventure_path/fetch.json
+++ b/monster_families/kingmaker_adventure_path/fetch.json
@@ -54,20 +54,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Warning - this sidebar contains spoilers for the Kingmaker adventure path.",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Freed Fetches')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -86,6 +77,34 @@
   "name": "Fetch",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Warning - this sidebar contains spoilers for the Kingmaker adventure path.",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Freed Fetches",
+      "sources": [
+        {
+          "link": {
+            "alt": "Kingmaker Adventure Path pg. 612",
+            "aonid": 150,
+            "game-obj": "Sources",
+            "name": "Kingmaker Adventure Path pg. 612",
+            "type": "link"
+          },
+          "name": "Kingmaker Adventure Path",
+          "page": 612,
+          "type": "source"
+        }
+      ],
+      "text": "**Warning - this sidebar contains spoilers for the Kingmaker adventure path.**  \n  \nIf a fetch replaces its source by slaying them and taking their place in society, it can become a freed fetch. These are unique entities and should be hand-crafted as needed. All fetches begin their lives chaotic evil, but once they claim their place in the cycle of souls, they can (albeit rarely) find redemption. Fetches created by powerful entities after the source soul has moved on to be judged (including all fetches in *Kingmaker*) can never become freed, for they exist only at the whim of their creator.",
+      "type": "section"
+    },
     {
       "links": [
         {

--- a/monster_families/monster_core/caligni.json
+++ b/monster_families/monster_core/caligni.json
@@ -59,75 +59,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "darkvision",
-                    "aonid": 415,
-                    "game-obj": "Rules",
-                    "name": "darkvision",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concealed",
-                    "aonid": 62,
-                    "game-obj": "Conditions",
-                    "name": "concealed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "hidden",
-                    "aonid": 79,
-                    "game-obj": "Conditions",
-                    "name": "hidden",
-                    "type": "link"
-                  }
-                ],
-                "maximum_duration": "6 rounds",
-                "name": "Saving Throw",
-                "saving_throw": [
-                  {
-                    "dc": 16,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 16 Fortitude",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "1d6 poison (1 round)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "1d6 poison and creatures you can see only with darkvision are concealed from you (1 round)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "1d6 poison and creatures you can see only with darkvision are hidden from you (1 round)",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "DC 16 Fortitude;",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Darkening Poison')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "concealed",
+                "aonid": 62,
+                "game-obj": "Conditions",
+                "name": "concealed",
+                "type": "link"
+              },
+              {
+                "alt": "hidden",
+                "aonid": 79,
+                "game-obj": "Conditions",
+                "name": "hidden",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -137,7 +97,6 @@
         ],
         "name": "Darkening Poison",
         "subtype": "monster_family",
-        "text": "Many calignis keep several doses of darkening poison, an uncommon injury poison made from Darklands spider venom, on hand to incapacitate foes. A dose of darkening poison costs 5 gp, is of light Bulk, is held in 2 hands, and has the following statistics.",
         "type": "stat_block_section"
       }
     ],
@@ -207,6 +166,118 @@
         }
       ],
       "text": "Some calignis have abandoned their traditional faith in favor of more active deities; evil individuals favor Norgorber or Zon-Kuthon, while the less malevolent might follow Nocticula or Pharasma. Perhaps unexpectedly, Desna also has a small caligni following, particularly among those who frequently travel.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "affliction",
+          "links": [
+            {
+              "alt": "darkvision",
+              "aonid": 415,
+              "game-obj": "Rules",
+              "name": "darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "concealed",
+              "aonid": 62,
+              "game-obj": "Conditions",
+              "name": "concealed",
+              "type": "link"
+            },
+            {
+              "alt": "hidden",
+              "aonid": 79,
+              "game-obj": "Conditions",
+              "name": "hidden",
+              "type": "link"
+            }
+          ],
+          "maximum_duration": "6 rounds",
+          "name": "Saving Throw",
+          "saving_throw": [
+            {
+              "dc": 16,
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "DC 16 Fortitude",
+              "type": "stat_block_section"
+            }
+          ],
+          "stages": [
+            {
+              "name": "Stage 1",
+              "subtype": "affliction_stage",
+              "text": "1d6 poison (1 round)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 2",
+              "subtype": "affliction_stage",
+              "text": "1d6 poison and creatures you can see only with darkvision are concealed from you (1 round)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 3",
+              "subtype": "affliction_stage",
+              "text": "1d6 poison and creatures you can see only with darkvision are hidden from you (1 round)",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "DC 16 Fortitude;",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "darkvision",
+          "aonid": 415,
+          "game-obj": "Rules",
+          "name": "darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "concealed",
+          "aonid": 62,
+          "game-obj": "Conditions",
+          "name": "concealed",
+          "type": "link"
+        },
+        {
+          "alt": "hidden",
+          "aonid": 79,
+          "game-obj": "Conditions",
+          "name": "hidden",
+          "type": "link"
+        }
+      ],
+      "name": "Darkening Poison",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 48",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 48",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 48,
+          "type": "source"
+        }
+      ],
+      "text": "Many calignis keep several doses of darkening poison, an uncommon injury poison made from Darklands spider venom, on hand to incapacitate foes. A dose of darkening poison costs 5 gp, is of light Bulk, is held in 2 hands, and has the following statistics.  \n  \n**Saving Throw** DC 16 Fortitude; **Maximum Duration** 6 rounds; **Stage 1** 1d6 poison (1 round); **Stage 2** 1d6 poison and creatures you can see only with darkvision are concealed from you (1 round); **Stage 3** 1d6 poison and creatures you can see only with darkvision are hidden from you (1 round)",
       "type": "section"
     },
     {

--- a/monster_families/monster_core/dog.json
+++ b/monster_families/monster_core/dog.json
@@ -59,86 +59,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 91,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "confused",
-                    "aonid": 63,
-                    "game-obj": "Conditions",
-                    "name": "confused",
-                    "type": "link"
-                  }
-                ],
-                "name": "Rabies",
-                "saving_throw": [
-                  {
-                    "dc": 17,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 17 Fortitude",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "sickened 1 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "sickened 2 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "confused (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 4",
-                    "subtype": "affliction_stage",
-                    "text": "dead.",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 578,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Rabies')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "confused",
+                "aonid": 63,
+                "game-obj": "Conditions",
+                "name": "confused",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -148,7 +97,6 @@
         ],
         "name": "Rabies",
         "subtype": "monster_family",
-        "text": "Many societies adore dogs and value them for their loyalty as pets. For such pet owners, there's perhaps no affliction more horrible than rabies. While many animals can be stricken with this debilitating illness, the idea of a loyal family pet growing feral and violent makes it all the more feared.",
         "type": "stat_block_section"
       }
     ],
@@ -156,6 +104,131 @@
   },
   "name": "Dog",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "affliction",
+          "links": [
+            {
+              "alt": "sickened 1",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            },
+            {
+              "alt": "confused",
+              "aonid": 63,
+              "game-obj": "Conditions",
+              "name": "confused",
+              "type": "link"
+            }
+          ],
+          "name": "Rabies",
+          "saving_throw": [
+            {
+              "dc": 17,
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "DC 17 Fortitude",
+              "type": "stat_block_section"
+            }
+          ],
+          "stages": [
+            {
+              "name": "Stage 1",
+              "subtype": "affliction_stage",
+              "text": "sickened 1 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 2",
+              "subtype": "affliction_stage",
+              "text": "sickened 2 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 3",
+              "subtype": "affliction_stage",
+              "text": "confused (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 4",
+              "subtype": "affliction_stage",
+              "text": "dead.",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "sickened 1",
+          "aonid": 91,
+          "game-obj": "Conditions",
+          "name": "sickened 1",
+          "type": "link"
+        },
+        {
+          "alt": "confused",
+          "aonid": 63,
+          "game-obj": "Conditions",
+          "name": "confused",
+          "type": "link"
+        }
+      ],
+      "name": "Rabies",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 102",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 102",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 102,
+          "type": "source"
+        }
+      ],
+      "text": "Many societies adore dogs and value them for their loyalty as pets. For such pet owners, there's perhaps no affliction more horrible than rabies. While many animals can be stricken with this debilitating illness, the idea of a loyal family pet growing feral and violent makes it all the more feared.  \n  \n**Rabies** (disease) **Saving Throw** DC 17 Fortitude; **Stage 1** sickened 1 (1 day); **Stage 2** sickened 2 (1 day); **Stage 3** confused (1 day); **Stage 4** dead.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "errata": {

--- a/monster_families/monster_core/dragon_adamantine.json
+++ b/monster_families/monster_core/dragon_adamantine.json
@@ -68,303 +68,125 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shape stone",
-                            "aonid": 1667,
-                            "game-obj": "Spells",
-                            "name": "shape stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shape stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthbind",
-                            "aonid": 1506,
-                            "game-obj": "Spells",
-                            "name": "earthbind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthbind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "one with stone",
-                            "aonid": 1619,
-                            "game-obj": "Spells",
-                            "name": "one with stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "one with stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "darkness",
-                            "aonid": 1480,
-                            "game-obj": "Spells",
-                            "name": "darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shatter",
-                            "aonid": 1670,
-                            "game-obj": "Spells",
-                            "name": "shatter",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shatter",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water walk",
-                            "aonid": 1756,
-                            "game-obj": "Spells",
-                            "name": "water walk",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water walk",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "air bubble",
-                            "aonid": 1438,
-                            "game-obj": "Spells",
-                            "name": "air bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "air bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tailwind",
-                            "aonid": 1711,
-                            "game-obj": "Spells",
-                            "name": "tailwind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tailwind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vanishing tracks",
-                            "aonid": 1737,
-                            "game-obj": "Spells",
-                            "name": "vanishing tracks",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vanishing tracks",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "caustic blast",
-                            "aonid": 1461,
-                            "game-obj": "Spells",
-                            "name": "caustic blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangle vine",
-                            "aonid": 1713,
-                            "game-obj": "Spells",
-                            "name": "tangle vine",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Adamantine Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "shape stone",
+                "aonid": 1667,
+                "game-obj": "Spells",
+                "name": "shape stone",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "earthbind",
+                "aonid": 1506,
+                "game-obj": "Spells",
+                "name": "earthbind",
+                "type": "link"
+              },
+              {
+                "alt": "one with stone",
+                "aonid": 1619,
+                "game-obj": "Spells",
+                "name": "one with stone",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "shatter",
+                "aonid": 1670,
+                "game-obj": "Spells",
+                "name": "shatter",
+                "type": "link"
+              },
+              {
+                "alt": "water walk",
+                "aonid": 1756,
+                "game-obj": "Spells",
+                "name": "water walk",
+                "type": "link"
+              },
+              {
+                "alt": "air bubble",
+                "aonid": 1438,
+                "game-obj": "Spells",
+                "name": "air bubble",
+                "type": "link"
+              },
+              {
+                "alt": "tailwind",
+                "aonid": 1711,
+                "game-obj": "Spells",
+                "name": "tailwind",
+                "type": "link"
+              },
+              {
+                "alt": "vanishing tracks",
+                "aonid": 1737,
+                "game-obj": "Spells",
+                "name": "vanishing tracks",
+                "type": "link"
+              },
+              {
+                "alt": "caustic blast",
+                "aonid": 1461,
+                "game-obj": "Spells",
+                "name": "caustic blast",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "tangle vine",
+                "aonid": 1713,
+                "game-obj": "Spells",
+                "name": "tangle vine",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -380,169 +202,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young adamantine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 27,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "petrify",
-                            "aonid": 1628,
-                            "game-obj": "Spells",
-                            "name": "petrify",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "petrify",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangling creepers",
-                            "aonid": 1714,
-                            "game-obj": "Spells",
-                            "name": "tangling creepers",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangling creepers",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "impaling spike",
-                            "aonid": 1571,
-                            "game-obj": "Spells",
-                            "name": "impaling spike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "impaling spike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "magic passage",
-                            "aonid": 1591,
-                            "game-obj": "Spells",
-                            "name": "magic passage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "magic passage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "speak with stones",
-                            "aonid": 1682,
-                            "game-obj": "Spells",
-                            "name": "speak with stones",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "speak with stones",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "vapor form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Adamantine Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "petrify",
+                "aonid": 1628,
+                "game-obj": "Spells",
+                "name": "petrify",
+                "type": "link"
+              },
+              {
+                "alt": "tangling creepers",
+                "aonid": 1714,
+                "game-obj": "Spells",
+                "name": "tangling creepers",
+                "type": "link"
+              },
+              {
+                "alt": "impaling spike",
+                "aonid": 1571,
+                "game-obj": "Spells",
+                "name": "impaling spike",
+                "type": "link"
+              },
+              {
+                "alt": "magic passage",
+                "aonid": 1591,
+                "game-obj": "Spells",
+                "name": "magic passage",
+                "type": "link"
+              },
+              {
+                "alt": "speak with stones",
+                "aonid": 1682,
+                "game-obj": "Spells",
+                "name": "speak with stones",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -558,193 +259,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult adamantine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "earthquake",
-                            "aonid": 1507,
-                            "game-obj": "Spells",
-                            "name": "earthquake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "earthquake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 1607,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "volcanic eruption",
-                            "aonid": 1746,
-                            "game-obj": "Spells",
-                            "name": "volcanic eruption",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "volcanic eruption",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "field of life",
-                            "aonid": 1526,
-                            "game-obj": "Spells",
-                            "name": "field of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "field of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Adamantine Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "earthquake",
+                "aonid": 1507,
+                "game-obj": "Spells",
+                "name": "earthquake",
+                "type": "link"
+              },
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "moment of renewal",
+                "aonid": 1607,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "volcanic eruption",
+                "aonid": 1746,
+                "game-obj": "Spells",
+                "name": "volcanic eruption",
+                "type": "link"
+              },
+              {
+                "alt": "field of life",
+                "aonid": 1526,
+                "game-obj": "Spells",
+                "name": "field of life",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -760,102 +330,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient adamantine dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adamantine Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -870,307 +365,119 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cratering Smash",
-                "saving_throw": [
-                  {
-                    "dc": 20,
-                    "subtype": "save_dc",
-                    "text": "DC 20",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The dragon smashes itself into the ground, cratering the earth in a 10-foot deep, 60-foot wide emanation. Creatures in the area are thrown into the air and must attempt a Reflex save with a DC equal to the dragon's Avalanche Breath.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature lands on its feet.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "prone",
-                    "aonid": 88,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature lands prone.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature lands prone and takes 1d6 damage per every two levels of the dragon.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, and the dragon can make a jaws Strike against the creature as a free action. It can only attack one creature that critically failed its save.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 60,
-                    "subtype": "area",
-                    "text": "60-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Interact",
-                    "aonid": 3259,
-                    "game-obj": "Actions",
-                    "name": "Interact",
-                    "type": "link"
-                  }
-                ],
-                "name": "Magnetic Roar",
-                "subtype": "ability",
-                "text": "With a mighty roar, the dragon attracts metal in a 60-foot emanation. Any unattended metal object of 1 Bulk or less flies to the dragon and sticks to their hide, granting a +2 item bonus to AC for 1 minute. Any creature holding a metal object of 1 Bulk or less must attempt at a Fortitude save with a DC equal to the dragon's Avalanche Breath DC or have their item pulled to the dragon and stuck for 1 round. A creature wearing metal armor instead must succeed at a Fortitude save against the DC + 2 or be pulled, taking 1d6 bludgeoning damage for every 10 feet it was moved, and become magnetically stuck to the dragon for 1 round. An object or creature can be unstuck with an Interact action.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "metal",
-                      "aonid": 505,
-                      "game-obj": "Traits",
-                      "name": "metal",
-                      "type": "link"
-                    },
-                    "name": "metal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Frightful Presence",
-                    "aonid": 64,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Frightful Presence",
-                    "type": "link"
-                  }
-                ],
-                "name": "Petrifying Blow",
-                "subtype": "ability",
-                "text": "The adamantine dragon's attacks can turn creatures into sculptures to add to their hoard. A creature critically hit by the dragon's claw or jaw Strike must attempt a Fortitude save with a DC equal to the dragon's Frightful Presence. On a successful save, the creature is temporarily immune for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "metal",
-                      "aonid": 505,
-                      "game-obj": "Traits",
-                      "name": "metal",
-                      "type": "link"
-                    },
-                    "name": "metal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "slowed",
-                    "aonid": 92,
-                    "game-obj": "Conditions",
-                    "name": "slowed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is slowed 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature is slowed 2.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "petrified",
-                    "aonid": 87,
-                    "game-obj": "Conditions",
-                    "name": "petrified",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "The creature is petrified permanently into adamantine.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The dragon Flies and makes up to two claw attacks against different creatures along their flight.",
-                "frequency": "one per day",
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Flies",
-                    "aonid": 2312,
-                    "game-obj": "Actions",
-                    "name": "Flies",
-                    "type": "link"
-                  }
-                ],
-                "name": "Repelling Blast",
-                "requirement": "The dragon has their Speed increased by Abandon Armor",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "metal",
-                      "aonid": 505,
-                      "game-obj": "Traits",
-                      "name": "metal",
-                      "type": "link"
-                    },
-                    "name": "metal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "prone",
+                "aonid": 88,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "metal",
+                "aonid": 505,
+                "game-obj": "Traits",
+                "name": "metal",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "Interact",
+                "aonid": 3259,
+                "game-obj": "Actions",
+                "name": "Interact",
+                "type": "link"
+              },
+              {
+                "alt": "metal",
+                "aonid": 505,
+                "game-obj": "Traits",
+                "name": "metal",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "Frightful Presence",
+                "aonid": 64,
+                "game-obj": "MonsterAbilities",
+                "name": "Frightful Presence",
+                "type": "link"
+              },
+              {
+                "alt": "slowed",
+                "aonid": 92,
+                "game-obj": "Conditions",
+                "name": "slowed",
+                "type": "link"
+              },
+              {
+                "alt": "petrified",
+                "aonid": 87,
+                "game-obj": "Conditions",
+                "name": "petrified",
+                "type": "link"
+              },
+              {
+                "alt": "metal",
+                "aonid": 505,
+                "game-obj": "Traits",
+                "name": "metal",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "Flies",
+                "aonid": 2312,
+                "game-obj": "Actions",
+                "name": "Flies",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1180,54 +487,16 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "You can create a more unusual adamantine dragon by substituting any one of the following abilities for Burrowing Pounce, Draconic Frenzy, or Frightful Presence.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1238,263 +507,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1504,7 +557,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1563,6 +615,1507 @@
         }
       ],
       "text": "Adamantine dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "shape stone",
+          "aonid": 1667,
+          "game-obj": "Spells",
+          "name": "shape stone",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "earthbind",
+          "aonid": 1506,
+          "game-obj": "Spells",
+          "name": "earthbind",
+          "type": "link"
+        },
+        {
+          "alt": "one with stone",
+          "aonid": 1619,
+          "game-obj": "Spells",
+          "name": "one with stone",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "darkness",
+          "aonid": 1480,
+          "game-obj": "Spells",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "shatter",
+          "aonid": 1670,
+          "game-obj": "Spells",
+          "name": "shatter",
+          "type": "link"
+        },
+        {
+          "alt": "water walk",
+          "aonid": 1756,
+          "game-obj": "Spells",
+          "name": "water walk",
+          "type": "link"
+        },
+        {
+          "alt": "air bubble",
+          "aonid": 1438,
+          "game-obj": "Spells",
+          "name": "air bubble",
+          "type": "link"
+        },
+        {
+          "alt": "tailwind",
+          "aonid": 1711,
+          "game-obj": "Spells",
+          "name": "tailwind",
+          "type": "link"
+        },
+        {
+          "alt": "vanishing tracks",
+          "aonid": 1737,
+          "game-obj": "Spells",
+          "name": "vanishing tracks",
+          "type": "link"
+        },
+        {
+          "alt": "caustic blast",
+          "aonid": 1461,
+          "game-obj": "Spells",
+          "name": "caustic blast",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "tangle vine",
+          "aonid": 1713,
+          "game-obj": "Spells",
+          "name": "tangle vine",
+          "type": "link"
+        }
+      ],
+      "name": "Young Adamantine Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 108",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 108",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 108,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shape stone",
+                      "aonid": 1667,
+                      "game-obj": "Spells",
+                      "name": "shape stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shape stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthbind",
+                      "aonid": 1506,
+                      "game-obj": "Spells",
+                      "name": "earthbind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthbind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "one with stone",
+                      "aonid": 1619,
+                      "game-obj": "Spells",
+                      "name": "one with stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "one with stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "darkness",
+                      "aonid": 1480,
+                      "game-obj": "Spells",
+                      "name": "darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shatter",
+                      "aonid": 1670,
+                      "game-obj": "Spells",
+                      "name": "shatter",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shatter",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water walk",
+                      "aonid": 1756,
+                      "game-obj": "Spells",
+                      "name": "water walk",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water walk",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "air bubble",
+                      "aonid": 1438,
+                      "game-obj": "Spells",
+                      "name": "air bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "air bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tailwind",
+                      "aonid": 1711,
+                      "game-obj": "Spells",
+                      "name": "tailwind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tailwind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vanishing tracks",
+                      "aonid": 1737,
+                      "game-obj": "Spells",
+                      "name": "vanishing tracks",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vanishing tracks",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "caustic blast",
+                      "aonid": 1461,
+                      "game-obj": "Spells",
+                      "name": "caustic blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangle vine",
+                      "aonid": 1713,
+                      "game-obj": "Spells",
+                      "name": "tangle vine",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 28, attack +21; **4th** *shape stone*, *unfettered movement*; **3rd** *earthbind*, *one with stone*, *slow*; **2nd** *darkness*, *shatter*, *water walk*; **1st** *air bubble*, *tailwind*, *vanishing tracks*; **Cantrips (4th)** *caustic blast*, *detect magic*, *know the way*, *sigil*, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "petrify",
+          "aonid": 1628,
+          "game-obj": "Spells",
+          "name": "petrify",
+          "type": "link"
+        },
+        {
+          "alt": "tangling creepers",
+          "aonid": 1714,
+          "game-obj": "Spells",
+          "name": "tangling creepers",
+          "type": "link"
+        },
+        {
+          "alt": "impaling spike",
+          "aonid": 1571,
+          "game-obj": "Spells",
+          "name": "impaling spike",
+          "type": "link"
+        },
+        {
+          "alt": "magic passage",
+          "aonid": 1591,
+          "game-obj": "Spells",
+          "name": "magic passage",
+          "type": "link"
+        },
+        {
+          "alt": "speak with stones",
+          "aonid": 1682,
+          "game-obj": "Spells",
+          "name": "speak with stones",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Adamantine Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 108",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 108",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 108,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young adamantine dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 27,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "petrify",
+                      "aonid": 1628,
+                      "game-obj": "Spells",
+                      "name": "petrify",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "petrify",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangling creepers",
+                      "aonid": 1714,
+                      "game-obj": "Spells",
+                      "name": "tangling creepers",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangling creepers",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "impaling spike",
+                      "aonid": 1571,
+                      "game-obj": "Spells",
+                      "name": "impaling spike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "impaling spike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "magic passage",
+                      "aonid": 1591,
+                      "game-obj": "Spells",
+                      "name": "magic passage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "magic passage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "speak with stones",
+                      "aonid": 1682,
+                      "game-obj": "Spells",
+                      "name": "speak with stones",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "speak with stones",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "vapor form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 34, attack +27; As young adamantine dragon, plus **6th** *petrify*, *tangling creepers*; **5th** *impaling spike*, *magic passage*, *speak with stones*; **4th** vapor form; **Cantrips (6th)** *caustic blast*, *detect magic*, *know the way*, *sigil*, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "earthquake",
+          "aonid": 1507,
+          "game-obj": "Spells",
+          "name": "earthquake",
+          "type": "link"
+        },
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "moment of renewal",
+          "aonid": 1607,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "volcanic eruption",
+          "aonid": 1746,
+          "game-obj": "Spells",
+          "name": "volcanic eruption",
+          "type": "link"
+        },
+        {
+          "alt": "field of life",
+          "aonid": 1526,
+          "game-obj": "Spells",
+          "name": "field of life",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Adamantine Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 108",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 108",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 108,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult adamantine dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "earthquake",
+                      "aonid": 1507,
+                      "game-obj": "Spells",
+                      "name": "earthquake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "earthquake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 1607,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "volcanic eruption",
+                      "aonid": 1746,
+                      "game-obj": "Spells",
+                      "name": "volcanic eruption",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "volcanic eruption",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "field of life",
+                      "aonid": 1526,
+                      "game-obj": "Spells",
+                      "name": "field of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "field of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +36; As adult adamantine dragon, plus **8th** *earthquake*, *desiccate*, *moment of renewal*; **7th** *mask of terror*, *regenerate*, *volcanic eruption*; **6th** *field of life*; **Cantrips (8th)** *caustic blast*, *detect magic*, *know the way*, *sigil*, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        }
+      ],
+      "name": "Adamantine Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 108",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 108",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 108,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient adamantine dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 44, attack +36; As ancient adamantine dragon plus **9th** *implosion*, *falling stars*; **Cantrips (9th)** *caustic blast*, *detect magic*, *know the way*, sigil, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            }
+          ],
+          "name": "Cratering Smash",
+          "saving_throw": [
+            {
+              "dc": 20,
+              "subtype": "save_dc",
+              "text": "DC 20",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The dragon smashes itself into the ground, cratering the earth in a 10-foot deep, 60-foot wide emanation. Creatures in the area are thrown into the air and must attempt a Reflex save with a DC equal to the dragon's Avalanche Breath.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature lands on its feet.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "prone",
+              "aonid": 88,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature lands prone.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "damage": [
+            {
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature lands prone and takes 1d6 damage per every two levels of the dragon.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, and the dragon can make a jaws Strike against the creature as a free action. It can only attack one creature that critically failed its save.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 60,
+              "subtype": "area",
+              "text": "60-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "bludgeoning",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "Interact",
+              "aonid": 3259,
+              "game-obj": "Actions",
+              "name": "Interact",
+              "type": "link"
+            }
+          ],
+          "name": "Magnetic Roar",
+          "subtype": "ability",
+          "text": "With a mighty roar, the dragon attracts metal in a 60-foot emanation. Any unattended metal object of 1 Bulk or less flies to the dragon and sticks to their hide, granting a +2 item bonus to AC for 1 minute. Any creature holding a metal object of 1 Bulk or less must attempt at a Fortitude save with a DC equal to the dragon's Avalanche Breath DC or have their item pulled to the dragon and stuck for 1 round. A creature wearing metal armor instead must succeed at a Fortitude save against the DC + 2 or be pulled, taking 1d6 bludgeoning damage for every 10 feet it was moved, and become magnetically stuck to the dragon for 1 round. An object or creature can be unstuck with an Interact action.",
+          "traits": [
+            {
+              "link": {
+                "alt": "metal",
+                "aonid": 505,
+                "game-obj": "Traits",
+                "name": "metal",
+                "type": "link"
+              },
+              "name": "metal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Frightful Presence",
+              "aonid": 64,
+              "game-obj": "MonsterAbilities",
+              "name": "Frightful Presence",
+              "type": "link"
+            }
+          ],
+          "name": "Petrifying Blow",
+          "subtype": "ability",
+          "text": "The adamantine dragon's attacks can turn creatures into sculptures to add to their hoard. A creature critically hit by the dragon's claw or jaw Strike must attempt a Fortitude save with a DC equal to the dragon's Frightful Presence. On a successful save, the creature is temporarily immune for 1 minute.",
+          "traits": [
+            {
+              "link": {
+                "alt": "metal",
+                "aonid": 505,
+                "game-obj": "Traits",
+                "name": "metal",
+                "type": "link"
+              },
+              "name": "metal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "slowed",
+              "aonid": 92,
+              "game-obj": "Conditions",
+              "name": "slowed",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is slowed 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature is slowed 2.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "petrified",
+              "aonid": 87,
+              "game-obj": "Conditions",
+              "name": "petrified",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "The creature is petrified permanently into adamantine.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The dragon Flies and makes up to two claw attacks against different creatures along their flight.",
+          "frequency": "one per day",
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "Flies",
+              "aonid": 2312,
+              "game-obj": "Actions",
+              "name": "Flies",
+              "type": "link"
+            }
+          ],
+          "name": "Repelling Blast",
+          "requirement": "The dragon has their Speed increased by Abandon Armor",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "metal",
+                "aonid": 505,
+                "game-obj": "Traits",
+                "name": "metal",
+                "type": "link"
+              },
+              "name": "metal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "prone",
+          "aonid": 88,
+          "game-obj": "Conditions",
+          "name": "prone",
+          "type": "link"
+        },
+        {
+          "alt": "metal",
+          "aonid": 505,
+          "game-obj": "Traits",
+          "name": "metal",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "Interact",
+          "aonid": 3259,
+          "game-obj": "Actions",
+          "name": "Interact",
+          "type": "link"
+        },
+        {
+          "alt": "metal",
+          "aonid": 505,
+          "game-obj": "Traits",
+          "name": "metal",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "Frightful Presence",
+          "aonid": 64,
+          "game-obj": "MonsterAbilities",
+          "name": "Frightful Presence",
+          "type": "link"
+        },
+        {
+          "alt": "slowed",
+          "aonid": 92,
+          "game-obj": "Conditions",
+          "name": "slowed",
+          "type": "link"
+        },
+        {
+          "alt": "petrified",
+          "aonid": 87,
+          "game-obj": "Conditions",
+          "name": "petrified",
+          "type": "link"
+        },
+        {
+          "alt": "metal",
+          "aonid": 505,
+          "game-obj": "Traits",
+          "name": "metal",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "Flies",
+          "aonid": 2312,
+          "game-obj": "Actions",
+          "name": "Flies",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 108",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 108",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 108,
+          "type": "source"
+        }
+      ],
+      "text": "You can create a more unusual adamantine dragon by substituting any one of the following abilities for Burrowing Pounce, Draconic Frenzy, or Frightful Presence.   \n  \n**Cratering Smash** [##] The dragon smashes itself into the ground, cratering the earth in a 10-foot deep, 60-foot wide emanation. Creatures in the area are thrown into the air and must attempt a Reflex save with a DC equal to the dragon's Avalanche Breath.   \n**Critical Success** The creature lands on its feet.   \n**Success** The creature lands prone.   \n**Failure** The creature lands prone and takes 1d6 damage per every two levels of the dragon.   \n**Critical Failure** As failure, and the dragon can make a jaws Strike against the creature as a free action. It can only attack one creature that critically failed its save.   \n  \n**Magnetic Roar** [##] (metal, primal) With a mighty roar, the dragon attracts metal in a 60-foot emanation. Any unattended metal object of 1 Bulk or less flies to the dragon and sticks to their hide, granting a +2 item bonus to AC for 1 minute. Any creature holding a metal object of 1 Bulk or less must attempt at a Fortitude save with a DC equal to the dragon's Avalanche Breath DC or have their item pulled to the dragon and stuck for 1 round. A creature wearing metal armor instead must succeed at a Fortitude save against the DC + 2 or be pulled, taking 1d6 bludgeoning damage for every 10 feet it was moved, and become magnetically stuck to the dragon for 1 round. An object or creature can be unstuck with an Interact action.  \n  \n**Petrifying Blow** (metal, primal) The adamantine dragon's attacks can turn creatures into sculptures to add to their hoard. A creature critically hit by the dragon's claw or jaw Strike must attempt a Fortitude save with a DC equal to the dragon's Frightful Presence. On a successful save, the creature is temporarily immune for 1 minute.   \n**Critical Success** The creature is unaffected.   \n**Success** The creature is slowed 1.   \n**Failure** The creature is slowed 2.   \n**Critical Failure** The creature is petrified permanently into adamantine.   \n  \n**Repelling Blast** [##] (metal, primal); **Frequency** one per day; **Effect** The dragon expels scales from their body in a 50-foot emanation. Creatures in the area take slashing damage equal to the dragon's Avalanche Breath (with a basic Reflex save of the same DC). The dragon receives the modifiers of Abandon Armor regardless of their Hit Points until after a night of rest. Scything Wings [##] ; **Requirements** The dragon has their Speed increased by Abandon Armor; **Effect** The dragon Flies and makes up to two claw attacks against different creatures along their flight.",
       "type": "section"
     },
     {
@@ -1910,6 +2463,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 108",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 108",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 108,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -2071,6 +2687,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 108",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 108",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 108,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/dragon_conspirator.json
+++ b/monster_families/monster_core/dragon_conspirator.json
@@ -58,179 +58,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "quickened",
-                    "aonid": 89,
-                    "game-obj": "Conditions",
-                    "name": "quickened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Apex Paranoids",
-                "subtype": "ability",
-                "text": "Conspirator dragons fear more than any one of them would admit; holding power comes with the fear that power will be lost or stolen. The dragon has the quickened condition and can use the extra action only for Feint, Seek, and Sense Motive actions.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The dragon uses their mental blast against the triggering creature. On a critical hit, the mental effect is disrupted.",
-                "links": [
-                  {
-                    "alt": "mental",
-                    "aonid": 647,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mental Feedback",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "A creature uses a magical mental effect against the dragon",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "detection",
-                    "aonid": 574,
-                    "game-obj": "Traits",
-                    "name": "detection",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "revelation",
-                    "aonid": 686,
-                    "game-obj": "Traits",
-                    "name": "revelation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "scrying",
-                    "aonid": 689,
-                    "game-obj": "Traits",
-                    "name": "scrying",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteract",
-                    "aonid": 3280,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Obscure Revelations",
-                "subtype": "ability",
-                "text": "When the dragon is subject to a detection, revelation, or scrying effect, the GM rolls a secret counteract check with a counteract rank of half the dragon\u2019s level (rounded up) and a modifier equal to the dragon\u2019s Will. The dragon becomes aware of effects counteracted this way and their sources, then provides false information of its choosing.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "manipulate",
-                    "aonid": 645,
-                    "game-obj": "Traits",
-                    "name": "manipulate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "linguistic",
-                    "aonid": 642,
-                    "game-obj": "Traits",
-                    "name": "linguistic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Occult Whisperers",
-                "subtype": "ability",
-                "text": "After conversing with a creature for 10 minutes, the dragon can cast one of its occult innate spells targeting the creature by weaving it into the conversation. Spells cast in this way lose the manipulate trait and gain the linguistic trait.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -262,6 +94,97 @@
                 "game-obj": "Classes",
                 "name": "gunslinger",
                 "type": "link"
+              },
+              {
+                "alt": "quickened",
+                "aonid": 89,
+                "game-obj": "Conditions",
+                "name": "quickened",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "detection",
+                "aonid": 574,
+                "game-obj": "Traits",
+                "name": "detection",
+                "type": "link"
+              },
+              {
+                "alt": "revelation",
+                "aonid": 686,
+                "game-obj": "Traits",
+                "name": "revelation",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 689,
+                "game-obj": "Traits",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 3280,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "linguistic",
+                "aonid": 642,
+                "game-obj": "Traits",
+                "name": "linguistic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -271,272 +194,117 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Conspirator dragons often accrue a variety of talents in line with the story of their disguises, and more than any other dragon might choose to hone skills that serve them in their chosen guises at the cost of prowess in their draconic forms. Though most practice the art of subtle manipulation, a particularly brash dragon might play the part of a more physically violent puppet tyrant, content to openly leave power to simpering advisors while secretly manipulating their desires. Such a conspirator dragon might draw on abilities or feats from classes like the barbarian, fighter, swashbuckler, or even gunslinger to maintain the charade.   \n  \nMost conspirator dragons, however, spend their days among the societies of other ancestries as advisors, confidants, and other such roles that hold the ear of those in power; thus, it\u2019s most common to encounter conspirator dragons with affinities for diplomacy, planning, and subterfuge to better empower their designs. Such a conspirator dragon can easily be made by replacing their Draconic Frenzy, Retract Body, or Rushed Transformation abilities with one of the following options.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 19,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairaudience",
-                            "aonid": 1465,
-                            "game-obj": "Spells",
-                            "name": "clairaudience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairaudience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "paralyze",
-                            "aonid": 1622,
-                            "game-obj": "Spells",
-                            "name": "paralyze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "paralyze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "veil of privacy",
-                            "aonid": 1739,
-                            "game-obj": "Spells",
-                            "name": "veil of privacy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "veil of privacy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "calm",
-                            "aonid": 1458,
-                            "game-obj": "Spells",
-                            "name": "calm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "calm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "invisibility",
-                            "aonid": 1577,
-                            "game-obj": "Spells",
-                            "name": "invisibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "invisibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "paranoia",
-                            "aonid": 1623,
-                            "game-obj": "Spells",
-                            "name": "paranoia",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "paranoia",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bane",
-                            "aonid": 1447,
-                            "game-obj": "Spells",
-                            "name": "bane",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bane",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantom pain",
-                            "aonid": 1632,
-                            "game-obj": "Spells",
-                            "name": "phantom pain",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantom pain",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 1718,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Conspirator Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "clairaudience",
+                "aonid": 1465,
+                "game-obj": "Spells",
+                "name": "clairaudience",
+                "type": "link"
+              },
+              {
+                "alt": "paralyze",
+                "aonid": 1622,
+                "game-obj": "Spells",
+                "name": "paralyze",
+                "type": "link"
+              },
+              {
+                "alt": "veil of privacy",
+                "aonid": 1739,
+                "game-obj": "Spells",
+                "name": "veil of privacy",
+                "type": "link"
+              },
+              {
+                "alt": "calm",
+                "aonid": 1458,
+                "game-obj": "Spells",
+                "name": "calm",
+                "type": "link"
+              },
+              {
+                "alt": "invisibility",
+                "aonid": 1577,
+                "game-obj": "Spells",
+                "name": "invisibility",
+                "type": "link"
+              },
+              {
+                "alt": "paranoia",
+                "aonid": 1623,
+                "game-obj": "Spells",
+                "name": "paranoia",
+                "type": "link"
+              },
+              {
+                "alt": "bane",
+                "aonid": 1447,
+                "game-obj": "Spells",
+                "name": "bane",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "phantom pain",
+                "aonid": 1632,
+                "game-obj": "Spells",
+                "name": "phantom pain",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 1718,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -552,170 +320,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young conspirator dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scouting eye",
-                            "aonid": 1661,
-                            "game-obj": "Spells",
-                            "name": "scouting eye",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scouting eye",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "synaptic pulse",
-                            "aonid": 1710,
-                            "game-obj": "Spells",
-                            "name": "synaptic pulse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "synaptic pulse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairvoyance",
-                            "aonid": 1466,
-                            "game-obj": "Spells",
-                            "name": "clairvoyance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairvoyance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "honeyed words",
-                            "aonid": 1558,
-                            "game-obj": "Spells",
-                            "name": "honeyed words",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "honeyed words",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "suggestion",
-                            "aonid": 1693,
-                            "game-obj": "Spells",
-                            "name": "suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Conspirator Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "scouting eye",
+                "aonid": 1661,
+                "game-obj": "Spells",
+                "name": "scouting eye",
+                "type": "link"
+              },
+              {
+                "alt": "synaptic pulse",
+                "aonid": 1710,
+                "game-obj": "Spells",
+                "name": "synaptic pulse",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
+              },
+              {
+                "alt": "clairvoyance",
+                "aonid": 1466,
+                "game-obj": "Spells",
+                "name": "clairvoyance",
+                "type": "link"
+              },
+              {
+                "alt": "honeyed words",
+                "aonid": 1558,
+                "game-obj": "Spells",
+                "name": "honeyed words",
+                "type": "link"
+              },
+              {
+                "alt": "suggestion",
+                "aonid": 1693,
+                "game-obj": "Spells",
+                "name": "suggestion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -731,208 +384,69 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult conspirator dragon"
-                ],
-                "saving_throw": {
-                  "dc": 39,
-                  "subtype": "save_dc",
-                  "text": "DC 39",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unrelenting observation",
-                            "aonid": 1734,
-                            "game-obj": "Spells",
-                            "name": "unrelenting observation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unrelenting observation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "duplicate foe",
-                            "aonid": 1505,
-                            "game-obj": "Spells",
-                            "name": "duplicate foe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "duplicate foe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 1640,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "warp mind",
-                            "aonid": 1754,
-                            "game-obj": "Spells",
-                            "name": "warp mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "warp mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mislead",
-                            "aonid": 1605,
-                            "game-obj": "Spells",
-                            "name": "mislead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mislead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scrying",
-                            "aonid": 1662,
-                            "game-obj": "Spells",
-                            "name": "scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Conspirator Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "unrelenting observation",
+                "aonid": 1734,
+                "game-obj": "Spells",
+                "name": "unrelenting observation",
+                "type": "link"
+              },
+              {
+                "alt": "duplicate foe",
+                "aonid": 1505,
+                "game-obj": "Spells",
+                "name": "duplicate foe",
+                "type": "link"
+              },
+              {
+                "alt": "project image",
+                "aonid": 1640,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
+              },
+              {
+                "alt": "warp mind",
+                "aonid": 1754,
+                "game-obj": "Spells",
+                "name": "warp mind",
+                "type": "link"
+              },
+              {
+                "alt": "mislead",
+                "aonid": 1605,
+                "game-obj": "Spells",
+                "name": "mislead",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 1662,
+                "game-obj": "Spells",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -948,102 +462,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient conspirator dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telepathic demand",
-                            "aonid": 2036,
-                            "game-obj": "Spells",
-                            "name": "telepathic demand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telepathic demand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Conspirator Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
+              },
+              {
+                "alt": "telepathic demand",
+                "aonid": 2036,
+                "game-obj": "Spells",
+                "name": "telepathic demand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1058,48 +497,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1110,263 +512,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1376,7 +562,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1385,6 +570,321 @@
   "name": "Dragon, Conspirator",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "quickened",
+              "aonid": 89,
+              "game-obj": "Conditions",
+              "name": "quickened",
+              "type": "link"
+            }
+          ],
+          "name": "Apex Paranoids",
+          "subtype": "ability",
+          "text": "Conspirator dragons fear more than any one of them would admit; holding power comes with the fear that power will be lost or stolen. The dragon has the quickened condition and can use the extra action only for Feint, Seek, and Sense Motive actions.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The dragon uses their mental blast against the triggering creature. On a critical hit, the mental effect is disrupted.",
+          "links": [
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            }
+          ],
+          "name": "Mental Feedback",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "trigger": "A creature uses a magical mental effect against the dragon",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "detection",
+              "aonid": 574,
+              "game-obj": "Traits",
+              "name": "detection",
+              "type": "link"
+            },
+            {
+              "alt": "revelation",
+              "aonid": 686,
+              "game-obj": "Traits",
+              "name": "revelation",
+              "type": "link"
+            },
+            {
+              "alt": "scrying",
+              "aonid": 689,
+              "game-obj": "Traits",
+              "name": "scrying",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 3280,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            }
+          ],
+          "name": "Obscure Revelations",
+          "subtype": "ability",
+          "text": "When the dragon is subject to a detection, revelation, or scrying effect, the GM rolls a secret counteract check with a counteract rank of half the dragon\u2019s level (rounded up) and a modifier equal to the dragon\u2019s Will. The dragon becomes aware of effects counteracted this way and their sources, then provides false information of its choosing.",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "manipulate",
+              "aonid": 645,
+              "game-obj": "Traits",
+              "name": "manipulate",
+              "type": "link"
+            },
+            {
+              "alt": "linguistic",
+              "aonid": 642,
+              "game-obj": "Traits",
+              "name": "linguistic",
+              "type": "link"
+            }
+          ],
+          "name": "Occult Whisperers",
+          "subtype": "ability",
+          "text": "After conversing with a creature for 10 minutes, the dragon can cast one of its occult innate spells targeting the creature by weaving it into the conversation. Spells cast in this way lose the manipulate trait and gain the linguistic trait.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "barbarian",
+          "aonid": 57,
+          "game-obj": "Classes",
+          "name": "barbarian",
+          "type": "link"
+        },
+        {
+          "alt": "fighter",
+          "aonid": 35,
+          "game-obj": "Classes",
+          "name": "fighter",
+          "type": "link"
+        },
+        {
+          "alt": "swashbuckler",
+          "aonid": 63,
+          "game-obj": "Classes",
+          "name": "swashbuckler",
+          "type": "link"
+        },
+        {
+          "alt": "gunslinger",
+          "aonid": 20,
+          "game-obj": "Classes",
+          "name": "gunslinger",
+          "type": "link"
+        },
+        {
+          "alt": "quickened",
+          "aonid": 89,
+          "game-obj": "Conditions",
+          "name": "quickened",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "detection",
+          "aonid": 574,
+          "game-obj": "Traits",
+          "name": "detection",
+          "type": "link"
+        },
+        {
+          "alt": "revelation",
+          "aonid": 686,
+          "game-obj": "Traits",
+          "name": "revelation",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 689,
+          "game-obj": "Traits",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 3280,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 645,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "linguistic",
+          "aonid": 642,
+          "game-obj": "Traits",
+          "name": "linguistic",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 110",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 110",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 110,
+          "type": "source"
+        }
+      ],
+      "text": "Conspirator dragons often accrue a variety of talents in line with the story of their disguises, and more than any other dragon might choose to hone skills that serve them in their chosen guises at the cost of prowess in their draconic forms. Though most practice the art of subtle manipulation, a particularly brash dragon might play the part of a more physically violent puppet tyrant, content to openly leave power to simpering advisors while secretly manipulating their desires. Such a conspirator dragon might draw on abilities or feats from classes like the barbarian, fighter, swashbuckler, or even gunslinger to maintain the charade.   \n  \nMost conspirator dragons, however, spend their days among the societies of other ancestries as advisors, confidants, and other such roles that hold the ear of those in power; thus, it\u2019s most common to encounter conspirator dragons with affinities for diplomacy, planning, and subterfuge to better empower their designs. Such a conspirator dragon can easily be made by replacing their Draconic Frenzy, Retract Body, or Rushed Transformation abilities with one of the following options.   \n  \n**Apex Paranoids** Conspirator dragons fear more than any one of them would admit; holding power comes with the fear that power will be lost or stolen. The dragon has the quickened condition and can use the extra action only for Feint, Seek, and Sense Motive actions.   \n  \n**Mental Feedback** [@] (concentrate, emotion, mental, occult) **Trigger** A creature uses a magical mental effect against the dragon; **Effect** The dragon uses their mental blast against the triggering creature. On a critical hit, the mental effect is disrupted.  \n  \n**Obscure Revelations** (occult) When the dragon is subject to a detection, revelation, or scrying effect, the GM rolls a secret counteract check with a counteract rank of half the dragon\u2019s level (rounded up) and a modifier equal to the dragon\u2019s Will. The dragon becomes aware of effects counteracted this way and their sources, then provides false information of its choosing.   \n  \n**Occult Whisperers** After conversing with a creature for 10 minutes, the dragon can cast one of its occult innate spells targeting the creature by weaving it into the conversation. Spells cast in this way lose the manipulate trait and gain the linguistic trait.",
+      "type": "section"
+    },
     {
       "name": "Conspirator Dragon Lairs",
       "sources": [
@@ -1435,6 +935,1057 @@
         }
       ],
       "text": "Conspirator dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "clairaudience",
+          "aonid": 1465,
+          "game-obj": "Spells",
+          "name": "clairaudience",
+          "type": "link"
+        },
+        {
+          "alt": "paralyze",
+          "aonid": 1622,
+          "game-obj": "Spells",
+          "name": "paralyze",
+          "type": "link"
+        },
+        {
+          "alt": "veil of privacy",
+          "aonid": 1739,
+          "game-obj": "Spells",
+          "name": "veil of privacy",
+          "type": "link"
+        },
+        {
+          "alt": "calm",
+          "aonid": 1458,
+          "game-obj": "Spells",
+          "name": "calm",
+          "type": "link"
+        },
+        {
+          "alt": "invisibility",
+          "aonid": 1577,
+          "game-obj": "Spells",
+          "name": "invisibility",
+          "type": "link"
+        },
+        {
+          "alt": "paranoia",
+          "aonid": 1623,
+          "game-obj": "Spells",
+          "name": "paranoia",
+          "type": "link"
+        },
+        {
+          "alt": "bane",
+          "aonid": 1447,
+          "game-obj": "Spells",
+          "name": "bane",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "phantom pain",
+          "aonid": 1632,
+          "game-obj": "Spells",
+          "name": "phantom pain",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 1718,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Young Conspirator Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 110",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 110",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 110,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 19,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairaudience",
+                      "aonid": 1465,
+                      "game-obj": "Spells",
+                      "name": "clairaudience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairaudience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "paralyze",
+                      "aonid": 1622,
+                      "game-obj": "Spells",
+                      "name": "paralyze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "paralyze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "veil of privacy",
+                      "aonid": 1739,
+                      "game-obj": "Spells",
+                      "name": "veil of privacy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "veil of privacy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "calm",
+                      "aonid": 1458,
+                      "game-obj": "Spells",
+                      "name": "calm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "calm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "invisibility",
+                      "aonid": 1577,
+                      "game-obj": "Spells",
+                      "name": "invisibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "invisibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "paranoia",
+                      "aonid": 1623,
+                      "game-obj": "Spells",
+                      "name": "paranoia",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "paranoia",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bane",
+                      "aonid": 1447,
+                      "game-obj": "Spells",
+                      "name": "bane",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bane",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantom pain",
+                      "aonid": 1632,
+                      "game-obj": "Spells",
+                      "name": "phantom pain",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantom pain",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 1718,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 26, attack +19; **3rd** *clairaudience*, *paralyze*, *veil of privacy*; **2nd** *calm*, *invisibility*, *paranoia*; **1st** *bane*, *fear*, *phantom pain*; **Cantrips (3rd)** *daze*, *detect magic*, *figment*, *message*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "scouting eye",
+          "aonid": 1661,
+          "game-obj": "Spells",
+          "name": "scouting eye",
+          "type": "link"
+        },
+        {
+          "alt": "synaptic pulse",
+          "aonid": 1710,
+          "game-obj": "Spells",
+          "name": "synaptic pulse",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        },
+        {
+          "alt": "clairvoyance",
+          "aonid": 1466,
+          "game-obj": "Spells",
+          "name": "clairvoyance",
+          "type": "link"
+        },
+        {
+          "alt": "honeyed words",
+          "aonid": 1558,
+          "game-obj": "Spells",
+          "name": "honeyed words",
+          "type": "link"
+        },
+        {
+          "alt": "suggestion",
+          "aonid": 1693,
+          "game-obj": "Spells",
+          "name": "suggestion",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Conspirator Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 110",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 110",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 110,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young conspirator dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scouting eye",
+                      "aonid": 1661,
+                      "game-obj": "Spells",
+                      "name": "scouting eye",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scouting eye",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "synaptic pulse",
+                      "aonid": 1710,
+                      "game-obj": "Spells",
+                      "name": "synaptic pulse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "synaptic pulse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairvoyance",
+                      "aonid": 1466,
+                      "game-obj": "Spells",
+                      "name": "clairvoyance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairvoyance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "honeyed words",
+                      "aonid": 1558,
+                      "game-obj": "Spells",
+                      "name": "honeyed words",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "honeyed words",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "suggestion",
+                      "aonid": 1693,
+                      "game-obj": "Spells",
+                      "name": "suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 33, attack +26; As young conspirator dragon, plus **5th** *scouting eye*, *synaptic pulse*, *truespeech*; **4th** *clairvoyance*, *honeyed words*, *suggestion*; **Cantrips (5th)** *daze*, *detect magic*, *figment*, *message*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "unrelenting observation",
+          "aonid": 1734,
+          "game-obj": "Spells",
+          "name": "unrelenting observation",
+          "type": "link"
+        },
+        {
+          "alt": "duplicate foe",
+          "aonid": 1505,
+          "game-obj": "Spells",
+          "name": "duplicate foe",
+          "type": "link"
+        },
+        {
+          "alt": "project image",
+          "aonid": 1640,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        },
+        {
+          "alt": "warp mind",
+          "aonid": 1754,
+          "game-obj": "Spells",
+          "name": "warp mind",
+          "type": "link"
+        },
+        {
+          "alt": "mislead",
+          "aonid": 1605,
+          "game-obj": "Spells",
+          "name": "mislead",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 1662,
+          "game-obj": "Spells",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Conspirator Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 110",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 110",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 110,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult conspirator dragon"
+          ],
+          "saving_throw": {
+            "dc": 39,
+            "subtype": "save_dc",
+            "text": "DC 39",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unrelenting observation",
+                      "aonid": 1734,
+                      "game-obj": "Spells",
+                      "name": "unrelenting observation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unrelenting observation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "duplicate foe",
+                      "aonid": 1505,
+                      "game-obj": "Spells",
+                      "name": "duplicate foe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "duplicate foe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 1640,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "warp mind",
+                      "aonid": 1754,
+                      "game-obj": "Spells",
+                      "name": "warp mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "warp mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mislead",
+                      "aonid": 1605,
+                      "game-obj": "Spells",
+                      "name": "mislead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mislead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scrying",
+                      "aonid": 1662,
+                      "game-obj": "Spells",
+                      "name": "scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 39, attack +33; As adult conspirator dragon, plus **8th** *hidden mind*, *unrelenting observation*; **7th** *duplicate foe*, *project image*, *warp mind*; **6th** *mislead*, *scrying*, *truesight*; **Cantrips (8th)** *daze*, *detect magic*, *figment*, *message*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        },
+        {
+          "alt": "telepathic demand",
+          "aonid": 2036,
+          "game-obj": "Spells",
+          "name": "telepathic demand",
+          "type": "link"
+        }
+      ],
+      "name": "Conspirator Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 110",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 110",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 110,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient conspirator dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telepathic demand",
+                      "aonid": 2036,
+                      "game-obj": "Spells",
+                      "name": "telepathic demand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telepathic demand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 42, attack +34; As ancient conspirator dragon plus **9th** *phantasmagoria*, *telepathic demand*; **Cantrips (9th)** *daze*, *detect magic*, *figment*, *message*, *telekinetic projectile*",
       "type": "section"
     },
     {
@@ -1782,6 +2333,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 110",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 110",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 110,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1943,6 +2557,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 110",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 110",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 110,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/dragon_diabolic.json
+++ b/monster_families/monster_core/dragon_diabolic.json
@@ -67,206 +67,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Change Shape",
-                    "aonid": 55,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Change Shape",
-                    "type": "link"
-                  }
-                ],
-                "name": "Diabolic Disguise",
-                "subtype": "ability",
-                "text": "The dragon assumes the form of a specific creature whose soul gem or infernal contract is in their possession or hoard. This has the effects of Change Shape, except the dragon also gains perfunctory knowledge of the creature\u2019s personality, social connections, mannerisms, and surface memories, at the GM\u2019s discretion. Any knowledge the dragon gains by taking on another creature\u2019s form is lost when the dragon dismisses the effect or changes shape again, although nothing prevents them from recording it by other means while transformed.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "fire",
-                    "formula": "3d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "Sustained",
-                    "aonid": 2631,
-                    "game-obj": "Actions",
-                    "name": "Sustained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Infernal Rift",
-                "subtype": "ability",
-                "text": "The dragon uses their claw to tear open a rift to Phlegethon, the fourth layer of Hell. The rift measures 5 feet wide, 10 feet high, and up to 20 feet long, and can be Sustained for up to 1 minute. While the rift is open, any creature occupying its area or an adjacent square at the start of its turn takes 3d6 fire damage (+1 die for each dragon age category beyond young) and an equal amount of spirit damage with a basic Reflex save. The dragon can choose instead to open a rift to Cocytus, the frozen seventh layer of Hell, to replace this fire damage with cold damage, although it is still subject to the dragon\u2019s Diabolic Fire ability.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fire",
-                      "aonid": 604,
-                      "game-obj": "Traits",
-                      "name": "fire",
-                      "type": "link"
-                    },
-                    "name": "fire",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "unholy",
-                      "aonid": 521,
-                      "game-obj": "Traits",
-                      "name": "unholy",
-                      "type": "link"
-                    },
-                    "name": "unholy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The dragon attempts a counteract check with a Hell Lore check (counteract rank equal to half the dragon\u2019s level, rounded up). On a success, the dragon seizes control of the effect, causing it to fail and immediately casting a *summon fiend*  spell of the same rank (minimum 5th) as the triggering effect to summon a creature with the devil trait.",
-                "links": [
-                  {
-                    "alt": "counteract",
-                    "aonid": 3280,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Hell Lore",
-                    "aonid": 41,
-                    "game-obj": "Skills",
-                    "name": "Hell Lore",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "summon fiend",
-                    "aonid": 1701,
-                    "game-obj": "Spells",
-                    "name": "summon fiend",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "devil",
-                    "aonid": 575,
-                    "game-obj": "Traits",
-                    "name": "devil",
-                    "type": "link"
-                  }
-                ],
-                "name": "Intercept Summons",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "A creature within 30 feet uses magic to summon or conjure a creature",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -277,6 +82,104 @@
                 "game-obj": "Planes",
                 "name": "Hell",
                 "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 604,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "unholy",
+                "aonid": 521,
+                "game-obj": "Traits",
+                "name": "unholy",
+                "type": "link"
+              },
+              {
+                "alt": "Sustained",
+                "aonid": 2631,
+                "game-obj": "Actions",
+                "name": "Sustained",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 3280,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "Hell Lore",
+                "aonid": 41,
+                "game-obj": "Skills",
+                "name": "Hell Lore",
+                "type": "link"
+              },
+              {
+                "alt": "summon fiend",
+                "aonid": 1701,
+                "game-obj": "Spells",
+                "name": "summon fiend",
+                "type": "link"
+              },
+              {
+                "alt": "devil",
+                "aonid": 575,
+                "game-obj": "Traits",
+                "name": "devil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -286,310 +189,131 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "With the powers of Hell at their disposal, diabolic dragons can have a multitude of different abilities. You can apply the following adjustments to diabolic dragons of any age.  \n  \nSome diabolic dragons can steal the faces and memories of those whose souls they possess, wearing them as disguises with which to deceive potential victims. To make a dragon with this ability, replace frightful presence with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispelling globe",
-                            "aonid": 1494,
-                            "game-obj": "Spells",
-                            "name": "dispelling globe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispelling globe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine wrath",
-                            "aonid": 1499,
-                            "game-obj": "Spells",
-                            "name": "divine wrath",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine wrath",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar tether",
-                            "aonid": 1636,
-                            "game-obj": "Spells",
-                            "name": "planar tether",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar tether",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blindness",
-                            "aonid": 1453,
-                            "game-obj": "Spells",
-                            "name": "blindness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blindness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chilling darkness",
-                            "aonid": 1464,
-                            "game-obj": "Spells",
-                            "name": "chilling darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chilling darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "harm",
-                            "aonid": 1552,
-                            "game-obj": "Spells",
-                            "name": "harm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "harm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blood vendetta",
-                            "aonid": 1454,
-                            "game-obj": "Spells",
-                            "name": "blood vendetta",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blood vendetta",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "darkness",
-                            "aonid": 1480,
-                            "game-obj": "Spells",
-                            "name": "darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translate",
-                            "aonid": 1723,
-                            "game-obj": "Spells",
-                            "name": "translate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count_text": "\u00d72",
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 1498,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "void warp",
-                            "aonid": 1745,
-                            "game-obj": "Spells",
-                            "name": "void warp",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Diabolic Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispelling globe",
+                "aonid": 1494,
+                "game-obj": "Spells",
+                "name": "dispelling globe",
+                "type": "link"
+              },
+              {
+                "alt": "divine wrath",
+                "aonid": 1499,
+                "game-obj": "Spells",
+                "name": "divine wrath",
+                "type": "link"
+              },
+              {
+                "alt": "planar tether",
+                "aonid": 1636,
+                "game-obj": "Spells",
+                "name": "planar tether",
+                "type": "link"
+              },
+              {
+                "alt": "blindness",
+                "aonid": 1453,
+                "game-obj": "Spells",
+                "name": "blindness",
+                "type": "link"
+              },
+              {
+                "alt": "chilling darkness",
+                "aonid": 1464,
+                "game-obj": "Spells",
+                "name": "chilling darkness",
+                "type": "link"
+              },
+              {
+                "alt": "harm",
+                "aonid": 1552,
+                "game-obj": "Spells",
+                "name": "harm",
+                "type": "link"
+              },
+              {
+                "alt": "blood vendetta",
+                "aonid": 1454,
+                "game-obj": "Spells",
+                "name": "blood vendetta",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "translate",
+                "aonid": 1723,
+                "game-obj": "Spells",
+                "name": "translate",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 1498,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "void warp",
+                "aonid": 1745,
+                "game-obj": "Spells",
+                "name": "void warp",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -605,170 +329,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young diabolic dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blessed boundary",
-                            "aonid": 1452,
-                            "game-obj": "Spells",
-                            "name": "blessed boundary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blessed boundary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dominate",
-                            "aonid": 1501,
-                            "game-obj": "Spells",
-                            "name": "dominate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dominate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translocate",
-                            "aonid": 1724,
-                            "game-obj": "Spells",
-                            "name": "translocate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translocate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Diabolic Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "blessed boundary",
+                "aonid": 1452,
+                "game-obj": "Spells",
+                "name": "blessed boundary",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
+              },
+              {
+                "alt": "translocate",
+                "aonid": 1724,
+                "game-obj": "Spells",
+                "name": "translocate",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -784,214 +393,69 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult diabolic dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "harm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wails of the damned",
-                            "aonid": 1747,
-                            "game-obj": "Spells",
-                            "name": "wails of the damned",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wails of the damned",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "canticle of everlasting grief",
-                            "aonid": 1459,
-                            "game-obj": "Spells",
-                            "name": "canticle of everlasting grief",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "canticle of everlasting grief",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "execute",
-                            "aonid": 1519,
-                            "game-obj": "Spells",
-                            "name": "execute",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "execute",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "eclipse burst",
-                            "aonid": 1508,
-                            "game-obj": "Spells",
-                            "name": "eclipse burst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "eclipse burst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar seal",
-                            "aonid": 1635,
-                            "game-obj": "Spells",
-                            "name": "planar seal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar seal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Diabolic Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
+              },
+              {
+                "alt": "wails of the damned",
+                "aonid": 1747,
+                "game-obj": "Spells",
+                "name": "wails of the damned",
+                "type": "link"
+              },
+              {
+                "alt": "canticle of everlasting grief",
+                "aonid": 1459,
+                "game-obj": "Spells",
+                "name": "canticle of everlasting grief",
+                "type": "link"
+              },
+              {
+                "alt": "execute",
+                "aonid": 1519,
+                "game-obj": "Spells",
+                "name": "execute",
+                "type": "link"
+              },
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
+              },
+              {
+                "alt": "eclipse burst",
+                "aonid": 1508,
+                "game-obj": "Spells",
+                "name": "eclipse burst",
+                "type": "link"
+              },
+              {
+                "alt": "planar seal",
+                "aonid": 1635,
+                "game-obj": "Spells",
+                "name": "planar seal",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1007,102 +471,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As ancient diabolic dragon"
-                ],
-                "saving_throw": {
-                  "dc": 46,
-                  "subtype": "save_dc",
-                  "text": "DC 46",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "indestructibility",
-                            "aonid": 1573,
-                            "game-obj": "Spells",
-                            "name": "indestructibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "indestructibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Diabolic Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
+              },
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1117,48 +506,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1169,263 +521,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1435,7 +571,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1444,6 +579,334 @@
   "name": "Dragon, Diabolic",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            }
+          ],
+          "name": "Diabolic Disguise",
+          "subtype": "ability",
+          "text": "The dragon assumes the form of a specific creature whose soul gem or infernal contract is in their possession or hoard. This has the effects of Change Shape, except the dragon also gains perfunctory knowledge of the creature\u2019s personality, social connections, mannerisms, and surface memories, at the GM\u2019s discretion. Any knowledge the dragon gains by taking on another creature\u2019s form is lost when the dragon dismisses the effect or changes shape again, although nothing prevents them from recording it by other means while transformed.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "fire",
+              "formula": "3d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Sustained",
+              "aonid": 2631,
+              "game-obj": "Actions",
+              "name": "Sustained",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Infernal Rift",
+          "subtype": "ability",
+          "text": "The dragon uses their claw to tear open a rift to Phlegethon, the fourth layer of Hell. The rift measures 5 feet wide, 10 feet high, and up to 20 feet long, and can be Sustained for up to 1 minute. While the rift is open, any creature occupying its area or an adjacent square at the start of its turn takes 3d6 fire damage (+1 die for each dragon age category beyond young) and an equal amount of spirit damage with a basic Reflex save. The dragon can choose instead to open a rift to Cocytus, the frozen seventh layer of Hell, to replace this fire damage with cold damage, although it is still subject to the dragon\u2019s Diabolic Fire ability.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fire",
+                "aonid": 604,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              "name": "fire",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "unholy",
+                "aonid": 521,
+                "game-obj": "Traits",
+                "name": "unholy",
+                "type": "link"
+              },
+              "name": "unholy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The dragon attempts a counteract check with a Hell Lore check (counteract rank equal to half the dragon\u2019s level, rounded up). On a success, the dragon seizes control of the effect, causing it to fail and immediately casting a *summon fiend*  spell of the same rank (minimum 5th) as the triggering effect to summon a creature with the devil trait.",
+          "links": [
+            {
+              "alt": "counteract",
+              "aonid": 3280,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            },
+            {
+              "alt": "Hell Lore",
+              "aonid": 41,
+              "game-obj": "Skills",
+              "name": "Hell Lore",
+              "type": "link"
+            },
+            {
+              "alt": "summon fiend",
+              "aonid": 1701,
+              "game-obj": "Spells",
+              "name": "summon fiend",
+              "type": "link"
+            },
+            {
+              "alt": "devil",
+              "aonid": 575,
+              "game-obj": "Traits",
+              "name": "devil",
+              "type": "link"
+            }
+          ],
+          "name": "Intercept Summons",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "trigger": "A creature within 30 feet uses magic to summon or conjure a creature",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Hell",
+          "aonid": 42,
+          "game-obj": "Planes",
+          "name": "Hell",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "Change Shape",
+          "aonid": 55,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "fire",
+          "aonid": 604,
+          "game-obj": "Traits",
+          "name": "fire",
+          "type": "link"
+        },
+        {
+          "alt": "unholy",
+          "aonid": 521,
+          "game-obj": "Traits",
+          "name": "unholy",
+          "type": "link"
+        },
+        {
+          "alt": "Sustained",
+          "aonid": 2631,
+          "game-obj": "Actions",
+          "name": "Sustained",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 2297,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 3280,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        },
+        {
+          "alt": "Hell Lore",
+          "aonid": 41,
+          "game-obj": "Skills",
+          "name": "Hell Lore",
+          "type": "link"
+        },
+        {
+          "alt": "summon fiend",
+          "aonid": 1701,
+          "game-obj": "Spells",
+          "name": "summon fiend",
+          "type": "link"
+        },
+        {
+          "alt": "devil",
+          "aonid": 575,
+          "game-obj": "Traits",
+          "name": "devil",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 112",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 112",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 112,
+          "type": "source"
+        }
+      ],
+      "text": "With the powers of Hell at their disposal, diabolic dragons can have a multitude of different abilities. You can apply the following adjustments to diabolic dragons of any age.  \n  \nSome diabolic dragons can steal the faces and memories of those whose souls they possess, wearing them as disguises with which to deceive potential victims. To make a dragon with this ability, replace frightful presence with the following.   \n  \n**Diabolic Disguise** [#] (concentrate, divine, polymorph) The dragon assumes the form of a specific creature whose soul gem or infernal contract is in their possession or hoard. This has the effects of Change Shape, except the dragon also gains perfunctory knowledge of the creature\u2019s personality, social connections, mannerisms, and surface memories, at the GM\u2019s discretion. Any knowledge the dragon gains by taking on another creature\u2019s form is lost when the dragon dismisses the effect or changes shape again, although nothing prevents them from recording it by other means while transformed.  \n  \nDiabolic dragons with a flair for sorcery can sunder the fabric between the Universe and the depths of Hell with a mere gesture. To make a dragon with this ability, replace Draconic Frenzy with the following.  \n  \n**Infernal Rift** [###] (divine, fire, unholy) The dragon uses their claw to tear open a rift to Phlegethon, the fourth layer of Hell. The rift measures 5 feet wide, 10 feet high, and up to 20 feet long, and can be Sustained for up to 1 minute. While the rift is open, any creature occupying its area or an adjacent square at the start of its turn takes 3d6 fire damage (+1 die for each dragon age category beyond young) and an equal amount of spirit damage with a basic Reflex save. The dragon can choose instead to open a rift to Cocytus, the frozen seventh layer of Hell, to replace this fire damage with cold damage, although it is still subject to the dragon\u2019s Diabolic Fire ability.  \n  \nDiabolic dragons with exceptional mastery of devilish pacts and interplanar summoning can replace spellcasters\u2019 conjured minions with their own. To make a dragon with this ability, replace Hell\u2019s Sting with the following.  \n  \n**Intercept Summons** [@] (concentrate) **Trigger** A creature within 30 feet uses magic to summon or conjure a creature; **Effect** The dragon attempts a counteract check with a Hell Lore check (counteract rank equal to half the dragon\u2019s level, rounded up). On a success, the dragon seizes control of the effect, causing it to fail and immediately casting a *summon fiend*  spell of the same rank (minimum 5th) as the triggering effect to summon a creature with the devil trait.",
+      "type": "section"
+    },
     {
       "name": "Azhadar",
       "sources": [
@@ -1520,6 +983,1115 @@
         }
       ],
       "text": "Diabolic dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispelling globe",
+          "aonid": 1494,
+          "game-obj": "Spells",
+          "name": "dispelling globe",
+          "type": "link"
+        },
+        {
+          "alt": "divine wrath",
+          "aonid": 1499,
+          "game-obj": "Spells",
+          "name": "divine wrath",
+          "type": "link"
+        },
+        {
+          "alt": "planar tether",
+          "aonid": 1636,
+          "game-obj": "Spells",
+          "name": "planar tether",
+          "type": "link"
+        },
+        {
+          "alt": "blindness",
+          "aonid": 1453,
+          "game-obj": "Spells",
+          "name": "blindness",
+          "type": "link"
+        },
+        {
+          "alt": "chilling darkness",
+          "aonid": 1464,
+          "game-obj": "Spells",
+          "name": "chilling darkness",
+          "type": "link"
+        },
+        {
+          "alt": "harm",
+          "aonid": 1552,
+          "game-obj": "Spells",
+          "name": "harm",
+          "type": "link"
+        },
+        {
+          "alt": "blood vendetta",
+          "aonid": 1454,
+          "game-obj": "Spells",
+          "name": "blood vendetta",
+          "type": "link"
+        },
+        {
+          "alt": "darkness",
+          "aonid": 1480,
+          "game-obj": "Spells",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "translate",
+          "aonid": 1723,
+          "game-obj": "Spells",
+          "name": "translate",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 1498,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "void warp",
+          "aonid": 1745,
+          "game-obj": "Spells",
+          "name": "void warp",
+          "type": "link"
+        }
+      ],
+      "name": "Young Diabolic Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 112",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 112",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 112,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispelling globe",
+                      "aonid": 1494,
+                      "game-obj": "Spells",
+                      "name": "dispelling globe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispelling globe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine wrath",
+                      "aonid": 1499,
+                      "game-obj": "Spells",
+                      "name": "divine wrath",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine wrath",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar tether",
+                      "aonid": 1636,
+                      "game-obj": "Spells",
+                      "name": "planar tether",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar tether",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blindness",
+                      "aonid": 1453,
+                      "game-obj": "Spells",
+                      "name": "blindness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blindness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chilling darkness",
+                      "aonid": 1464,
+                      "game-obj": "Spells",
+                      "name": "chilling darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chilling darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "harm",
+                      "aonid": 1552,
+                      "game-obj": "Spells",
+                      "name": "harm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "harm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blood vendetta",
+                      "aonid": 1454,
+                      "game-obj": "Spells",
+                      "name": "blood vendetta",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blood vendetta",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "darkness",
+                      "aonid": 1480,
+                      "game-obj": "Spells",
+                      "name": "darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translate",
+                      "aonid": 1723,
+                      "game-obj": "Spells",
+                      "name": "translate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count_text": "\u00d72",
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 1498,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "void warp",
+                      "aonid": 1745,
+                      "game-obj": "Spells",
+                      "name": "void warp",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 30, attack +24; **4th** *dispelling globe*, *divine wrath*, *planar tether*; **3rd** *blindness*, *chilling darkness*, *harm*; **2nd** *blood vendetta*, *darkness*, *translate*; **1st** *command* (\u00d72), *fear*; **Cantrips (4th)** *detect magic*, *divine lance*, *message*, *sigil*, *void warp*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "blessed boundary",
+          "aonid": 1452,
+          "game-obj": "Spells",
+          "name": "blessed boundary",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        },
+        {
+          "alt": "translocate",
+          "aonid": 1724,
+          "game-obj": "Spells",
+          "name": "translocate",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Diabolic Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 112",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 112",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 112,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young diabolic dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blessed boundary",
+                      "aonid": 1452,
+                      "game-obj": "Spells",
+                      "name": "blessed boundary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blessed boundary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dominate",
+                      "aonid": 1501,
+                      "game-obj": "Spells",
+                      "name": "dominate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dominate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translocate",
+                      "aonid": 1724,
+                      "game-obj": "Spells",
+                      "name": "translocate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translocate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 36, attack +30; As young diabolic dragon, plus **6th** *banishment*, *blessed boundary*, *dominate*; **5th** *sending*, *translocate*, *truespeech*; **Cantrips (6th)** *detect magic*, *divine lance*, *message*, *sigil*, *void warp*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        },
+        {
+          "alt": "wails of the damned",
+          "aonid": 1747,
+          "game-obj": "Spells",
+          "name": "wails of the damned",
+          "type": "link"
+        },
+        {
+          "alt": "canticle of everlasting grief",
+          "aonid": 1459,
+          "game-obj": "Spells",
+          "name": "canticle of everlasting grief",
+          "type": "link"
+        },
+        {
+          "alt": "execute",
+          "aonid": 1519,
+          "game-obj": "Spells",
+          "name": "execute",
+          "type": "link"
+        },
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        },
+        {
+          "alt": "eclipse burst",
+          "aonid": 1508,
+          "game-obj": "Spells",
+          "name": "eclipse burst",
+          "type": "link"
+        },
+        {
+          "alt": "planar seal",
+          "aonid": 1635,
+          "game-obj": "Spells",
+          "name": "planar seal",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Diabolic Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 112",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 112",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 112,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult diabolic dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "harm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wails of the damned",
+                      "aonid": 1747,
+                      "game-obj": "Spells",
+                      "name": "wails of the damned",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wails of the damned",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "canticle of everlasting grief",
+                      "aonid": 1459,
+                      "game-obj": "Spells",
+                      "name": "canticle of everlasting grief",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "canticle of everlasting grief",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "execute",
+                      "aonid": 1519,
+                      "game-obj": "Spells",
+                      "name": "execute",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "execute",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "eclipse burst",
+                      "aonid": 1508,
+                      "game-obj": "Spells",
+                      "name": "eclipse burst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "eclipse burst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar seal",
+                      "aonid": 1635,
+                      "game-obj": "Spells",
+                      "name": "planar seal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar seal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 42, attack +38; As adult diabolic dragon, plus **9th** *harm*, *massacre*, *wails of the damned*; **8th** *canticle of everlasting grief*, *execute*, *pinpoint*; **7th** *eclipse burst*, *planar seal*, *truespeech*; **Cantrips (9th)** *detect magic*, *divine lance*, *message*, *sigil*, *void warp*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        },
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        }
+      ],
+      "name": "Diabolic Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 112",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 112",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 112,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As ancient diabolic dragon"
+          ],
+          "saving_throw": {
+            "dc": 46,
+            "subtype": "save_dc",
+            "text": "DC 46",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "indestructibility",
+                      "aonid": 1573,
+                      "game-obj": "Spells",
+                      "name": "indestructibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "indestructibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 46, attack +38; As ancient diabolic dragon plus **10th** *indestructibility*, *massacre*; **Cantrips (10th)** *detect magic*, *divine lance*, *message*, *sigil*, *void warp*",
       "type": "section"
     },
     {
@@ -1841,6 +2413,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 112",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 112",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 112,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -2002,6 +2637,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 112",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 112",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 112,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/dragon_empyreal.json
+++ b/monster_families/monster_core/dragon_empyreal.json
@@ -81,171 +81,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The dragon\u2019s halo imposes itself in front of the creature like a shield, transferring the damage to the dragon. If the damage is void, the dragon gains resistance to that damage equal to half its level.",
-                "links": [
-                  {
-                    "alt": "resistance",
-                    "aonid": 2318,
-                    "game-obj": "Rules",
-                    "name": "resistance",
-                    "type": "link"
-                  }
-                ],
-                "name": "Sacrificial Shield",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "An ally within 60 feet of the dragon would take damage",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Restorative Halo",
-                "subtype": "ability",
-                "text": "The dragon\u2019s halo divides into smaller halos, hovering over up to six creatures of the dragon\u2019s choice within its inspiring presence aura. Creatures wearing a halo gain fast healing equal to half the dragon\u2019s level for 1 minute. The dragon cannot use other abilities of its halo while other creatures wear it, and they can Dismiss the effect for any or all affected creatures.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "fire",
-                    "formula": "1d10",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "fire",
-                    "formula": "1d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "persistent fire damage.",
-                    "aonid": 86,
-                    "game-obj": "Conditions",
-                    "name": "persistent fire damage.",
-                    "type": "link"
-                  }
-                ],
-                "name": "Wreath of Holy Light",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The dragon imbues its allies with heavenly fire. Creatures within 60 feet of the dragon gain the holy trait and their Strikes do an additional 1d10 fire damage for 1 minute. If the creature critically Strikes an enemy, the enemy is also set on fire and takes 1d6 persistent fire damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "holy",
-                      "aonid": 517,
-                      "game-obj": "Traits",
-                      "name": "holy",
-                      "type": "link"
-                    },
-                    "name": "holy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -256,6 +96,62 @@
                 "game-obj": "Traits",
                 "name": "celestial",
                 "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "resistance",
+                "aonid": 2318,
+                "game-obj": "Rules",
+                "name": "resistance",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "holy",
+                "aonid": 517,
+                "game-obj": "Traits",
+                "name": "holy",
+                "type": "link"
+              },
+              {
+                "alt": "persistent fire damage.",
+                "aonid": 86,
+                "game-obj": "Conditions",
+                "name": "persistent fire damage.",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -265,325 +161,138 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Empyreal dragons found on the celestial planes might have their own unique abilities. You can apply the following adjustments to empyreal dragons of any age.  \n  \nEmpyreal dragons understand that they sometimes need to make a sacrifice to protect others. To make a dragon with this ability, replace Divine Deflection with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vital beacon",
-                            "aonid": 1743,
-                            "game-obj": "Spells",
-                            "name": "vital beacon",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vital beacon",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bind undead",
-                            "aonid": 1449,
-                            "game-obj": "Spells",
-                            "name": "bind undead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bind undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ring of truth",
-                            "aonid": 1656,
-                            "game-obj": "Spells",
-                            "name": "ring of truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ring of truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sound body",
-                            "aonid": 1679,
-                            "game-obj": "Spells",
-                            "name": "sound body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sound body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "everlight",
-                            "aonid": 1518,
-                            "game-obj": "Spells",
-                            "name": "everlight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "everlight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "share life",
-                            "aonid": 1669,
-                            "game-obj": "Spells",
-                            "name": "share life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "share life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bless",
-                            "aonid": 1451,
-                            "game-obj": "Spells",
-                            "name": "bless",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bless",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mending",
-                            "aonid": 1597,
-                            "game-obj": "Spells",
-                            "name": "mending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sanctuary",
-                            "aonid": 1660,
-                            "game-obj": "Spells",
-                            "name": "sanctuary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sanctuary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": ") detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine lance",
-                            "aonid": 1498,
-                            "game-obj": "Spells",
-                            "name": "divine lance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 1689,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Empyreal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "vital beacon",
+                "aonid": 1743,
+                "game-obj": "Spells",
+                "name": "vital beacon",
+                "type": "link"
+              },
+              {
+                "alt": "bind undead",
+                "aonid": 1449,
+                "game-obj": "Spells",
+                "name": "bind undead",
+                "type": "link"
+              },
+              {
+                "alt": "ring of truth",
+                "aonid": 1656,
+                "game-obj": "Spells",
+                "name": "ring of truth",
+                "type": "link"
+              },
+              {
+                "alt": "sound body",
+                "aonid": 1679,
+                "game-obj": "Spells",
+                "name": "sound body",
+                "type": "link"
+              },
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "everlight",
+                "aonid": 1518,
+                "game-obj": "Spells",
+                "name": "everlight",
+                "type": "link"
+              },
+              {
+                "alt": "share life",
+                "aonid": 1669,
+                "game-obj": "Spells",
+                "name": "share life",
+                "type": "link"
+              },
+              {
+                "alt": "bless",
+                "aonid": 1451,
+                "game-obj": "Spells",
+                "name": "bless",
+                "type": "link"
+              },
+              {
+                "alt": "mending",
+                "aonid": 1597,
+                "game-obj": "Spells",
+                "name": "mending",
+                "type": "link"
+              },
+              {
+                "alt": "sanctuary",
+                "aonid": 1660,
+                "game-obj": "Spells",
+                "name": "sanctuary",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 1498,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 1689,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -599,170 +308,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young empyreal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "field of life",
-                            "aonid": 1526,
-                            "game-obj": "Spells",
-                            "name": "field of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "field of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit blast",
-                            "aonid": 1685,
-                            "game-obj": "Spells",
-                            "name": "spirit blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "breath of life",
-                            "aonid": 1456,
-                            "game-obj": "Spells",
-                            "name": "breath of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "breath of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Empyreal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "field of life",
+                "aonid": 1526,
+                "game-obj": "Spells",
+                "name": "field of life",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "spirit blast",
+                "aonid": 1685,
+                "game-obj": "Spells",
+                "name": "spirit blast",
+                "type": "link"
+              },
+              {
+                "alt": "breath of life",
+                "aonid": 1456,
+                "game-obj": "Spells",
+                "name": "breath of life",
+                "type": "link"
+              },
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -778,223 +372,76 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As adult empyreal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 35,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine decree",
-                            "aonid": 1495,
-                            "game-obj": "Spells",
-                            "name": "divine decree",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine decree",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sunburst",
-                            "aonid": 1707,
-                            "game-obj": "Spells",
-                            "name": "sunburst",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sunburst",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "divine inspiration",
-                            "aonid": 1497,
-                            "game-obj": "Spells",
-                            "name": "divine inspiration",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "divine inspiration",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 1607,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar seal",
-                            "aonid": 1635,
-                            "game-obj": "Spells",
-                            "name": "planar seal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar seal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Empyreal Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine decree",
+                "aonid": 1495,
+                "game-obj": "Spells",
+                "name": "divine decree",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "sunburst",
+                "aonid": 1707,
+                "game-obj": "Spells",
+                "name": "sunburst",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "divine inspiration",
+                "aonid": 1497,
+                "game-obj": "Spells",
+                "name": "divine inspiration",
+                "type": "link"
+              },
+              {
+                "alt": "moment of renewal",
+                "aonid": 1607,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "planar seal",
+                "aonid": 1635,
+                "game-obj": "Spells",
+                "name": "planar seal",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1010,102 +457,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As ancient empyreal dragon"
-                ],
-                "saving_throw": {
-                  "dc": 46,
-                  "subtype": "save_dc",
-                  "text": "DC 46",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gate",
-                            "aonid": 1540,
-                            "game-obj": "Spells",
-                            "name": "gate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revival",
-                            "aonid": 1654,
-                            "game-obj": "Spells",
-                            "name": "revival",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revival",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "divine lance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Empyreal Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "gate",
+                "aonid": 1540,
+                "game-obj": "Spells",
+                "name": "gate",
+                "type": "link"
+              },
+              {
+                "alt": "revival",
+                "aonid": 1654,
+                "game-obj": "Spells",
+                "name": "revival",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1120,48 +492,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1172,263 +507,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1438,7 +557,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1447,6 +565,257 @@
   "name": "Dragon, Empyreal",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The dragon\u2019s halo imposes itself in front of the creature like a shield, transferring the damage to the dragon. If the damage is void, the dragon gains resistance to that damage equal to half its level.",
+          "links": [
+            {
+              "alt": "resistance",
+              "aonid": 2318,
+              "game-obj": "Rules",
+              "name": "resistance",
+              "type": "link"
+            }
+          ],
+          "name": "Sacrificial Shield",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "trigger": "An ally within 60 feet of the dragon would take damage",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Restorative Halo",
+          "subtype": "ability",
+          "text": "The dragon\u2019s halo divides into smaller halos, hovering over up to six creatures of the dragon\u2019s choice within its inspiring presence aura. Creatures wearing a halo gain fast healing equal to half the dragon\u2019s level for 1 minute. The dragon cannot use other abilities of its halo while other creatures wear it, and they can Dismiss the effect for any or all affected creatures.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "fire",
+              "formula": "1d10",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            },
+            {
+              "damage_type": "fire",
+              "formula": "1d6",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "persistent fire damage.",
+              "aonid": 86,
+              "game-obj": "Conditions",
+              "name": "persistent fire damage.",
+              "type": "link"
+            }
+          ],
+          "name": "Wreath of Holy Light",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "within 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The dragon imbues its allies with heavenly fire. Creatures within 60 feet of the dragon gain the holy trait and their Strikes do an additional 1d10 fire damage for 1 minute. If the creature critically Strikes an enemy, the enemy is also set on fire and takes 1d6 persistent fire damage.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "holy",
+                "aonid": 517,
+                "game-obj": "Traits",
+                "name": "holy",
+                "type": "link"
+              },
+              "name": "holy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "celestial",
+          "aonid": 551,
+          "game-obj": "Traits",
+          "name": "celestial",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "resistance",
+          "aonid": 2318,
+          "game-obj": "Rules",
+          "name": "resistance",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "holy",
+          "aonid": 517,
+          "game-obj": "Traits",
+          "name": "holy",
+          "type": "link"
+        },
+        {
+          "alt": "persistent fire damage.",
+          "aonid": 86,
+          "game-obj": "Conditions",
+          "name": "persistent fire damage.",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 114",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 114",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 114,
+          "type": "source"
+        }
+      ],
+      "text": "Empyreal dragons found on the celestial planes might have their own unique abilities. You can apply the following adjustments to empyreal dragons of any age.  \n  \nEmpyreal dragons understand that they sometimes need to make a sacrifice to protect others. To make a dragon with this ability, replace Divine Deflection with the following.  \n  \n**Sacrificial Shield** [@] (divine) **Trigger** An ally within 60 feet of the dragon would take damage; **Effect** The dragon\u2019s halo imposes itself in front of the creature like a shield, transferring the damage to the dragon. If the damage is void, the dragon gains resistance to that damage equal to half its level.   \n  \nEmpyreal dragons who fight alongside mortals when the forces of evil are on the march can empower their allies. To make a dragon with either of these abilities, replace Draconic Frenzy with one of the following.  \n  \n**Restorative Halo** [##] (concentrate, divine) The dragon\u2019s halo divides into smaller halos, hovering over up to six creatures of the dragon\u2019s choice within its inspiring presence aura. Creatures wearing a halo gain fast healing equal to half the dragon\u2019s level for 1 minute. The dragon cannot use other abilities of its halo while other creatures wear it, and they can Dismiss the effect for any or all affected creatures.   \n  \n**Wreath of Holy Light** [##] (concentrate, divine, holy) The dragon imbues its allies with heavenly fire. Creatures within 60 feet of the dragon gain the holy trait and their Strikes do an additional 1d10 fire damage for 1 minute. If the creature critically Strikes an enemy, the enemy is also set on fire and takes 1d6 persistent fire damage.",
+      "type": "section"
+    },
     {
       "links": [
         {
@@ -1506,6 +875,1153 @@
         }
       ],
       "text": "Empyreal dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "vital beacon",
+          "aonid": 1743,
+          "game-obj": "Spells",
+          "name": "vital beacon",
+          "type": "link"
+        },
+        {
+          "alt": "bind undead",
+          "aonid": 1449,
+          "game-obj": "Spells",
+          "name": "bind undead",
+          "type": "link"
+        },
+        {
+          "alt": "ring of truth",
+          "aonid": 1656,
+          "game-obj": "Spells",
+          "name": "ring of truth",
+          "type": "link"
+        },
+        {
+          "alt": "sound body",
+          "aonid": 1679,
+          "game-obj": "Spells",
+          "name": "sound body",
+          "type": "link"
+        },
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "everlight",
+          "aonid": 1518,
+          "game-obj": "Spells",
+          "name": "everlight",
+          "type": "link"
+        },
+        {
+          "alt": "share life",
+          "aonid": 1669,
+          "game-obj": "Spells",
+          "name": "share life",
+          "type": "link"
+        },
+        {
+          "alt": "bless",
+          "aonid": 1451,
+          "game-obj": "Spells",
+          "name": "bless",
+          "type": "link"
+        },
+        {
+          "alt": "mending",
+          "aonid": 1597,
+          "game-obj": "Spells",
+          "name": "mending",
+          "type": "link"
+        },
+        {
+          "alt": "sanctuary",
+          "aonid": 1660,
+          "game-obj": "Spells",
+          "name": "sanctuary",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 1498,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 1689,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Young Empyreal Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 114",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 114",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 114,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vital beacon",
+                      "aonid": 1743,
+                      "game-obj": "Spells",
+                      "name": "vital beacon",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vital beacon",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bind undead",
+                      "aonid": 1449,
+                      "game-obj": "Spells",
+                      "name": "bind undead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bind undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ring of truth",
+                      "aonid": 1656,
+                      "game-obj": "Spells",
+                      "name": "ring of truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ring of truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sound body",
+                      "aonid": 1679,
+                      "game-obj": "Spells",
+                      "name": "sound body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sound body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "everlight",
+                      "aonid": 1518,
+                      "game-obj": "Spells",
+                      "name": "everlight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "everlight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "share life",
+                      "aonid": 1669,
+                      "game-obj": "Spells",
+                      "name": "share life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "share life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bless",
+                      "aonid": 1451,
+                      "game-obj": "Spells",
+                      "name": "bless",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bless",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mending",
+                      "aonid": 1597,
+                      "game-obj": "Spells",
+                      "name": "mending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sanctuary",
+                      "aonid": 1660,
+                      "game-obj": "Spells",
+                      "name": "sanctuary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sanctuary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": ") detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine lance",
+                      "aonid": 1498,
+                      "game-obj": "Spells",
+                      "name": "divine lance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 1689,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 29, attack +22; **4th** *dispel magic*, *unfettered movement*, *vital beacon*; **3rd** *bind undead*, *ring of truth*, *sound body*; **2nd** *clear mind*, *everlight*, *share life*; **1st** *bless*, *mending*, *sanctuary*; **Cantrips (4th**) *detect magic*, *divine lance*, *guidance*, *shield*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "field of life",
+          "aonid": 1526,
+          "game-obj": "Spells",
+          "name": "field of life",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "spirit blast",
+          "aonid": 1685,
+          "game-obj": "Spells",
+          "name": "spirit blast",
+          "type": "link"
+        },
+        {
+          "alt": "breath of life",
+          "aonid": 1456,
+          "game-obj": "Spells",
+          "name": "breath of life",
+          "type": "link"
+        },
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Empyreal Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 114",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 114",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 114,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young empyreal dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "field of life",
+                      "aonid": 1526,
+                      "game-obj": "Spells",
+                      "name": "field of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "field of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit blast",
+                      "aonid": 1685,
+                      "game-obj": "Spells",
+                      "name": "spirit blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "breath of life",
+                      "aonid": 1456,
+                      "game-obj": "Spells",
+                      "name": "breath of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "breath of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 34, attack +28; As young empyreal dragon, plus **6th** *field of life*, *dispel magic*, *spirit blast*; **5th** *breath of life*, *clear mind*, *sending*; **Cantrips (6th)** *detect magic*, *divine lance*, *guidance*, *shield*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "divine decree",
+          "aonid": 1495,
+          "game-obj": "Spells",
+          "name": "divine decree",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "sunburst",
+          "aonid": 1707,
+          "game-obj": "Spells",
+          "name": "sunburst",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "divine inspiration",
+          "aonid": 1497,
+          "game-obj": "Spells",
+          "name": "divine inspiration",
+          "type": "link"
+        },
+        {
+          "alt": "moment of renewal",
+          "aonid": 1607,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "planar seal",
+          "aonid": 1635,
+          "game-obj": "Spells",
+          "name": "planar seal",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Empyreal Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 114",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 114",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 114,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As adult empyreal dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 35,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine decree",
+                      "aonid": 1495,
+                      "game-obj": "Spells",
+                      "name": "divine decree",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine decree",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sunburst",
+                      "aonid": 1707,
+                      "game-obj": "Spells",
+                      "name": "sunburst",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sunburst",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "divine inspiration",
+                      "aonid": 1497,
+                      "game-obj": "Spells",
+                      "name": "divine inspiration",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "divine inspiration",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 1607,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar seal",
+                      "aonid": 1635,
+                      "game-obj": "Spells",
+                      "name": "planar seal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar seal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 41, attack +35; As adult empyreal dragon, plus **9th** *divine decree*, *overwhelming presence*, *sunburst*; **8th** *dispel magic*, *divine inspiration*, *moment of renewal*; **7th** *energy aegis*, *planar seal*, *regenerate*; **Cantrips (9th)** *detect magic*, *divine lance*, *guidance*, *shield*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "gate",
+          "aonid": 1540,
+          "game-obj": "Spells",
+          "name": "gate",
+          "type": "link"
+        },
+        {
+          "alt": "revival",
+          "aonid": 1654,
+          "game-obj": "Spells",
+          "name": "revival",
+          "type": "link"
+        }
+      ],
+      "name": "Empyreal Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 114",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 114",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 114,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As ancient empyreal dragon"
+          ],
+          "saving_throw": {
+            "dc": 46,
+            "subtype": "save_dc",
+            "text": "DC 46",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gate",
+                      "aonid": 1540,
+                      "game-obj": "Spells",
+                      "name": "gate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revival",
+                      "aonid": 1654,
+                      "game-obj": "Spells",
+                      "name": "revival",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revival",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "divine lance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 46, attack +38; As ancient empyreal dragon plus **10th** *gate*, *revival*; **Cantrips (10th)** *detect magic*, *divine lance*, *guidance*, *shield*, *stabilize*",
       "type": "section"
     },
     {
@@ -1862,6 +2378,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 114",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 114",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 114,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -2023,6 +2602,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 114",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 114",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 114,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/dragon_fortune.json
+++ b/monster_families/monster_core/dragon_fortune.json
@@ -58,146 +58,91 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "acid",
-                    "aonid": 524,
-                    "game-obj": "Traits",
-                    "name": "acid",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "cold",
-                    "aonid": 555,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "electricity",
-                    "aonid": 586,
-                    "game-obj": "Traits",
-                    "name": "electricity",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fire",
-                    "aonid": 604,
-                    "game-obj": "Traits",
-                    "name": "fire",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "void",
-                    "aonid": 510,
-                    "game-obj": "Traits",
-                    "name": "void",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "vitality",
-                    "aonid": 509,
-                    "game-obj": "Traits",
-                    "name": "vitality",
-                    "type": "link"
-                  }
-                ],
-                "name": "Chimeric Nature",
-                "subtype": "ability",
-                "text": "When the fortune dragon makes a Strike or uses its Disruptive Breath, it can choose acid, cold, electricity, fire, poison, void, or vitality. Its Strike deals an additional 1d6 damage of that type instead of additional force damage, and its Disruptive Breath deals that type of damage instead of force damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The dragon retreats inside of a pile of riches to restore their energy. They Hide within their pile of riches, using it as greater cover. The dragon regains one expended spontaneous spell slot. In addition, their Shield of Fortune regains Hit Points equal to the dragon\u2019s level.",
-                "links": [
-                  {
-                    "alt": "Hide",
-                    "aonid": 2404,
-                    "game-obj": "Actions",
-                    "name": "Hide",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "cover",
-                    "aonid": 2372,
-                    "game-obj": "Rules",
-                    "name": "cover",
-                    "type": "link"
-                  }
-                ],
-                "name": "Hidden Wealth",
-                "requirement": "The dragon is adjacent to their hoard",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Shield Block",
-                    "aonid": 75,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Shield Block",
-                    "type": "link"
-                  }
-                ],
-                "name": "Shield of Fortune",
-                "subtype": "ability",
-                "text": "The dragon adjusts the treasure around their body to function as a kind of shield. They gain a +2 circumstance bonus to AC until the beginning of their next turn and can use the Shield Block reaction. The shield has Hardness, Hit Points, and BT of a sturdy shield of the dragon\u2019s level. When it is broken, it triggers the effect of the dragon\u2019s Share the Wealth ability.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "acid",
+                "aonid": 524,
+                "game-obj": "Traits",
+                "name": "acid",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 555,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "electricity",
+                "aonid": 586,
+                "game-obj": "Traits",
+                "name": "electricity",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 604,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "Hide",
+                "aonid": 2404,
+                "game-obj": "Actions",
+                "name": "Hide",
+                "type": "link"
+              },
+              {
+                "alt": "cover",
+                "aonid": 2372,
+                "game-obj": "Rules",
+                "name": "cover",
+                "type": "link"
+              },
+              {
+                "alt": "Shield Block",
+                "aonid": 75,
+                "game-obj": "MonsterAbilities",
+                "name": "Shield Block",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -207,325 +152,138 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Fortune dragons collect all manner of different treasures, which they can use to their advantage. You can apply the following adjustments to a fortune dragon of any age.   \n  \nMorbid fortune dragons might collect artifacts made from the bodies of other dragons, incorporating teeth, scales, and claws into the items attached to their bodies. This grants them the power to draw upon the magic of those deceased dragons. To make a dragon with this ability, replace Draconic Frenzy with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "flicker",
-                            "aonid": 1532,
-                            "game-obj": "Spells",
-                            "name": "flicker",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "flicker",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translocate",
-                            "aonid": 1724,
-                            "game-obj": "Spells",
-                            "name": "translocate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translocate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vision of death",
-                            "aonid": 1742,
-                            "game-obj": "Spells",
-                            "name": "vision of death",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vision of death",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "aqueous orb",
-                            "aonid": 1443,
-                            "game-obj": "Spells",
-                            "name": "aqueous orb",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "aqueous orb",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grease",
-                            "aonid": 1547,
-                            "game-obj": "Spells",
-                            "name": "grease",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grease",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "invisibility",
-                            "aonid": 1577,
-                            "game-obj": "Spells",
-                            "name": "invisibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "invisibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "web",
-                            "aonid": 374,
-                            "game-obj": "Spells",
-                            "name": "web",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "web",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gust of wind",
-                            "aonid": 1550,
-                            "game-obj": "Spells",
-                            "name": "gust of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gust of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "item facade",
-                            "aonid": 1579,
-                            "game-obj": "Spells",
-                            "name": "item facade",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "item facade",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal minion",
-                            "aonid": 1631,
-                            "game-obj": "Spells",
-                            "name": "phantasmal minion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal minion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 1509,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Fortune Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "flicker",
+                "aonid": 1532,
+                "game-obj": "Spells",
+                "name": "flicker",
+                "type": "link"
+              },
+              {
+                "alt": "translocate",
+                "aonid": 1724,
+                "game-obj": "Spells",
+                "name": "translocate",
+                "type": "link"
+              },
+              {
+                "alt": "vision of death",
+                "aonid": 1742,
+                "game-obj": "Spells",
+                "name": "vision of death",
+                "type": "link"
+              },
+              {
+                "alt": "aqueous orb",
+                "aonid": 1443,
+                "game-obj": "Spells",
+                "name": "aqueous orb",
+                "type": "link"
+              },
+              {
+                "alt": "grease",
+                "aonid": 1547,
+                "game-obj": "Spells",
+                "name": "grease",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "invisibility",
+                "aonid": 1577,
+                "game-obj": "Spells",
+                "name": "invisibility",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "web",
+                "aonid": 374,
+                "game-obj": "Spells",
+                "name": "web",
+                "type": "link"
+              },
+              {
+                "alt": "gust of wind",
+                "aonid": 1550,
+                "game-obj": "Spells",
+                "name": "gust of wind",
+                "type": "link"
+              },
+              {
+                "alt": "item facade",
+                "aonid": 1579,
+                "game-obj": "Spells",
+                "name": "item facade",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal minion",
+                "aonid": 1631,
+                "game-obj": "Spells",
+                "name": "phantasmal minion",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 1509,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -541,170 +299,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young fortune dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cursed metamorphosis",
-                            "aonid": 1479,
-                            "game-obj": "Spells",
-                            "name": "cursed metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cursed metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "teleport",
-                            "aonid": 1720,
-                            "game-obj": "Spells",
-                            "name": "teleport",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "teleport",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of force",
-                            "aonid": 1749,
-                            "game-obj": "Spells",
-                            "name": "wall of force",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of force",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "howling blizzard",
-                            "aonid": 1559,
-                            "game-obj": "Spells",
-                            "name": "howling blizzard",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "howling blizzard",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scouting eye",
-                            "aonid": 1661,
-                            "game-obj": "Spells",
-                            "name": "scouting eye",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scouting eye",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Fortune Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cursed metamorphosis",
+                "aonid": 1479,
+                "game-obj": "Spells",
+                "name": "cursed metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "teleport",
+                "aonid": 1720,
+                "game-obj": "Spells",
+                "name": "teleport",
+                "type": "link"
+              },
+              {
+                "alt": "wall of force",
+                "aonid": 1749,
+                "game-obj": "Spells",
+                "name": "wall of force",
+                "type": "link"
+              },
+              {
+                "alt": "howling blizzard",
+                "aonid": 1559,
+                "game-obj": "Spells",
+                "name": "howling blizzard",
+                "type": "link"
+              },
+              {
+                "alt": "scouting eye",
+                "aonid": 1661,
+                "game-obj": "Spells",
+                "name": "scouting eye",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -720,223 +363,76 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult fortune dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "arctic rift",
-                            "aonid": 1444,
-                            "game-obj": "Spells",
-                            "name": "arctic rift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "arctic rift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 1490,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "uncontrollable dance",
-                            "aonid": 1730,
-                            "game-obj": "Spells",
-                            "name": "uncontrollable dance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "uncontrollable dance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "contingency",
-                            "aonid": 1472,
-                            "game-obj": "Spells",
-                            "name": "contingency",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "contingency",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar palace",
-                            "aonid": 1634,
-                            "game-obj": "Spells",
-                            "name": "planar palace",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar palace",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Fortune Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
+              },
+              {
+                "alt": "arctic rift",
+                "aonid": 1444,
+                "game-obj": "Spells",
+                "name": "arctic rift",
+                "type": "link"
+              },
+              {
+                "alt": "disappearance",
+                "aonid": 1490,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "uncontrollable dance",
+                "aonid": 1730,
+                "game-obj": "Spells",
+                "name": "uncontrollable dance",
+                "type": "link"
+              },
+              {
+                "alt": "contingency",
+                "aonid": 1472,
+                "game-obj": "Spells",
+                "name": "contingency",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "planar palace",
+                "aonid": 1634,
+                "game-obj": "Spells",
+                "name": "planar palace",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -952,102 +448,27 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As ancient fortune dragon"
-                ],
-                "saving_throw": {
-                  "dc": 50,
-                  "subtype": "save_dc",
-                  "text": "DC 50",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 42,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "indestructibility",
-                            "aonid": 1573,
-                            "game-obj": "Spells",
-                            "name": "indestructibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "indestructibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "remake",
-                            "aonid": 1649,
-                            "game-obj": "Spells",
-                            "name": "remake",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "remake",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Fortune Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
+              },
+              {
+                "alt": "remake",
+                "aonid": 1649,
+                "game-obj": "Spells",
+                "name": "remake",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1062,48 +483,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1114,263 +498,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1380,7 +548,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1389,6 +556,245 @@
   "name": "Dragon, Fortune",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "acid",
+              "aonid": 524,
+              "game-obj": "Traits",
+              "name": "acid",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 555,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "electricity",
+              "aonid": 586,
+              "game-obj": "Traits",
+              "name": "electricity",
+              "type": "link"
+            },
+            {
+              "alt": "fire",
+              "aonid": 604,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "void",
+              "aonid": 510,
+              "game-obj": "Traits",
+              "name": "void",
+              "type": "link"
+            },
+            {
+              "alt": "vitality",
+              "aonid": 509,
+              "game-obj": "Traits",
+              "name": "vitality",
+              "type": "link"
+            }
+          ],
+          "name": "Chimeric Nature",
+          "subtype": "ability",
+          "text": "When the fortune dragon makes a Strike or uses its Disruptive Breath, it can choose acid, cold, electricity, fire, poison, void, or vitality. Its Strike deals an additional 1d6 damage of that type instead of additional force damage, and its Disruptive Breath deals that type of damage instead of force damage.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The dragon retreats inside of a pile of riches to restore their energy. They Hide within their pile of riches, using it as greater cover. The dragon regains one expended spontaneous spell slot. In addition, their Shield of Fortune regains Hit Points equal to the dragon\u2019s level.",
+          "links": [
+            {
+              "alt": "Hide",
+              "aonid": 2404,
+              "game-obj": "Actions",
+              "name": "Hide",
+              "type": "link"
+            },
+            {
+              "alt": "cover",
+              "aonid": 2372,
+              "game-obj": "Rules",
+              "name": "cover",
+              "type": "link"
+            }
+          ],
+          "name": "Hidden Wealth",
+          "requirement": "The dragon is adjacent to their hoard",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "Shield Block",
+              "aonid": 75,
+              "game-obj": "MonsterAbilities",
+              "name": "Shield Block",
+              "type": "link"
+            }
+          ],
+          "name": "Shield of Fortune",
+          "subtype": "ability",
+          "text": "The dragon adjusts the treasure around their body to function as a kind of shield. They gain a +2 circumstance bonus to AC until the beginning of their next turn and can use the Shield Block reaction. The shield has Hardness, Hit Points, and BT of a sturdy shield of the dragon\u2019s level. When it is broken, it triggers the effect of the dragon\u2019s Share the Wealth ability.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "acid",
+          "aonid": 524,
+          "game-obj": "Traits",
+          "name": "acid",
+          "type": "link"
+        },
+        {
+          "alt": "cold",
+          "aonid": 555,
+          "game-obj": "Traits",
+          "name": "cold",
+          "type": "link"
+        },
+        {
+          "alt": "electricity",
+          "aonid": 586,
+          "game-obj": "Traits",
+          "name": "electricity",
+          "type": "link"
+        },
+        {
+          "alt": "fire",
+          "aonid": 604,
+          "game-obj": "Traits",
+          "name": "fire",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        },
+        {
+          "alt": "vitality",
+          "aonid": 509,
+          "game-obj": "Traits",
+          "name": "vitality",
+          "type": "link"
+        },
+        {
+          "alt": "Hide",
+          "aonid": 2404,
+          "game-obj": "Actions",
+          "name": "Hide",
+          "type": "link"
+        },
+        {
+          "alt": "cover",
+          "aonid": 2372,
+          "game-obj": "Rules",
+          "name": "cover",
+          "type": "link"
+        },
+        {
+          "alt": "Shield Block",
+          "aonid": 75,
+          "game-obj": "MonsterAbilities",
+          "name": "Shield Block",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 116",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 116",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 116,
+          "type": "source"
+        }
+      ],
+      "text": "Fortune dragons collect all manner of different treasures, which they can use to their advantage. You can apply the following adjustments to a fortune dragon of any age.   \n  \nMorbid fortune dragons might collect artifacts made from the bodies of other dragons, incorporating teeth, scales, and claws into the items attached to their bodies. This grants them the power to draw upon the magic of those deceased dragons. To make a dragon with this ability, replace Draconic Frenzy with the following.   \n  \n**Chimeric Nature** (arcane) When the fortune dragon makes a Strike or uses its Disruptive Breath, it can choose acid, cold, electricity, fire, poison, void, or vitality. Its Strike deals an additional 1d6 damage of that type instead of additional force damage, and its Disruptive Breath deals that type of damage instead of force damage.  \n  \nInstead of relying on the magical power of the items in their hoard, some fortune dragons use their treasure to form protective shells. Such dragons are usually found only at the heart of their lairs, surrounded by the bulk of their hoard. To make a dragon with this ability, replace Capture Spell and Treasure Dive with the following.   \n  \n**Hidden Wealth** [##] **Requirements** The dragon is adjacent to their hoard; **Effect** The dragon retreats inside of a pile of riches to restore their energy. They Hide within their pile of riches, using it as greater cover. The dragon regains one expended spontaneous spell slot. In addition, their Shield of Fortune regains Hit Points equal to the dragon\u2019s level.   \n  \n**Shield of Fortune** [#] The dragon adjusts the treasure around their body to function as a kind of shield. They gain a +2 circumstance bonus to AC until the beginning of their next turn and can use the Shield Block reaction. The shield has Hardness, Hit Points, and BT of a sturdy shield of the dragon\u2019s level. When it is broken, it triggers the effect of the dragon\u2019s Share the Wealth ability.",
+      "type": "section"
+    },
     {
       "name": "Fortune Dragon Lairs",
       "sources": [
@@ -1439,6 +845,1153 @@
         }
       ],
       "text": "Fortune dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "flicker",
+          "aonid": 1532,
+          "game-obj": "Spells",
+          "name": "flicker",
+          "type": "link"
+        },
+        {
+          "alt": "translocate",
+          "aonid": 1724,
+          "game-obj": "Spells",
+          "name": "translocate",
+          "type": "link"
+        },
+        {
+          "alt": "vision of death",
+          "aonid": 1742,
+          "game-obj": "Spells",
+          "name": "vision of death",
+          "type": "link"
+        },
+        {
+          "alt": "aqueous orb",
+          "aonid": 1443,
+          "game-obj": "Spells",
+          "name": "aqueous orb",
+          "type": "link"
+        },
+        {
+          "alt": "grease",
+          "aonid": 1547,
+          "game-obj": "Spells",
+          "name": "grease",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "invisibility",
+          "aonid": 1577,
+          "game-obj": "Spells",
+          "name": "invisibility",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "web",
+          "aonid": 374,
+          "game-obj": "Spells",
+          "name": "web",
+          "type": "link"
+        },
+        {
+          "alt": "gust of wind",
+          "aonid": 1550,
+          "game-obj": "Spells",
+          "name": "gust of wind",
+          "type": "link"
+        },
+        {
+          "alt": "item facade",
+          "aonid": 1579,
+          "game-obj": "Spells",
+          "name": "item facade",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal minion",
+          "aonid": 1631,
+          "game-obj": "Spells",
+          "name": "phantasmal minion",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 1509,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Young Fortune Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 116",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 116",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 116,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "flicker",
+                      "aonid": 1532,
+                      "game-obj": "Spells",
+                      "name": "flicker",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "flicker",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translocate",
+                      "aonid": 1724,
+                      "game-obj": "Spells",
+                      "name": "translocate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translocate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vision of death",
+                      "aonid": 1742,
+                      "game-obj": "Spells",
+                      "name": "vision of death",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vision of death",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "aqueous orb",
+                      "aonid": 1443,
+                      "game-obj": "Spells",
+                      "name": "aqueous orb",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "aqueous orb",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grease",
+                      "aonid": 1547,
+                      "game-obj": "Spells",
+                      "name": "grease",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grease",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "invisibility",
+                      "aonid": 1577,
+                      "game-obj": "Spells",
+                      "name": "invisibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "invisibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "web",
+                      "aonid": 374,
+                      "game-obj": "Spells",
+                      "name": "web",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "web",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gust of wind",
+                      "aonid": 1550,
+                      "game-obj": "Spells",
+                      "name": "gust of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gust of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "item facade",
+                      "aonid": 1579,
+                      "game-obj": "Spells",
+                      "name": "item facade",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "item facade",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal minion",
+                      "aonid": 1631,
+                      "game-obj": "Spells",
+                      "name": "phantasmal minion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal minion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 1509,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 30, attack +22; **4th** *flicker*, *translocate*, *vision of death*; **3rd** *aqueous orb*, *grease*, *haste*; **2nd** *invisibility*, *mist*, *web*; **1st** *gust of wind*, *item facade*, *phantasmal minion*; **Cantrips (4th)** *electric arc*, *figment*, *prestidigitation*, *shield*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cursed metamorphosis",
+          "aonid": 1479,
+          "game-obj": "Spells",
+          "name": "cursed metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "teleport",
+          "aonid": 1720,
+          "game-obj": "Spells",
+          "name": "teleport",
+          "type": "link"
+        },
+        {
+          "alt": "wall of force",
+          "aonid": 1749,
+          "game-obj": "Spells",
+          "name": "wall of force",
+          "type": "link"
+        },
+        {
+          "alt": "howling blizzard",
+          "aonid": 1559,
+          "game-obj": "Spells",
+          "name": "howling blizzard",
+          "type": "link"
+        },
+        {
+          "alt": "scouting eye",
+          "aonid": 1661,
+          "game-obj": "Spells",
+          "name": "scouting eye",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Fortune Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 116",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 116",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 116,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young fortune dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cursed metamorphosis",
+                      "aonid": 1479,
+                      "game-obj": "Spells",
+                      "name": "cursed metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cursed metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "teleport",
+                      "aonid": 1720,
+                      "game-obj": "Spells",
+                      "name": "teleport",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "teleport",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of force",
+                      "aonid": 1749,
+                      "game-obj": "Spells",
+                      "name": "wall of force",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of force",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "howling blizzard",
+                      "aonid": 1559,
+                      "game-obj": "Spells",
+                      "name": "howling blizzard",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "howling blizzard",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scouting eye",
+                      "aonid": 1661,
+                      "game-obj": "Spells",
+                      "name": "scouting eye",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scouting eye",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 36, attack +28; As young fortune dragon, plus **6th** *cursed metamorphosis*, *teleport*, *wall of force*; **5th** *howling blizzard*, *scouting eye*, *toxic cloud*; **Cantrips (6th)** *electric arc*, *figment*, *prestidigitation*, *shield*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        },
+        {
+          "alt": "arctic rift",
+          "aonid": 1444,
+          "game-obj": "Spells",
+          "name": "arctic rift",
+          "type": "link"
+        },
+        {
+          "alt": "disappearance",
+          "aonid": 1490,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "uncontrollable dance",
+          "aonid": 1730,
+          "game-obj": "Spells",
+          "name": "uncontrollable dance",
+          "type": "link"
+        },
+        {
+          "alt": "contingency",
+          "aonid": 1472,
+          "game-obj": "Spells",
+          "name": "contingency",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "planar palace",
+          "aonid": 1634,
+          "game-obj": "Spells",
+          "name": "planar palace",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Fortune Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 116",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 116",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 116,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult fortune dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "arctic rift",
+                      "aonid": 1444,
+                      "game-obj": "Spells",
+                      "name": "arctic rift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "arctic rift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 1490,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "uncontrollable dance",
+                      "aonid": 1730,
+                      "game-obj": "Spells",
+                      "name": "uncontrollable dance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "uncontrollable dance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "contingency",
+                      "aonid": 1472,
+                      "game-obj": "Spells",
+                      "name": "contingency",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "contingency",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar palace",
+                      "aonid": 1634,
+                      "game-obj": "Spells",
+                      "name": "planar palace",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar palace",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 45, attack +37; As adult fortune dragon, plus **9th** *detonate magic*, *falling stars*, *phantasmagoria*; **8th** *arctic rift*, *disappearance*, *uncontrollable dance*; **7th** *contingency*, *energy aegis*, *planar palace*; **Cantrips (9th)** *electric arc*, *figment*, *prestidigitation*, *shield*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        },
+        {
+          "alt": "remake",
+          "aonid": 1649,
+          "game-obj": "Spells",
+          "name": "remake",
+          "type": "link"
+        }
+      ],
+      "name": "Fortune Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 116",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 116",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 116,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As ancient fortune dragon"
+          ],
+          "saving_throw": {
+            "dc": 50,
+            "subtype": "save_dc",
+            "text": "DC 50",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 42,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "indestructibility",
+                      "aonid": 1573,
+                      "game-obj": "Spells",
+                      "name": "indestructibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "indestructibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "remake",
+                      "aonid": 1649,
+                      "game-obj": "Spells",
+                      "name": "remake",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "remake",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 50, attack +42; As ancient fortune dragon plus **10th** *indestructibility*, *remake*; **Cantrips (10th)** *electric arc*, *figment*, *prestidigitation*, *shield*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -1786,6 +2339,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 116",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 116",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 116,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1947,6 +2563,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 116",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 116",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 116,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/dragon_horned.json
+++ b/monster_families/monster_core/dragon_horned.json
@@ -64,161 +64,63 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "temporary Hit Points",
-                    "aonid": 2321,
-                    "game-obj": "Rules",
-                    "name": "temporary Hit Points",
-                    "type": "link"
-                  }
-                ],
-                "name": "Invigorating Spores",
-                "subtype": "ability",
-                "text": "The dragon contorts, ejecting spores from a variety of multicolored fungi covering its limbs. The spores drift toward the dragon\u2019s snout and invigorate it. The dragon gains temporary Hit Points equal to its level that last 10 minutes. The dragon also gains resistance to bludgeoning, slashing, and piercing damage equal to half its level until the end of its next turn. The dragon can\u2019t use Invigorating Spores again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 645,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The dragon hurls a fragment of its horn at a target within 40 feet. The target takes the same damage as the dragon\u2019s horn Strike and must attempt a Reflex save.",
-                "frequency": "once per round",
-                "name": "Horn Projectile",
-                "range": {
-                  "range": 40,
-                  "subtype": "range",
-                  "text": "within 40 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The target takes no damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The target takes half damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The target takes full damage and is immobilized as the horn fragment pins them to the nearest surface.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "bleed",
-                    "formula": "2d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, but the target takes double damage and 2d6 persistent bleed damage as the fragment pierces their body.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "communication",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 1501,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "animal",
-                    "aonid": 531,
-                    "game-obj": "Traits",
-                    "name": "animal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Draconic",
-                    "aonid": 156,
-                    "game-obj": "Languages",
-                    "name": "Draconic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "controlled",
-                    "aonid": 64,
-                    "game-obj": "Conditions",
-                    "name": "controlled",
-                    "type": "link"
-                  }
-                ],
-                "name": "Apex Dominance",
-                "subtype": "ability",
-                "text": "When the dragon casts *dominate* on a creature with the animal trait, the result of the target\u2019s saving throw is one degree of success worse. An animal the dragon controls with this spell can speak Draconic and gains a +2 status bonus to any Intelligence-, Wisdom-, and Charisma-based skill checks it attempts while controlled.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "temporary Hit Points",
+                "aonid": 2321,
+                "game-obj": "Rules",
+                "name": "temporary Hit Points",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "animal",
+                "aonid": 531,
+                "game-obj": "Traits",
+                "name": "animal",
+                "type": "link"
+              },
+              {
+                "alt": "Draconic",
+                "aonid": 156,
+                "game-obj": "Languages",
+                "name": "Draconic",
+                "type": "link"
+              },
+              {
+                "alt": "controlled",
+                "aonid": 64,
+                "game-obj": "Conditions",
+                "name": "controlled",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -228,287 +130,124 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Many horned dragons adapt to their environment to learn unique abilities.  \n  \nSwamp-dwelling horned dragons grow mushrooms on their scales and inhale the spores released by these fungi for temporary effects. To make a dragon with this ability, replace Draconic Frenzy from a horned dragon of any age and with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "veil of privacy",
-                            "aonid": 1739,
-                            "game-obj": "Spells",
-                            "name": "veil of privacy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "veil of privacy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of thorns",
-                            "aonid": 1752,
-                            "game-obj": "Spells",
-                            "name": "wall of thorns",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of thorns",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 1560,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "one with plants",
-                            "aonid": 1618,
-                            "game-obj": "Spells",
-                            "name": "one with plants",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "one with plants",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sound body",
-                            "aonid": 1679,
-                            "game-obj": "Spells",
-                            "name": "sound body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sound body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gust of wind",
-                            "aonid": 1550,
-                            "game-obj": "Spells",
-                            "name": "gust of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gust of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vanishing tracks",
-                            "aonid": 1737,
-                            "game-obj": "Spells",
-                            "name": "vanishing tracks",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vanishing tracks",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ventriloquism",
-                            "aonid": 1740,
-                            "game-obj": "Spells",
-                            "name": "ventriloquism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ventriloquism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangle vine",
-                            "aonid": 1713,
-                            "game-obj": "Spells",
-                            "name": "tangle vine",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Horned Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "veil of privacy",
+                "aonid": 1739,
+                "game-obj": "Spells",
+                "name": "veil of privacy",
+                "type": "link"
+              },
+              {
+                "alt": "wall of thorns",
+                "aonid": 1752,
+                "game-obj": "Spells",
+                "name": "wall of thorns",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 1560,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "one with plants",
+                "aonid": 1618,
+                "game-obj": "Spells",
+                "name": "one with plants",
+                "type": "link"
+              },
+              {
+                "alt": "sound body",
+                "aonid": 1679,
+                "game-obj": "Spells",
+                "name": "sound body",
+                "type": "link"
+              },
+              {
+                "alt": "gust of wind",
+                "aonid": 1550,
+                "game-obj": "Spells",
+                "name": "gust of wind",
+                "type": "link"
+              },
+              {
+                "alt": "vanishing tracks",
+                "aonid": 1737,
+                "game-obj": "Spells",
+                "name": "vanishing tracks",
+                "type": "link"
+              },
+              {
+                "alt": "ventriloquism",
+                "aonid": 1740,
+                "game-obj": "Spells",
+                "name": "ventriloquism",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "tangle vine",
+                "aonid": 1713,
+                "game-obj": "Spells",
+                "name": "tangle vine",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -524,170 +263,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young horned dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "veil of privacy",
-                            "aonid": 1739,
-                            "game-obj": "Spells",
-                            "name": "veil of privacy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "veil of privacy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hydraulic torrent",
-                            "aonid": 1562,
-                            "game-obj": "Spells",
-                            "name": "hydraulic torrent",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mountain resilience",
-                            "aonid": 1610,
-                            "game-obj": "Spells",
-                            "name": "mountain resilience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mountain resilience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Horned Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
+              },
+              {
+                "alt": "veil of privacy",
+                "aonid": 1739,
+                "game-obj": "Spells",
+                "name": "veil of privacy",
+                "type": "link"
+              },
+              {
+                "alt": "hydraulic torrent",
+                "aonid": 1562,
+                "game-obj": "Spells",
+                "name": "hydraulic torrent",
+                "type": "link"
+              },
+              {
+                "alt": "mountain resilience",
+                "aonid": 1610,
+                "game-obj": "Spells",
+                "name": "mountain resilience",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -703,208 +327,69 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult horned dragon"
-                ],
-                "saving_throw": {
-                  "dc": 39,
-                  "subtype": "save_dc",
-                  "text": "DC 39",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "punishing winds",
-                            "aonid": 1643,
-                            "game-obj": "Spells",
-                            "name": "punishing winds",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "punishing winds",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "execute",
-                            "aonid": 1519,
-                            "game-obj": "Spells",
-                            "name": "execute",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "execute",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "veil of privacy",
-                            "aonid": 1739,
-                            "game-obj": "Spells",
-                            "name": "veil of privacy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "veil of privacy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "field of life",
-                            "aonid": 1526,
-                            "game-obj": "Spells",
-                            "name": "field of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "field of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tangling creepers",
-                            "aonid": 1714,
-                            "game-obj": "Spells",
-                            "name": "tangling creepers",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tangling creepers",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Horned Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "punishing winds",
+                "aonid": 1643,
+                "game-obj": "Spells",
+                "name": "punishing winds",
+                "type": "link"
+              },
+              {
+                "alt": "execute",
+                "aonid": 1519,
+                "game-obj": "Spells",
+                "name": "execute",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "veil of privacy",
+                "aonid": 1739,
+                "game-obj": "Spells",
+                "name": "veil of privacy",
+                "type": "link"
+              },
+              {
+                "alt": "field of life",
+                "aonid": 1526,
+                "game-obj": "Spells",
+                "name": "field of life",
+                "type": "link"
+              },
+              {
+                "alt": "tangling creepers",
+                "aonid": 1714,
+                "game-obj": "Spells",
+                "name": "tangling creepers",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -920,125 +405,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient horned dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cataclysm",
-                            "aonid": 1460,
-                            "game-obj": "Spells",
-                            "name": "cataclysm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cataclysm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nature\u2019s enmity",
-                            "aonid": 2010,
-                            "game-obj": "Spells",
-                            "name": "nature\u2019s enmity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nature\u2019s enmity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "tangle vine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Horned Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cataclysm",
+                "aonid": 1460,
+                "game-obj": "Spells",
+                "name": "cataclysm",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "nature\u2019s enmity",
+                "aonid": 2010,
+                "game-obj": "Spells",
+                "name": "nature\u2019s enmity",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1053,48 +447,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1105,263 +462,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1371,7 +512,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1380,6 +520,232 @@
   "name": "Dragon, Horned",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "frequency": "1d4 rounds",
+          "links": [
+            {
+              "alt": "temporary Hit Points",
+              "aonid": 2321,
+              "game-obj": "Rules",
+              "name": "temporary Hit Points",
+              "type": "link"
+            }
+          ],
+          "name": "Invigorating Spores",
+          "subtype": "ability",
+          "text": "The dragon contorts, ejecting spores from a variety of multicolored fungi covering its limbs. The spores drift toward the dragon\u2019s snout and invigorate it. The dragon gains temporary Hit Points equal to its level that last 10 minutes. The dragon also gains resistance to bludgeoning, slashing, and piercing damage equal to half its level until the end of its next turn. The dragon can\u2019t use Invigorating Spores again for 1d4 rounds.",
+          "traits": [
+            {
+              "link": {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              "name": "manipulate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The dragon hurls a fragment of its horn at a target within 40 feet. The target takes the same damage as the dragon\u2019s horn Strike and must attempt a Reflex save.",
+          "frequency": "once per round",
+          "name": "Horn Projectile",
+          "range": {
+            "range": 40,
+            "subtype": "range",
+            "text": "within 40 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The target takes no damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The target takes half damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The target takes full damage and is immobilized as the horn fragment pins them to the nearest surface.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "bleed",
+              "formula": "2d6",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, but the target takes double damage and 2d6 persistent bleed damage as the fragment pierces their body.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "communication",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "dominate",
+              "aonid": 1501,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            },
+            {
+              "alt": "animal",
+              "aonid": 531,
+              "game-obj": "Traits",
+              "name": "animal",
+              "type": "link"
+            },
+            {
+              "alt": "Draconic",
+              "aonid": 156,
+              "game-obj": "Languages",
+              "name": "Draconic",
+              "type": "link"
+            },
+            {
+              "alt": "controlled",
+              "aonid": 64,
+              "game-obj": "Conditions",
+              "name": "controlled",
+              "type": "link"
+            }
+          ],
+          "name": "Apex Dominance",
+          "subtype": "ability",
+          "text": "When the dragon casts *dominate* on a creature with the animal trait, the result of the target\u2019s saving throw is one degree of success worse. An animal the dragon controls with this spell can speak Draconic and gains a +2 status bonus to any Intelligence-, Wisdom-, and Charisma-based skill checks it attempts while controlled.",
+          "traits": [
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "manipulate",
+          "aonid": 645,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "temporary Hit Points",
+          "aonid": 2321,
+          "game-obj": "Rules",
+          "name": "temporary Hit Points",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "animal",
+          "aonid": 531,
+          "game-obj": "Traits",
+          "name": "animal",
+          "type": "link"
+        },
+        {
+          "alt": "Draconic",
+          "aonid": 156,
+          "game-obj": "Languages",
+          "name": "Draconic",
+          "type": "link"
+        },
+        {
+          "alt": "controlled",
+          "aonid": 64,
+          "game-obj": "Conditions",
+          "name": "controlled",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 119",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 119",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 119,
+          "type": "source"
+        }
+      ],
+      "text": "Many horned dragons adapt to their environment to learn unique abilities.  \n  \nSwamp-dwelling horned dragons grow mushrooms on their scales and inhale the spores released by these fungi for temporary effects. To make a dragon with this ability, replace Draconic Frenzy from a horned dragon of any age and with the following.  \n  \n**Invigorating Spores** [#] (manipulate) The dragon contorts, ejecting spores from a variety of multicolored fungi covering its limbs. The spores drift toward the dragon\u2019s snout and invigorate it. The dragon gains temporary Hit Points equal to its level that last 10 minutes. The dragon also gains resistance to bludgeoning, slashing, and piercing damage equal to half its level until the end of its next turn. The dragon can\u2019t use Invigorating Spores again for 1d4 rounds.  \n  \nSome mature horned dragons use fragments of the horns as missiles to catch foes unaware and pin them down. To make a dragon with this ability, replace Draconic Frenzy of an adult horned dragon or older with the following.   \n  \n**Horn Projectile** [#] **Frequency** once per round; **Effect** The dragon hurls a fragment of its horn at a target within 40 feet. The target takes the same damage as the dragon\u2019s horn Strike and must attempt a Reflex save.  \n**Critical Success** The target takes no damage.   \n**Success** The target takes half damage.   \n**Failure** The target takes full damage and is immobilized as the horn fragment pins them to the nearest surface.   \n**Critical Failure** As failure, but the target takes double damage and 2d6 persistent bleed damage as the fragment pierces their body.  \n  \nThe most powerful of horned dragons exude primal magic that expands the minds of animals in their domain, giving them sway over these creatures during critical moments. To make a dragon with this ability, replace draconic momentum of an ancient horned dragon or older with the following.   \n  \n**Apex Dominance** (primal) When the dragon casts *dominate* on a creature with the animal trait, the result of the target\u2019s saving throw is one degree of success worse. An animal the dragon controls with this spell can speak Draconic and gains a +2 status bonus to any Intelligence-, Wisdom-, and Charisma-based skill checks it attempts while controlled.",
+      "type": "section"
+    },
     {
       "name": "Athervox",
       "sources": [
@@ -1456,6 +822,1109 @@
         }
       ],
       "text": "Horned dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "veil of privacy",
+          "aonid": 1739,
+          "game-obj": "Spells",
+          "name": "veil of privacy",
+          "type": "link"
+        },
+        {
+          "alt": "wall of thorns",
+          "aonid": 1752,
+          "game-obj": "Spells",
+          "name": "wall of thorns",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 1560,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "one with plants",
+          "aonid": 1618,
+          "game-obj": "Spells",
+          "name": "one with plants",
+          "type": "link"
+        },
+        {
+          "alt": "sound body",
+          "aonid": 1679,
+          "game-obj": "Spells",
+          "name": "sound body",
+          "type": "link"
+        },
+        {
+          "alt": "gust of wind",
+          "aonid": 1550,
+          "game-obj": "Spells",
+          "name": "gust of wind",
+          "type": "link"
+        },
+        {
+          "alt": "vanishing tracks",
+          "aonid": 1737,
+          "game-obj": "Spells",
+          "name": "vanishing tracks",
+          "type": "link"
+        },
+        {
+          "alt": "ventriloquism",
+          "aonid": 1740,
+          "game-obj": "Spells",
+          "name": "ventriloquism",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "tangle vine",
+          "aonid": 1713,
+          "game-obj": "Spells",
+          "name": "tangle vine",
+          "type": "link"
+        }
+      ],
+      "name": "Young Horned Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 119",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 119",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 119,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "veil of privacy",
+                      "aonid": 1739,
+                      "game-obj": "Spells",
+                      "name": "veil of privacy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "veil of privacy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of thorns",
+                      "aonid": 1752,
+                      "game-obj": "Spells",
+                      "name": "wall of thorns",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of thorns",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 1560,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "one with plants",
+                      "aonid": 1618,
+                      "game-obj": "Spells",
+                      "name": "one with plants",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "one with plants",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sound body",
+                      "aonid": 1679,
+                      "game-obj": "Spells",
+                      "name": "sound body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sound body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gust of wind",
+                      "aonid": 1550,
+                      "game-obj": "Spells",
+                      "name": "gust of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gust of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vanishing tracks",
+                      "aonid": 1737,
+                      "game-obj": "Spells",
+                      "name": "vanishing tracks",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vanishing tracks",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ventriloquism",
+                      "aonid": 1740,
+                      "game-obj": "Spells",
+                      "name": "ventriloquism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ventriloquism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangle vine",
+                      "aonid": 1713,
+                      "game-obj": "Spells",
+                      "name": "tangle vine",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 26, attack +20; **3rd** *dispel magic*, *slow*, *veil of privacy*, *wall of thorns*; **2nd** *humanoid form*, *one with plants*, *sound body*; **1st** *gust of wind*, *vanishing tracks*, *ventriloquism*; **Cantrips (3rd)** *detect magic*, *know the way*, *light*, *read aura*, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        },
+        {
+          "alt": "veil of privacy",
+          "aonid": 1739,
+          "game-obj": "Spells",
+          "name": "veil of privacy",
+          "type": "link"
+        },
+        {
+          "alt": "hydraulic torrent",
+          "aonid": 1562,
+          "game-obj": "Spells",
+          "name": "hydraulic torrent",
+          "type": "link"
+        },
+        {
+          "alt": "mountain resilience",
+          "aonid": 1610,
+          "game-obj": "Spells",
+          "name": "mountain resilience",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Horned Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 119",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 119",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 119,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young horned dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "veil of privacy",
+                      "aonid": 1739,
+                      "game-obj": "Spells",
+                      "name": "veil of privacy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "veil of privacy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hydraulic torrent",
+                      "aonid": 1562,
+                      "game-obj": "Spells",
+                      "name": "hydraulic torrent",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mountain resilience",
+                      "aonid": 1610,
+                      "game-obj": "Spells",
+                      "name": "mountain resilience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mountain resilience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 33, attack +26; As young horned dragon, plus **5th** *dispel magic*, *toxic cloud*, *veil of privacy*; **4th** *hydraulic torrent*, *mountain resilience*, *unfettered movement*; **Cantrips (5th)** *detect magic*, *know the way*, *light*, *read aura*, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "punishing winds",
+          "aonid": 1643,
+          "game-obj": "Spells",
+          "name": "punishing winds",
+          "type": "link"
+        },
+        {
+          "alt": "execute",
+          "aonid": 1519,
+          "game-obj": "Spells",
+          "name": "execute",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "veil of privacy",
+          "aonid": 1739,
+          "game-obj": "Spells",
+          "name": "veil of privacy",
+          "type": "link"
+        },
+        {
+          "alt": "field of life",
+          "aonid": 1526,
+          "game-obj": "Spells",
+          "name": "field of life",
+          "type": "link"
+        },
+        {
+          "alt": "tangling creepers",
+          "aonid": 1714,
+          "game-obj": "Spells",
+          "name": "tangling creepers",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Horned Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 119",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 119",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 119,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult horned dragon"
+          ],
+          "saving_throw": {
+            "dc": 39,
+            "subtype": "save_dc",
+            "text": "DC 39",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "punishing winds",
+                      "aonid": 1643,
+                      "game-obj": "Spells",
+                      "name": "punishing winds",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "punishing winds",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "execute",
+                      "aonid": 1519,
+                      "game-obj": "Spells",
+                      "name": "execute",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "execute",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "veil of privacy",
+                      "aonid": 1739,
+                      "game-obj": "Spells",
+                      "name": "veil of privacy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "veil of privacy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "field of life",
+                      "aonid": 1526,
+                      "game-obj": "Spells",
+                      "name": "field of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "field of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tangling creepers",
+                      "aonid": 1714,
+                      "game-obj": "Spells",
+                      "name": "tangling creepers",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tangling creepers",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 39, attack +33; As adult horned dragon, plus **8th** *desiccate*, *punishing winds*; **7th** *execute*, *mask of terror*, *veil of privacy*; **6th** *field of life*, *tangling creepers*, *truesight*; **Cantrips (8th)** *detect magic*, *know the way*, *light*, *read aura*, *tangle vine*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cataclysm",
+          "aonid": 1460,
+          "game-obj": "Spells",
+          "name": "cataclysm",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "nature\u2019s enmity",
+          "aonid": 2010,
+          "game-obj": "Spells",
+          "name": "nature\u2019s enmity",
+          "type": "link"
+        }
+      ],
+      "name": "Horned Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 119",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 119",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 119,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient horned dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cataclysm",
+                      "aonid": 1460,
+                      "game-obj": "Spells",
+                      "name": "cataclysm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cataclysm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nature\u2019s enmity",
+                      "aonid": 2010,
+                      "game-obj": "Spells",
+                      "name": "nature\u2019s enmity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nature\u2019s enmity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "tangle vine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 44, attack +36; As ancient horned dragon, plus **10th** *cataclysm*; **9th** *implosion*, *nature\u2019s enmity*; **Cantrips (10th)** *detect magic*, *know the way*, *light*, *read aura*, *tangle vine*",
       "type": "section"
     },
     {
@@ -1777,6 +2246,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 119",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 119",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 119,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1938,6 +2470,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 119",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 119",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 119,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/dragon_mirage.json
+++ b/monster_families/monster_core/dragon_mirage.json
@@ -58,339 +58,175 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "As the dragon turns invisible, they leave an illusory duplicate of themself in their original position that lasts for 1 minute. A creature that determines the duplicate is an illusion doesn\u2019t necessarily know the mirage dragon is invisible, and one that can see their invisible form doesn\u2019t necessarily know the duplicate is an illusion. When the mirage dragon Strides or Flies, they can Sustain the illusion as a free action to have it Stride or Fly up to 60 feet, speak through the illusion, or make a claw Strike using the dragon\u2019s spell attack modifier for the attack roll. This Strike deals the same amount and type of damage as an illusory creature spell heightened to the dragon\u2019s highest spell rank. The mirage dragon can Dismiss the illusion.",
-                "frequency": "once per hour",
-                "links": [
-                  {
-                    "alt": "invisibility",
-                    "aonid": 1577,
-                    "game-obj": "Spells",
-                    "name": "invisibility",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "invisible",
-                    "aonid": 83,
-                    "game-obj": "Conditions",
-                    "name": "invisible",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Strides",
-                    "aonid": 2305,
-                    "game-obj": "Actions",
-                    "name": "Strides",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Flies",
-                    "aonid": 2312,
-                    "game-obj": "Actions",
-                    "name": "Flies",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Sustain",
-                    "aonid": 2317,
-                    "game-obj": "Actions",
-                    "name": "Sustain",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Dismiss",
-                    "aonid": 2311,
-                    "game-obj": "Actions",
-                    "name": "Dismiss",
-                    "type": "link"
-                  }
-                ],
-                "name": "Afterimage",
-                "requirement": "The mirage dragon\u2019s next action is to cast *invisibility*",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 629,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "spellshape",
-                      "aonid": 513,
-                      "game-obj": "Traits",
-                      "name": "spellshape",
-                      "type": "link"
-                    },
-                    "name": "spellshape",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 120,
-                    "subtype": "area",
-                    "text": "120-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  }
-                ],
-                "name": "Phantasmal Terror",
-                "saving_throw": [
-                  {
-                    "dc": 20,
-                    "subtype": "save_dc",
-                    "text": "DC 20",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The dragon either temporarily appears to be in multiple places at once or grows to Gargantuan size to frighten their foes. Each enemy within a 120-foot emanation who can see the mirage dragon must attempt a Will save (with a DC equal to the dragon\u2019s Captivating Display).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 629,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The target is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightened",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The target is frightened 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The target is frightened 2 and can\u2019t use reactions until the start of the dragon\u2019s next turn.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, but frightened 3.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 25,
-                    "subtype": "area",
-                    "text": "25-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "difficult terrain",
-                    "aonid": 2366,
-                    "game-obj": "Rules",
-                    "name": "difficult terrain",
-                    "type": "link"
-                  }
-                ],
-                "name": "Reshape Terrain",
-                "subtype": "ability",
-                "text": "The mirage dragon blends illusion and reality in a 25-foot emanation. A creature that enters the area must succeed at a Will save (the same DC as the dragon\u2019s Captivating Display) or treat the area as difficult terrain. Creatures who attempt a save against this effect use the same outcome if they leave and reenter the area.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 629,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "spellshape",
+                "aonid": 513,
+                "game-obj": "Traits",
+                "name": "spellshape",
+                "type": "link"
+              },
+              {
+                "alt": "invisibility",
+                "aonid": 1577,
+                "game-obj": "Spells",
+                "name": "invisibility",
+                "type": "link"
+              },
+              {
+                "alt": "invisible",
+                "aonid": 83,
+                "game-obj": "Conditions",
+                "name": "invisible",
+                "type": "link"
+              },
+              {
+                "alt": "Strides",
+                "aonid": 2305,
+                "game-obj": "Actions",
+                "name": "Strides",
+                "type": "link"
+              },
+              {
+                "alt": "Flies",
+                "aonid": 2312,
+                "game-obj": "Actions",
+                "name": "Flies",
+                "type": "link"
+              },
+              {
+                "alt": "Sustain",
+                "aonid": 2317,
+                "game-obj": "Actions",
+                "name": "Sustain",
+                "type": "link"
+              },
+              {
+                "alt": "Dismiss",
+                "aonid": 2311,
+                "game-obj": "Actions",
+                "name": "Dismiss",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "frightened",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "difficult terrain",
+                "aonid": 2366,
+                "game-obj": "Rules",
+                "name": "difficult terrain",
+                "type": "link"
+              },
+              {
+                "alt": "Sustain",
+                "aonid": 2317,
+                "game-obj": "Actions",
+                "name": "Sustain",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -400,177 +236,131 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "While some mirage dragons tend toward melee combat, others rely more on their magic to confound enemies. To create a variant mirage dragon, replace Lunging Bite with one of the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "confusion",
-                    "aonid": 1471,
-                    "game-obj": "Spells",
-                    "name": "confusion",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "vision of death",
-                    "aonid": 1742,
-                    "game-obj": "Spells",
-                    "name": "vision of death",
-                    "type": "link"
-                  }
-                ],
-                "name": "4th",
-                "subtype": "ability",
-                "text": "*confusion*, *vision of death*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "disguise magic",
-                    "aonid": 1491,
-                    "game-obj": "Spells",
-                    "name": "disguise magic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enthrall",
-                    "aonid": 1516,
-                    "game-obj": "Spells",
-                    "name": "enthrall",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "hypnotize",
-                    "aonid": 1564,
-                    "game-obj": "Spells",
-                    "name": "hypnotize",
-                    "type": "link"
-                  }
-                ],
-                "name": "3rd",
-                "subtype": "ability",
-                "text": "*disguise magic*, *enthrall*, *hypnotize*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "embed message",
-                    "aonid": 1511,
-                    "game-obj": "Spells",
-                    "name": "embed message",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "revealing light",
-                    "aonid": 1653,
-                    "game-obj": "Spells",
-                    "name": "revealing light",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "see the unseen",
-                    "aonid": 1663,
-                    "game-obj": "Spells",
-                    "name": "see the unseen",
-                    "type": "link"
-                  }
-                ],
-                "name": "2nd",
-                "subtype": "ability",
-                "text": "*embed message*, *revealing light*, *see the unseen*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "item facade",
-                    "aonid": 1579,
-                    "game-obj": "Spells",
-                    "name": "item facade",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "phantasmal minion",
-                    "aonid": 1631,
-                    "game-obj": "Spells",
-                    "name": "phantasmal minion",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ventriloquism",
-                    "aonid": 1740,
-                    "game-obj": "Spells",
-                    "name": "ventriloquism",
-                    "type": "link"
-                  }
-                ],
-                "name": "1st",
-                "subtype": "ability",
-                "text": "*item facade*, *phantasmal minion*, *ventriloquism*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "daze",
-                    "aonid": 1482,
-                    "game-obj": "Spells",
-                    "name": "daze",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "detect magic",
-                    "aonid": 1485,
-                    "game-obj": "Spells",
-                    "name": "detect magic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "light",
-                    "aonid": 1585,
-                    "game-obj": "Spells",
-                    "name": "light",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "prestidigitation",
-                    "aonid": 1639,
-                    "game-obj": "Spells",
-                    "name": "prestidigitation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "read aura",
-                    "aonid": 1646,
-                    "game-obj": "Spells",
-                    "name": "read aura",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cantrips (4th)",
-                "subtype": "ability",
-                "text": "*daze*, *detect magic*, *light*, *prestidigitation*, *read aura*",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Young Mirage Dragon')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "vision of death",
+                "aonid": 1742,
+                "game-obj": "Spells",
+                "name": "vision of death",
+                "type": "link"
+              },
+              {
+                "alt": "disguise magic",
+                "aonid": 1491,
+                "game-obj": "Spells",
+                "name": "disguise magic",
+                "type": "link"
+              },
+              {
+                "alt": "enthrall",
+                "aonid": 1516,
+                "game-obj": "Spells",
+                "name": "enthrall",
+                "type": "link"
+              },
+              {
+                "alt": "hypnotize",
+                "aonid": 1564,
+                "game-obj": "Spells",
+                "name": "hypnotize",
+                "type": "link"
+              },
+              {
+                "alt": "embed message",
+                "aonid": 1511,
+                "game-obj": "Spells",
+                "name": "embed message",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "see the unseen",
+                "aonid": 1663,
+                "game-obj": "Spells",
+                "name": "see the unseen",
+                "type": "link"
+              },
+              {
+                "alt": "item facade",
+                "aonid": 1579,
+                "game-obj": "Spells",
+                "name": "item facade",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal minion",
+                "aonid": 1631,
+                "game-obj": "Spells",
+                "name": "phantasmal minion",
+                "type": "link"
+              },
+              {
+                "alt": "ventriloquism",
+                "aonid": 1740,
+                "game-obj": "Spells",
+                "name": "ventriloquism",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -580,185 +370,61 @@
         ],
         "name": "Young Mirage Dragon",
         "subtype": "monster_family",
-        "text": "Arcane Prepared Spells DC 27, attack +20;",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young mirage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 35,
-                  "subtype": "save_dc",
-                  "text": "DC 35",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 27,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mislead",
-                            "aonid": 1605,
-                            "game-obj": "Spells",
-                            "name": "mislead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mislead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal calamity",
-                            "aonid": 1630,
-                            "game-obj": "Spells",
-                            "name": "phantasmal calamity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal calamity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "false vision",
-                            "aonid": 1522,
-                            "game-obj": "Spells",
-                            "name": "false vision",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "false vision",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic haul",
-                            "aonid": 1716,
-                            "game-obj": "Spells",
-                            "name": "telekinetic haul",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic haul",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vapor form",
-                            "aonid": 1738,
-                            "game-obj": "Spells",
-                            "name": "vapor form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vapor form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Mirage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mislead",
+                "aonid": 1605,
+                "game-obj": "Spells",
+                "name": "mislead",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal calamity",
+                "aonid": 1630,
+                "game-obj": "Spells",
+                "name": "phantasmal calamity",
+                "type": "link"
+              },
+              {
+                "alt": "false vision",
+                "aonid": 1522,
+                "game-obj": "Spells",
+                "name": "false vision",
+                "type": "link"
+              },
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic haul",
+                "aonid": 1716,
+                "game-obj": "Spells",
+                "name": "telekinetic haul",
+                "type": "link"
+              },
+              {
+                "alt": "vapor form",
+                "aonid": 1738,
+                "game-obj": "Spells",
+                "name": "vapor form",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -774,193 +440,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult mirage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 43,
-                  "subtype": "save_dc",
-                  "text": "DC 43",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 35,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 1490,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucination",
-                            "aonid": 1551,
-                            "game-obj": "Spells",
-                            "name": "hallucination",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucination",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "contingency",
-                            "aonid": 1472,
-                            "game-obj": "Spells",
-                            "name": "contingency",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "contingency",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 1640,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Mirage Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disappearance",
+                "aonid": 1490,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "hallucination",
+                "aonid": 1551,
+                "game-obj": "Spells",
+                "name": "hallucination",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "contingency",
+                "aonid": 1472,
+                "game-obj": "Spells",
+                "name": "contingency",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "project image",
+                "aonid": 1640,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -976,125 +511,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As ancient mirage dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "manifestation",
-                            "aonid": 1592,
-                            "game-obj": "Spells",
-                            "name": "manifestation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "manifestation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resplendent mansion",
-                            "aonid": 2018,
-                            "game-obj": "Spells",
-                            "name": "resplendent mansion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resplendent mansion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Mirage Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "manifestation",
+                "aonid": 1592,
+                "game-obj": "Spells",
+                "name": "manifestation",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
+              },
+              {
+                "alt": "resplendent mansion",
+                "aonid": 2018,
+                "game-obj": "Spells",
+                "name": "resplendent mansion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1109,48 +553,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1161,263 +568,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1427,7 +618,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1436,6 +626,522 @@
   "name": "Dragon, Mirage",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "As the dragon turns invisible, they leave an illusory duplicate of themself in their original position that lasts for 1 minute. A creature that determines the duplicate is an illusion doesn\u2019t necessarily know the mirage dragon is invisible, and one that can see their invisible form doesn\u2019t necessarily know the duplicate is an illusion. When the mirage dragon Strides or Flies, they can Sustain the illusion as a free action to have it Stride or Fly up to 60 feet, speak through the illusion, or make a claw Strike using the dragon\u2019s spell attack modifier for the attack roll. This Strike deals the same amount and type of damage as an illusory creature spell heightened to the dragon\u2019s highest spell rank. The mirage dragon can Dismiss the illusion.",
+          "frequency": "once per hour",
+          "links": [
+            {
+              "alt": "invisibility",
+              "aonid": 1577,
+              "game-obj": "Spells",
+              "name": "invisibility",
+              "type": "link"
+            },
+            {
+              "alt": "invisible",
+              "aonid": 83,
+              "game-obj": "Conditions",
+              "name": "invisible",
+              "type": "link"
+            },
+            {
+              "alt": "Strides",
+              "aonid": 2305,
+              "game-obj": "Actions",
+              "name": "Strides",
+              "type": "link"
+            },
+            {
+              "alt": "Flies",
+              "aonid": 2312,
+              "game-obj": "Actions",
+              "name": "Flies",
+              "type": "link"
+            },
+            {
+              "alt": "Sustain",
+              "aonid": 2317,
+              "game-obj": "Actions",
+              "name": "Sustain",
+              "type": "link"
+            },
+            {
+              "alt": "Dismiss",
+              "aonid": 2311,
+              "game-obj": "Actions",
+              "name": "Dismiss",
+              "type": "link"
+            }
+          ],
+          "name": "Afterimage",
+          "requirement": "The mirage dragon\u2019s next action is to cast *invisibility*",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              "name": "illusion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "spellshape",
+                "aonid": 513,
+                "game-obj": "Traits",
+                "name": "spellshape",
+                "type": "link"
+              },
+              "name": "spellshape",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 120,
+              "subtype": "area",
+              "text": "120-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            }
+          ],
+          "name": "Phantasmal Terror",
+          "saving_throw": [
+            {
+              "dc": 20,
+              "subtype": "save_dc",
+              "text": "DC 20",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The dragon either temporarily appears to be in multiple places at once or grows to Gargantuan size to frighten their foes. Each enemy within a 120-foot emanation who can see the mirage dragon must attempt a Will save (with a DC equal to the dragon\u2019s Captivating Display).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              "name": "illusion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The target is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "frightened",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The target is frightened 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The target is frightened 2 and can\u2019t use reactions until the start of the dragon\u2019s next turn.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, but frightened 3.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 25,
+              "subtype": "area",
+              "text": "25-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "difficult terrain",
+              "aonid": 2366,
+              "game-obj": "Rules",
+              "name": "difficult terrain",
+              "type": "link"
+            }
+          ],
+          "name": "Reshape Terrain",
+          "subtype": "ability",
+          "text": "The mirage dragon blends illusion and reality in a 25-foot emanation. A creature that enters the area must succeed at a Will save (the same DC as the dragon\u2019s Captivating Display) or treat the area as difficult terrain. Creatures who attempt a save against this effect use the same outcome if they leave and reenter the area.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              "name": "illusion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "illusion",
+          "aonid": 629,
+          "game-obj": "Traits",
+          "name": "illusion",
+          "type": "link"
+        },
+        {
+          "alt": "spellshape",
+          "aonid": 513,
+          "game-obj": "Traits",
+          "name": "spellshape",
+          "type": "link"
+        },
+        {
+          "alt": "invisibility",
+          "aonid": 1577,
+          "game-obj": "Spells",
+          "name": "invisibility",
+          "type": "link"
+        },
+        {
+          "alt": "invisible",
+          "aonid": 83,
+          "game-obj": "Conditions",
+          "name": "invisible",
+          "type": "link"
+        },
+        {
+          "alt": "Strides",
+          "aonid": 2305,
+          "game-obj": "Actions",
+          "name": "Strides",
+          "type": "link"
+        },
+        {
+          "alt": "Flies",
+          "aonid": 2312,
+          "game-obj": "Actions",
+          "name": "Flies",
+          "type": "link"
+        },
+        {
+          "alt": "Sustain",
+          "aonid": 2317,
+          "game-obj": "Actions",
+          "name": "Sustain",
+          "type": "link"
+        },
+        {
+          "alt": "Dismiss",
+          "aonid": 2311,
+          "game-obj": "Actions",
+          "name": "Dismiss",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "illusion",
+          "aonid": 629,
+          "game-obj": "Traits",
+          "name": "illusion",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "frightened",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "illusion",
+          "aonid": 629,
+          "game-obj": "Traits",
+          "name": "illusion",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "difficult terrain",
+          "aonid": 2366,
+          "game-obj": "Rules",
+          "name": "difficult terrain",
+          "type": "link"
+        },
+        {
+          "alt": "Sustain",
+          "aonid": 2317,
+          "game-obj": "Actions",
+          "name": "Sustain",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 121",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 121",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "text": "While some mirage dragons tend toward melee combat, others rely more on their magic to confound enemies. To create a variant mirage dragon, replace Lunging Bite with one of the following.   \n  \n**Afterimage** [-] (arcane, illusion, spellshape) **Frequency** once per hour; **Requirements** The mirage dragon\u2019s next action is to cast *invisibility*; **Effect** As the dragon turns invisible, they leave an illusory duplicate of themself in their original position that lasts for 1 minute. A creature that determines the duplicate is an illusion doesn\u2019t necessarily know the mirage dragon is invisible, and one that can see their invisible form doesn\u2019t necessarily know the duplicate is an illusion. When the mirage dragon Strides or Flies, they can Sustain the illusion as a free action to have it Stride or Fly up to 60 feet, speak through the illusion, or make a claw Strike using the dragon\u2019s spell attack modifier for the attack roll. This Strike deals the same amount and type of damage as an illusory creature spell heightened to the dragon\u2019s highest spell rank. The mirage dragon can Dismiss the illusion.   \n  \n**Phantasmal Terror** [##] (concentrate, emotion, fear, illusion, mental, visual) The dragon either temporarily appears to be in multiple places at once or grows to Gargantuan size to frighten their foes. Each enemy within a 120-foot emanation who can see the mirage dragon must attempt a Will save (with a DC equal to the dragon\u2019s Captivating Display).   \n**Critical Success** The target is unaffected.  \n**Success** The target is frightened 1.  \n**Failure** The target is frightened 2 and can\u2019t use reactions until the start of the dragon\u2019s next turn.  \n**Critical Failure** As failure, but frightened 3.   \n  \n**Reshape Terrain** [##] (arcane, concentrate, illusion) The mirage dragon blends illusion and reality in a 25-foot emanation. A creature that enters the area must succeed at a Will save (the same DC as the dragon\u2019s Captivating Display) or treat the area as difficult terrain. Creatures who attempt a save against this effect use the same outcome if they leave and reenter the area.   \n  \nOn its turn, the archdragon can Sustain this effect to move the illusions up to 35 feet each, or to swap spots with any illusion that is within 30 feet of itself. Any duplicate that is more than 60 feet away from the archdragon disappears.",
+      "type": "section"
+    },
     {
       "name": "Dijansi",
       "sources": [
@@ -1512,6 +1218,985 @@
         }
       ],
       "text": "Mirage dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "confusion",
+              "aonid": 1471,
+              "game-obj": "Spells",
+              "name": "confusion",
+              "type": "link"
+            },
+            {
+              "alt": "vision of death",
+              "aonid": 1742,
+              "game-obj": "Spells",
+              "name": "vision of death",
+              "type": "link"
+            }
+          ],
+          "name": "4th",
+          "subtype": "ability",
+          "text": "*confusion*, *vision of death*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "disguise magic",
+              "aonid": 1491,
+              "game-obj": "Spells",
+              "name": "disguise magic",
+              "type": "link"
+            },
+            {
+              "alt": "enthrall",
+              "aonid": 1516,
+              "game-obj": "Spells",
+              "name": "enthrall",
+              "type": "link"
+            },
+            {
+              "alt": "hypnotize",
+              "aonid": 1564,
+              "game-obj": "Spells",
+              "name": "hypnotize",
+              "type": "link"
+            }
+          ],
+          "name": "3rd",
+          "subtype": "ability",
+          "text": "*disguise magic*, *enthrall*, *hypnotize*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "embed message",
+              "aonid": 1511,
+              "game-obj": "Spells",
+              "name": "embed message",
+              "type": "link"
+            },
+            {
+              "alt": "revealing light",
+              "aonid": 1653,
+              "game-obj": "Spells",
+              "name": "revealing light",
+              "type": "link"
+            },
+            {
+              "alt": "see the unseen",
+              "aonid": 1663,
+              "game-obj": "Spells",
+              "name": "see the unseen",
+              "type": "link"
+            }
+          ],
+          "name": "2nd",
+          "subtype": "ability",
+          "text": "*embed message*, *revealing light*, *see the unseen*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "item facade",
+              "aonid": 1579,
+              "game-obj": "Spells",
+              "name": "item facade",
+              "type": "link"
+            },
+            {
+              "alt": "phantasmal minion",
+              "aonid": 1631,
+              "game-obj": "Spells",
+              "name": "phantasmal minion",
+              "type": "link"
+            },
+            {
+              "alt": "ventriloquism",
+              "aonid": 1740,
+              "game-obj": "Spells",
+              "name": "ventriloquism",
+              "type": "link"
+            }
+          ],
+          "name": "1st",
+          "subtype": "ability",
+          "text": "*item facade*, *phantasmal minion*, *ventriloquism*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "daze",
+              "aonid": 1482,
+              "game-obj": "Spells",
+              "name": "daze",
+              "type": "link"
+            },
+            {
+              "alt": "detect magic",
+              "aonid": 1485,
+              "game-obj": "Spells",
+              "name": "detect magic",
+              "type": "link"
+            },
+            {
+              "alt": "light",
+              "aonid": 1585,
+              "game-obj": "Spells",
+              "name": "light",
+              "type": "link"
+            },
+            {
+              "alt": "prestidigitation",
+              "aonid": 1639,
+              "game-obj": "Spells",
+              "name": "prestidigitation",
+              "type": "link"
+            },
+            {
+              "alt": "read aura",
+              "aonid": 1646,
+              "game-obj": "Spells",
+              "name": "read aura",
+              "type": "link"
+            }
+          ],
+          "name": "Cantrips (4th)",
+          "subtype": "ability",
+          "text": "*daze*, *detect magic*, *light*, *prestidigitation*, *read aura*",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "vision of death",
+          "aonid": 1742,
+          "game-obj": "Spells",
+          "name": "vision of death",
+          "type": "link"
+        },
+        {
+          "alt": "disguise magic",
+          "aonid": 1491,
+          "game-obj": "Spells",
+          "name": "disguise magic",
+          "type": "link"
+        },
+        {
+          "alt": "enthrall",
+          "aonid": 1516,
+          "game-obj": "Spells",
+          "name": "enthrall",
+          "type": "link"
+        },
+        {
+          "alt": "hypnotize",
+          "aonid": 1564,
+          "game-obj": "Spells",
+          "name": "hypnotize",
+          "type": "link"
+        },
+        {
+          "alt": "embed message",
+          "aonid": 1511,
+          "game-obj": "Spells",
+          "name": "embed message",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "see the unseen",
+          "aonid": 1663,
+          "game-obj": "Spells",
+          "name": "see the unseen",
+          "type": "link"
+        },
+        {
+          "alt": "item facade",
+          "aonid": 1579,
+          "game-obj": "Spells",
+          "name": "item facade",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal minion",
+          "aonid": 1631,
+          "game-obj": "Spells",
+          "name": "phantasmal minion",
+          "type": "link"
+        },
+        {
+          "alt": "ventriloquism",
+          "aonid": 1740,
+          "game-obj": "Spells",
+          "name": "ventriloquism",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        }
+      ],
+      "name": "Young Mirage Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 121",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 121",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "text": "Arcane Prepared Spells DC 27, attack +20; **4th** *confusion*, *vision of death*; **3rd** *disguise magic*, *enthrall*, *hypnotize*; **2nd** *embed message*, *revealing light*, *see the unseen*; **1st** *item facade*, *phantasmal minion*, *ventriloquism*; **Cantrips (4th)** *daze*, *detect magic*, *light*, *prestidigitation*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "mislead",
+          "aonid": 1605,
+          "game-obj": "Spells",
+          "name": "mislead",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal calamity",
+          "aonid": 1630,
+          "game-obj": "Spells",
+          "name": "phantasmal calamity",
+          "type": "link"
+        },
+        {
+          "alt": "false vision",
+          "aonid": 1522,
+          "game-obj": "Spells",
+          "name": "false vision",
+          "type": "link"
+        },
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic haul",
+          "aonid": 1716,
+          "game-obj": "Spells",
+          "name": "telekinetic haul",
+          "type": "link"
+        },
+        {
+          "alt": "vapor form",
+          "aonid": 1738,
+          "game-obj": "Spells",
+          "name": "vapor form",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Mirage Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 121",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 121",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young mirage dragon"
+          ],
+          "saving_throw": {
+            "dc": 35,
+            "subtype": "save_dc",
+            "text": "DC 35",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 27,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mislead",
+                      "aonid": 1605,
+                      "game-obj": "Spells",
+                      "name": "mislead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mislead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal calamity",
+                      "aonid": 1630,
+                      "game-obj": "Spells",
+                      "name": "phantasmal calamity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal calamity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "false vision",
+                      "aonid": 1522,
+                      "game-obj": "Spells",
+                      "name": "false vision",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "false vision",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic haul",
+                      "aonid": 1716,
+                      "game-obj": "Spells",
+                      "name": "telekinetic haul",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic haul",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vapor form",
+                      "aonid": 1738,
+                      "game-obj": "Spells",
+                      "name": "vapor form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vapor form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 35, attack +27; As young mirage dragon, plus **6th** *mislead*, *phantasmal calamity*; **5th** *false vision*, *sending*, *telekinetic haul*; **4th** *vapor form*; **Cantrips (6th)** *daze*, *detect magic*, *light*, *prestidigitation*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "disappearance",
+          "aonid": 1490,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "hallucination",
+          "aonid": 1551,
+          "game-obj": "Spells",
+          "name": "hallucination",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "contingency",
+          "aonid": 1472,
+          "game-obj": "Spells",
+          "name": "contingency",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "project image",
+          "aonid": 1640,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Mirage Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 121",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 121",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult mirage dragon"
+          ],
+          "saving_throw": {
+            "dc": 43,
+            "subtype": "save_dc",
+            "text": "DC 43",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 35,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 1490,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucination",
+                      "aonid": 1551,
+                      "game-obj": "Spells",
+                      "name": "hallucination",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucination",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "contingency",
+                      "aonid": 1472,
+                      "game-obj": "Spells",
+                      "name": "contingency",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "contingency",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 1640,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 43, attack +35; As adult mirage dragon, plus **8th** *disappearance*, *hallucination*, *hidden mind*; **7th** *contingency*, *mask of terror*, *project image*; **6th** *truesight*; **Cantrips (8th)** *daze*, *detect magic*, *light*, *prestidigitation*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "manifestation",
+          "aonid": 1592,
+          "game-obj": "Spells",
+          "name": "manifestation",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        },
+        {
+          "alt": "resplendent mansion",
+          "aonid": 2018,
+          "game-obj": "Spells",
+          "name": "resplendent mansion",
+          "type": "link"
+        }
+      ],
+      "name": "Mirage Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 121",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 121",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 121,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As ancient mirage dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "manifestation",
+                      "aonid": 1592,
+                      "game-obj": "Spells",
+                      "name": "manifestation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "manifestation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resplendent mansion",
+                      "aonid": 2018,
+                      "game-obj": "Spells",
+                      "name": "resplendent mansion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resplendent mansion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 45, attack +37; As ancient mirage dragon plus **10th** *manifestation*; **9th** *phantasmagoria*, *resplendent mansion*; **Cantrips (10th)** *daze*, *detect magic*, *light*, *prestidigitation*, *read aura*",
       "type": "section"
     },
     {
@@ -1833,6 +2518,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 121",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 121",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 121,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1994,6 +2742,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 121",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 121",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 121,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/dragon_omen.json
+++ b/monster_families/monster_core/dragon_omen.json
@@ -79,103 +79,49 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Forewarned and Forearmed",
-                "subtype": "ability",
-                "text": "At the start of the day, a dragon can perform a 10-minute ritual to prepare themself for any fights they might have in the day ahead. The dragon chooses one of the following effects, which last for 24 hours. Some omen dragons can partially manipulate the destinies of other creatures, linking them together. To make an omen dragon with this ability, replace Draconic Frenzy with the following.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Link Fates",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The omen dragon creates a bond between two creatures within 60 feet, entwining their destinies for 1 round. The first time during this duration that one of the creatures takes damage, the other takes an equal amount of mental damage, with a basic Will save (DC equal to the dragon\u2019s Destiny Breath DC).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 566,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -185,257 +131,110 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Being inundated with nebulous glimpses of the future can change how an omen dragon uses their powers. You can apply the following adjustments to an omen dragon of any age.  \n  \nSome omen dragons focus on staying a single step ahead of fate, using what they can see of the future to counteract immediate threats by giving up some of their long-term vision of the future. To make an omen dragon with these abilities, replace the dragon\u2019s Prophetic Wings with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 25,
-                  "subtype": "save_dc",
-                  "text": "DC 25",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 17,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dream message",
-                            "aonid": 1503,
-                            "game-obj": "Spells",
-                            "name": "dream message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dream message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hypercognition",
-                            "aonid": 1563,
-                            "game-obj": "Spells",
-                            "name": "hypercognition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hypercognition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "status",
-                            "aonid": 1690,
-                            "game-obj": "Spells",
-                            "name": "status",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "status",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stupefy",
-                            "aonid": 1691,
-                            "game-obj": "Spells",
-                            "name": "stupefy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stupefy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "protection",
-                            "aonid": 1641,
-                            "game-obj": "Spells",
-                            "name": "protection",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "protection",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Omen Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dream message",
+                "aonid": 1503,
+                "game-obj": "Spells",
+                "name": "dream message",
+                "type": "link"
+              },
+              {
+                "alt": "hypercognition",
+                "aonid": 1563,
+                "game-obj": "Spells",
+                "name": "hypercognition",
+                "type": "link"
+              },
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "status",
+                "aonid": 1690,
+                "game-obj": "Spells",
+                "name": "status",
+                "type": "link"
+              },
+              {
+                "alt": "stupefy",
+                "aonid": 1691,
+                "game-obj": "Spells",
+                "name": "stupefy",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "protection",
+                "aonid": 1641,
+                "game-obj": "Spells",
+                "name": "protection",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -451,169 +250,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young omen dragon"
-                ],
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "locate",
-                            "aonid": 1588,
-                            "game-obj": "Spells",
-                            "name": "locate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "locate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wave of despair",
-                            "aonid": 1757,
-                            "game-obj": "Spells",
-                            "name": "wave of despair",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wave of despair",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairvoyance",
-                            "aonid": 1466,
-                            "game-obj": "Spells",
-                            "name": "clairvoyance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairvoyance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read omens",
-                            "aonid": 1647,
-                            "game-obj": "Spells",
-                            "name": "read omens",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read omens",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "locate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Omen Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "locate",
+                "aonid": 1588,
+                "game-obj": "Spells",
+                "name": "locate",
+                "type": "link"
+              },
+              {
+                "alt": "wave of despair",
+                "aonid": 1757,
+                "game-obj": "Spells",
+                "name": "wave of despair",
+                "type": "link"
+              },
+              {
+                "alt": "clairvoyance",
+                "aonid": 1466,
+                "game-obj": "Spells",
+                "name": "clairvoyance",
+                "type": "link"
+              },
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "read omens",
+                "aonid": 1647,
+                "game-obj": "Spells",
+                "name": "read omens",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -629,193 +307,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult omen dragon"
-                ],
-                "saving_throw": {
-                  "dc": 39,
-                  "subtype": "save_dc",
-                  "text": "DC 39",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 31,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "never mind",
-                            "aonid": 1614,
-                            "game-obj": "Spells",
-                            "name": "never mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "never mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "visions of danger",
-                            "aonid": 358,
-                            "game-obj": "Spells",
-                            "name": "visions of danger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "visions of danger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "warp mind",
-                            "aonid": 1754,
-                            "game-obj": "Spells",
-                            "name": "warp mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "warp mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "repulsion",
-                            "aonid": 1650,
-                            "game-obj": "Spells",
-                            "name": "repulsion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "repulsion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scrying",
-                            "aonid": 1662,
-                            "game-obj": "Spells",
-                            "name": "scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Omen Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "never mind",
+                "aonid": 1614,
+                "game-obj": "Spells",
+                "name": "never mind",
+                "type": "link"
+              },
+              {
+                "alt": "visions of danger",
+                "aonid": 358,
+                "game-obj": "Spells",
+                "name": "visions of danger",
+                "type": "link"
+              },
+              {
+                "alt": "warp mind",
+                "aonid": 1754,
+                "game-obj": "Spells",
+                "name": "warp mind",
+                "type": "link"
+              },
+              {
+                "alt": "repulsion",
+                "aonid": 1650,
+                "game-obj": "Spells",
+                "name": "repulsion",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 1662,
+                "game-obj": "Spells",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -831,155 +378,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient omen dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "visions of danger",
-                            "aonid": 2040,
-                            "game-obj": "Spells",
-                            "name": "visions of danger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "visions of danger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusing colors",
-                            "aonid": 1980,
-                            "game-obj": "Spells",
-                            "name": "confusing colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusing colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Omen Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "visions of danger",
+                "aonid": 2040,
+                "game-obj": "Spells",
+                "name": "visions of danger",
+                "type": "link"
+              },
+              {
+                "alt": "confusing colors",
+                "aonid": 1980,
+                "game-obj": "Spells",
+                "name": "confusing colors",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -994,48 +434,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1046,263 +449,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1312,7 +499,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1321,6 +507,160 @@
   "name": "Dragon, Omen",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Forewarned and Forearmed",
+          "subtype": "ability",
+          "text": "At the start of the day, a dragon can perform a 10-minute ritual to prepare themself for any fights they might have in the day ahead. The dragon chooses one of the following effects, which last for 24 hours. Some omen dragons can partially manipulate the destinies of other creatures, linking them together. To make an omen dragon with this ability, replace Draconic Frenzy with the following.",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Link Fates",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "within 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The omen dragon creates a bond between two creatures within 60 feet, entwining their destinies for 1 round. The first time during this duration that one of the creatures takes damage, the other takes an equal amount of mental damage, with a basic Will save (DC equal to the dragon\u2019s Destiny Breath DC).",
+          "traits": [
+            {
+              "link": {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              "name": "curse",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 566,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 2297,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 123",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 123",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 123,
+          "type": "source"
+        }
+      ],
+      "text": "Being inundated with nebulous glimpses of the future can change how an omen dragon uses their powers. You can apply the following adjustments to an omen dragon of any age.  \n  \nSome omen dragons focus on staying a single step ahead of fate, using what they can see of the future to counteract immediate threats by giving up some of their long-term vision of the future. To make an omen dragon with these abilities, replace the dragon\u2019s Prophetic Wings with the following.   \n  \n**Forewarned and Forearmed** (occult) At the start of the day, a dragon can perform a 10-minute ritual to prepare themself for any fights they might have in the day ahead. The dragon chooses one of the following effects, which last for 24 hours. Some omen dragons can partially manipulate the destinies of other creatures, linking them together. To make an omen dragon with this ability, replace Draconic Frenzy with the following.  \n  \n**Link Fates** [##] (curse, mental, occult) The omen dragon creates a bond between two creatures within 60 feet, entwining their destinies for 1 round. The first time during this duration that one of the creatures takes damage, the other takes an equal amount of mental damage, with a basic Will save (DC equal to the dragon\u2019s Destiny Breath DC).",
+      "type": "section"
+    },
     {
       "name": "Gurvallinn",
       "sources": [
@@ -1397,6 +737,1079 @@
         }
       ],
       "text": "Omen dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dream message",
+          "aonid": 1503,
+          "game-obj": "Spells",
+          "name": "dream message",
+          "type": "link"
+        },
+        {
+          "alt": "hypercognition",
+          "aonid": 1563,
+          "game-obj": "Spells",
+          "name": "hypercognition",
+          "type": "link"
+        },
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "status",
+          "aonid": 1690,
+          "game-obj": "Spells",
+          "name": "status",
+          "type": "link"
+        },
+        {
+          "alt": "stupefy",
+          "aonid": 1691,
+          "game-obj": "Spells",
+          "name": "stupefy",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "protection",
+          "aonid": 1641,
+          "game-obj": "Spells",
+          "name": "protection",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        }
+      ],
+      "name": "Young Omen Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 123",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 123",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 123,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 25,
+            "subtype": "save_dc",
+            "text": "DC 25",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 17,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dream message",
+                      "aonid": 1503,
+                      "game-obj": "Spells",
+                      "name": "dream message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dream message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hypercognition",
+                      "aonid": 1563,
+                      "game-obj": "Spells",
+                      "name": "hypercognition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hypercognition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "status",
+                      "aonid": 1690,
+                      "game-obj": "Spells",
+                      "name": "status",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "status",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stupefy",
+                      "aonid": 1691,
+                      "game-obj": "Spells",
+                      "name": "stupefy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stupefy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "protection",
+                      "aonid": 1641,
+                      "game-obj": "Spells",
+                      "name": "protection",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "protection",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 25, attack +17; **3rd** *dream message*, *hypercognition*; **2nd** *clear mind*, *status*, *stupefy*; **1st** *command*, *fear*, *protection*; **Cantrips (3rd)** *daze*, *detect magic*, *know the way*, *message*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "locate",
+          "aonid": 1588,
+          "game-obj": "Spells",
+          "name": "locate",
+          "type": "link"
+        },
+        {
+          "alt": "wave of despair",
+          "aonid": 1757,
+          "game-obj": "Spells",
+          "name": "wave of despair",
+          "type": "link"
+        },
+        {
+          "alt": "clairvoyance",
+          "aonid": 1466,
+          "game-obj": "Spells",
+          "name": "clairvoyance",
+          "type": "link"
+        },
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "read omens",
+          "aonid": 1647,
+          "game-obj": "Spells",
+          "name": "read omens",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Omen Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 123",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 123",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 123,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young omen dragon"
+          ],
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "locate",
+                      "aonid": 1588,
+                      "game-obj": "Spells",
+                      "name": "locate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "locate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wave of despair",
+                      "aonid": 1757,
+                      "game-obj": "Spells",
+                      "name": "wave of despair",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wave of despair",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairvoyance",
+                      "aonid": 1466,
+                      "game-obj": "Spells",
+                      "name": "clairvoyance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairvoyance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read omens",
+                      "aonid": 1647,
+                      "game-obj": "Spells",
+                      "name": "read omens",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read omens",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "locate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 30, attack +22; As young omen dragon, plus **5th** *locate*, *wave of despair*; **4th** *clairvoyance*, *confusion*, *read omens*; **3rd** *locate*; **Cantrips (5th)** *daze*, *detect magic*, *know the way*, *message*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "never mind",
+          "aonid": 1614,
+          "game-obj": "Spells",
+          "name": "never mind",
+          "type": "link"
+        },
+        {
+          "alt": "visions of danger",
+          "aonid": 358,
+          "game-obj": "Spells",
+          "name": "visions of danger",
+          "type": "link"
+        },
+        {
+          "alt": "warp mind",
+          "aonid": 1754,
+          "game-obj": "Spells",
+          "name": "warp mind",
+          "type": "link"
+        },
+        {
+          "alt": "repulsion",
+          "aonid": 1650,
+          "game-obj": "Spells",
+          "name": "repulsion",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 1662,
+          "game-obj": "Spells",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Omen Dragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 123",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 123",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 123,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult omen dragon"
+          ],
+          "saving_throw": {
+            "dc": 39,
+            "subtype": "save_dc",
+            "text": "DC 39",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 31,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "never mind",
+                      "aonid": 1614,
+                      "game-obj": "Spells",
+                      "name": "never mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "never mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "visions of danger",
+                      "aonid": 358,
+                      "game-obj": "Spells",
+                      "name": "visions of danger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "visions of danger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "warp mind",
+                      "aonid": 1754,
+                      "game-obj": "Spells",
+                      "name": "warp mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "warp mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "repulsion",
+                      "aonid": 1650,
+                      "game-obj": "Spells",
+                      "name": "repulsion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "repulsion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scrying",
+                      "aonid": 1662,
+                      "game-obj": "Spells",
+                      "name": "scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 39, attack +31; As adult omen dragon, plus **7th** *never mind*, *visions of danger*, *warp mind*; **6th** *repulsion*, *scrying*, *truesight*; **5th** *sending*; **Cantrips (7th)** *daze*, *detect magic*, *know the way*, *message*, *read aura*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "visions of danger",
+          "aonid": 2040,
+          "game-obj": "Spells",
+          "name": "visions of danger",
+          "type": "link"
+        },
+        {
+          "alt": "confusing colors",
+          "aonid": 1980,
+          "game-obj": "Spells",
+          "name": "confusing colors",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        }
+      ],
+      "name": "Omen Archdragon",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 123",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 123",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 123,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient omen dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "visions of danger",
+                      "aonid": 2040,
+                      "game-obj": "Spells",
+                      "name": "visions of danger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "visions of danger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusing colors",
+                      "aonid": 1980,
+                      "game-obj": "Spells",
+                      "name": "confusing colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusing colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 44, attack +36; As ancient omen dragon plus **9th** *foresight*, *visions of danger*; **8th** *confusing colors*, *hidden mind*, *pinpoint*; **Cantrips (9th)** *daze*, *detect magic*, *know the way*, *message*, *read aura*",
       "type": "section"
     },
     {
@@ -1718,6 +2131,69 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 123",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 123",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 123,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1879,6 +2355,307 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 123",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 123",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 123,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core/ghost.json
+++ b/monster_families/monster_core/ghost.json
@@ -133,305 +133,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Site Bound",
-                "subtype": "ability",
-                "text": "A typical ghost can stray only a short distance from where it was killed or the place it haunts. A typical limit is 120 feet. Some ghosts are instead bound to a room, building, item, or creature that was special to it rather than a location.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Rejuvenation",
-                "subtype": "ability",
-                "text": "When a ghost is destroyed, it re-forms after 2d4 days within the location it's bound to, fully healed. A ghost can be permanently destroyed only if someone sets right whatever prevents the spirit from resting.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "force",
-                    "aonid": 610,
-                    "game-obj": "Traits",
-                    "name": "force",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ghost touch",
-                    "aonid": 2840,
-                    "game-obj": "Equipment",
-                    "name": "ghost touch",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "spirit",
-                    "aonid": 737,
-                    "game-obj": "Traits",
-                    "name": "spirit",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "vitality",
-                    "aonid": 509,
-                    "game-obj": "Traits",
-                    "name": "vitality",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magical",
-                    "aonid": 644,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "bleed, death effects, disease, paralyzed, poison, precision, unconscious Resistances all damage 5 (except force, *ghost touch*, spirit, or vitality; double resistance to non-magical). This resistance increases to 10 at 9th level and 15 at 16th level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Fly Speed",
-                "subtype": "ability",
-                "text": "equal to its Speed",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 526,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "finesse",
-                    "aonid": 602,
-                    "game-obj": "Traits",
-                    "name": "finesse",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magical",
-                    "aonid": 644,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ghostly Hand",
-                "subtype": "ability",
-                "text": "All ghosts have a ghostly hand unarmed attack that deals void damage. It typically has the agile, finesse, and magical traits. Some ghosts wield ghostly memories of weapons they held in life, but the effect is the same.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Ghost Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -484,6 +190,118 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "force",
+                "aonid": 610,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              {
+                "alt": "ghost touch",
+                "aonid": 2840,
+                "game-obj": "Equipment",
+                "name": "ghost touch",
+                "type": "link"
+              },
+              {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 644,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 526,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "finesse",
+                "aonid": 602,
+                "game-obj": "Traits",
+                "name": "finesse",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 644,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -493,282 +311,16 @@
         ],
         "name": "Ghost Abilities",
         "subtype": "monster_family",
-        "text": "A ghost gains the ghost, incorporeal, spirit, and undead traits. Many become unholy. The base creature loses any traits that represented its life as a living creature, such as human and humanoid, and any abilities or traits that rely on it being a living, corporeal creature. You might also need to adjust some abilities that conflict with the theme of a ghost. All ghosts gain the following abilities.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "void",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 94,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Corrupting Gaze",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost stares at a creature it can see within 30 feet. The target takes 1d6 void damage plus 1d6 for every 2 levels the ghost has with a basic Will save. A creature that fails its save is also stupefied 1 for 1 minute.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Draining Touch",
-                "subtype": "ability",
-                "text": "With a touch, the ghost attempts to drain a living creature's life force. It makes a ghostly hand Strike but deals no damage on a hit. Instead, the target becomes drained 1 for 1 day, and the ghost regains HP equal to half its own level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "frightened 2",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Frightful Moan",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost laments its fate, forcing each living creature within 30 feet to attempt a Will save. On a failure, a creature becomes frightened 2 (or frightened 3 on a critical failure). On a success, a creature is temporarily immune to this ghost's frightful moan for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 541,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "animated object",
-                    "aonid": 4,
-                    "game-obj": "MonsterFamilies",
-                    "name": "animated object",
-                    "type": "link"
-                  }
-                ],
-                "name": "Inhabit Object",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "within 20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The ghost possesses an object of size Large or smaller within 20 feet, making it an animated object. This animated object's level can be no higher than the ghost's level \u2013 2. If the target object is being held by a creature,  the bearer can attempt a Will save to prevent the possession. This possession ends when the object is destroyed or the ghost leaves it. At this point, the ghost reappears in the object's square and can't Inhabit an Object again for 1d4 rounds.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "possession",
-                    "aonid": 1638,
-                    "game-obj": "Spells",
-                    "name": "possession",
-                    "type": "link"
-                  }
-                ],
-                "name": "Malevolent Possession",
-                "subtype": "ability",
-                "text": "The ghost attempts to possess an adjacent corporeal creature. This has the same effect as the *possession* spell, except since the ghost doesn't have a physical body, it is unaffected by that restriction of the spell.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Telekinetic Assault",
-                "subtype": "ability",
-                "text": "The ghost cries out in pain and anguish as small objects and debris fly about in a 30-foot emanation. Creatures in this area take 1d6 bludgeoning damage + 1d6 per 2 levels the ghost has, with a basic Reflex save.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Special Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -779,6 +331,97 @@
                 "game-obj": "Rules",
                 "name": "ghost's level",
                 "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 1",
+                "aonid": 94,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 2",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened 2",
+                "type": "link"
+              },
+              {
+                "alt": "animated object",
+                "aonid": 4,
+                "game-obj": "MonsterFamilies",
+                "name": "animated object",
+                "type": "link"
+              },
+              {
+                "alt": "possession",
+                "aonid": 1638,
+                "game-obj": "Spells",
+                "name": "possession",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -788,7 +431,6 @@
         ],
         "name": "Special Abilities",
         "subtype": "monster_family",
-        "text": "Select one or two of the following abilities, or potentially three if the ghost is 9th level or higher. These should relate to the ghost's death or its history. You can also create new abilities or adapt those from monsters or classes. For DCs, use the high spell DC of the ghost's level.",
         "type": "stat_block_section"
       }
     ],
@@ -821,6 +463,880 @@
         }
       ],
       "text": "You can also use the following guidelines to turn living creatures into ghosts. Increase the creature's level by 2 and change its statistics as follows.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Darkvision",
+            "aonid": 12,
+            "game-obj": "MonsterAbilities",
+            "name": "Darkvision",
+            "type": "link"
+          },
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Site Bound",
+          "subtype": "ability",
+          "text": "A typical ghost can stray only a short distance from where it was killed or the place it haunts. A typical limit is 120 feet. Some ghosts are instead bound to a room, building, item, or creature that was special to it rather than a location.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Rejuvenation",
+          "subtype": "ability",
+          "text": "When a ghost is destroyed, it re-forms after 2d4 days within the location it's bound to, fully healed. A ghost can be permanently destroyed only if someone sets right whatever prevents the spirit from resting.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 42,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "force",
+              "aonid": 610,
+              "game-obj": "Traits",
+              "name": "force",
+              "type": "link"
+            },
+            {
+              "alt": "ghost touch",
+              "aonid": 2840,
+              "game-obj": "Equipment",
+              "name": "ghost touch",
+              "type": "link"
+            },
+            {
+              "alt": "spirit",
+              "aonid": 737,
+              "game-obj": "Traits",
+              "name": "spirit",
+              "type": "link"
+            },
+            {
+              "alt": "vitality",
+              "aonid": 509,
+              "game-obj": "Traits",
+              "name": "vitality",
+              "type": "link"
+            },
+            {
+              "alt": "magical",
+              "aonid": 644,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "bleed, death effects, disease, paralyzed, poison, precision, unconscious Resistances all damage 5 (except force, *ghost touch*, spirit, or vitality; double resistance to non-magical). This resistance increases to 10 at 9th level and 15 at 16th level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Fly Speed",
+          "subtype": "ability",
+          "text": "equal to its Speed",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 526,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "finesse",
+              "aonid": 602,
+              "game-obj": "Traits",
+              "name": "finesse",
+              "type": "link"
+            },
+            {
+              "alt": "magical",
+              "aonid": 644,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            }
+          ],
+          "name": "Ghostly Hand",
+          "subtype": "ability",
+          "text": "All ghosts have a ghostly hand unarmed attack that deals void damage. It typically has the agile, finesse, and magical traits. Some ghosts wield ghostly memories of weapons they held in life, but the effect is the same.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "ghost",
+          "aonid": 753,
+          "game-obj": "Traits",
+          "name": "ghost",
+          "type": "link"
+        },
+        {
+          "alt": "incorporeal",
+          "aonid": 632,
+          "game-obj": "Traits",
+          "name": "incorporeal",
+          "type": "link"
+        },
+        {
+          "alt": "spirit",
+          "aonid": 737,
+          "game-obj": "Traits",
+          "name": "spirit",
+          "type": "link"
+        },
+        {
+          "alt": "undead",
+          "aonid": 722,
+          "game-obj": "Traits",
+          "name": "undead",
+          "type": "link"
+        },
+        {
+          "alt": "unholy",
+          "aonid": 521,
+          "game-obj": "Traits",
+          "name": "unholy",
+          "type": "link"
+        },
+        {
+          "alt": "human",
+          "aonid": 627,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Darkvision",
+          "aonid": 12,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 42,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "force",
+          "aonid": 610,
+          "game-obj": "Traits",
+          "name": "force",
+          "type": "link"
+        },
+        {
+          "alt": "ghost touch",
+          "aonid": 2840,
+          "game-obj": "Equipment",
+          "name": "ghost touch",
+          "type": "link"
+        },
+        {
+          "alt": "spirit",
+          "aonid": 737,
+          "game-obj": "Traits",
+          "name": "spirit",
+          "type": "link"
+        },
+        {
+          "alt": "vitality",
+          "aonid": 509,
+          "game-obj": "Traits",
+          "name": "vitality",
+          "type": "link"
+        },
+        {
+          "alt": "magical",
+          "aonid": 644,
+          "game-obj": "Traits",
+          "name": "magical",
+          "type": "link"
+        },
+        {
+          "alt": "agile",
+          "aonid": 526,
+          "game-obj": "Traits",
+          "name": "agile",
+          "type": "link"
+        },
+        {
+          "alt": "finesse",
+          "aonid": 602,
+          "game-obj": "Traits",
+          "name": "finesse",
+          "type": "link"
+        },
+        {
+          "alt": "magical",
+          "aonid": 644,
+          "game-obj": "Traits",
+          "name": "magical",
+          "type": "link"
+        }
+      ],
+      "name": "Ghost Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 160",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 160",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 160,
+          "type": "source"
+        }
+      ],
+      "text": "A ghost gains the ghost, incorporeal, spirit, and undead traits. Many become unholy. The base creature loses any traits that represented its life as a living creature, such as human and humanoid, and any abilities or traits that rely on it being a living, corporeal creature. You might also need to adjust some abilities that conflict with the theme of a ghost. All ghosts gain the following abilities.  \n  \n**Darkvision**  \n**Site Bound** A typical ghost can stray only a short distance from where it was killed or the place it haunts. A typical limit is 120 feet. Some ghosts are instead bound to a room, building, item, or creature that was special to it rather than a location.   \n**Rejuvenation** (divine) When a ghost is destroyed, it re-forms after 2d4 days within the location it's bound to, fully healed. A ghost can be permanently destroyed only if someone sets right whatever prevents the spirit from resting.  \n**Void Healing**  \n**Immunities** bleed, death effects, disease, paralyzed, poison, precision, unconscious Resistances all damage 5 (except force, *ghost touch*, spirit, or vitality; double resistance to non-magical). This resistance increases to 10 at 9th level and 15 at 16th level.   \n**Fly Speed** equal to its Speed  \n**Ghostly Hand** All ghosts have a ghostly hand unarmed attack that deals void damage. It typically has the agile, finesse, and magical traits. Some ghosts wield ghostly memories of weapons they held in life, but the effect is the same.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "void",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied 1",
+              "aonid": 94,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            }
+          ],
+          "name": "Corrupting Gaze",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "within 30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The ghost stares at a creature it can see within 30 feet. The target takes 1d6 void damage plus 1d6 for every 2 levels the ghost has with a basic Will save. A creature that fails its save is also stupefied 1 for 1 minute.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Draining Touch",
+          "subtype": "ability",
+          "text": "With a touch, the ghost attempts to drain a living creature's life force. It makes a ghostly hand Strike but deals no damage on a hit. Instead, the target becomes drained 1 for 1 day, and the ghost regains HP equal to half its own level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "frightened 2",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened 2",
+              "type": "link"
+            }
+          ],
+          "name": "Frightful Moan",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "within 30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The ghost laments its fate, forcing each living creature within 30 feet to attempt a Will save. On a failure, a creature becomes frightened 2 (or frightened 3 on a critical failure). On a success, a creature is temporarily immune to this ghost's frightful moan for 1 minute.",
+          "traits": [
+            {
+              "link": {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              "name": "auditory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "frequency": "1d4 rounds",
+          "links": [
+            {
+              "alt": "animated object",
+              "aonid": 4,
+              "game-obj": "MonsterFamilies",
+              "name": "animated object",
+              "type": "link"
+            }
+          ],
+          "name": "Inhabit Object",
+          "range": {
+            "range": 20,
+            "subtype": "range",
+            "text": "within 20 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The ghost possesses an object of size Large or smaller within 20 feet, making it an animated object. This animated object's level can be no higher than the ghost's level \u2013 2. If the target object is being held by a creature,  the bearer can attempt a Will save to prevent the possession. This possession ends when the object is destroyed or the ghost leaves it. At this point, the ghost reappears in the object's square and can't Inhabit an Object again for 1d4 rounds.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "possession",
+              "aonid": 1638,
+              "game-obj": "Spells",
+              "name": "possession",
+              "type": "link"
+            }
+          ],
+          "name": "Malevolent Possession",
+          "subtype": "ability",
+          "text": "The ghost attempts to possess an adjacent corporeal creature. This has the same effect as the *possession* spell, except since the ghost doesn't have a physical body, it is unaffected by that restriction of the spell.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "bludgeoning",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Telekinetic Assault",
+          "subtype": "ability",
+          "text": "The ghost cries out in pain and anguish as small objects and debris fly about in a 30-foot emanation. Creatures in this area take 1d6 bludgeoning damage + 1d6 per 2 levels the ghost has, with a basic Reflex save.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "ghost's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "ghost's level",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "stupefied 1",
+          "aonid": 94,
+          "game-obj": "Conditions",
+          "name": "stupefied 1",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "auditory",
+          "aonid": 541,
+          "game-obj": "Traits",
+          "name": "auditory",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "frightened 2",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened 2",
+          "type": "link"
+        },
+        {
+          "alt": "animated object",
+          "aonid": 4,
+          "game-obj": "MonsterFamilies",
+          "name": "animated object",
+          "type": "link"
+        },
+        {
+          "alt": "possession",
+          "aonid": 1638,
+          "game-obj": "Spells",
+          "name": "possession",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        }
+      ],
+      "name": "Special Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 160",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 160",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 160,
+          "type": "source"
+        }
+      ],
+      "text": "Select one or two of the following abilities, or potentially three if the ghost is 9th level or higher. These should relate to the ghost's death or its history. You can also create new abilities or adapt those from monsters or classes. For DCs, use the high spell DC of the ghost's level.  \n  \n**Corrupting Gaze** [##] The ghost stares at a creature it can see within 30 feet. The target takes 1d6 void damage plus 1d6 for every 2 levels the ghost has with a basic Will save. A creature that fails its save is also stupefied 1 for 1 minute.  \n**Draining Touch** [##] With a touch, the ghost attempts to drain a living creature's life force. It makes a ghostly hand Strike but deals no damage on a hit. Instead, the target becomes drained 1 for 1 day, and the ghost regains HP equal to half its own level.  \n**Frightful Moan** [#] (auditory, divine, emotion, fear, mental) The ghost laments its fate, forcing each living creature within 30 feet to attempt a Will save. On a failure, a creature becomes frightened 2 (or frightened 3 on a critical failure). On a success, a creature is temporarily immune to this ghost's frightful moan for 1 minute.  \n**Inhabit Object** [#] The ghost possesses an object of size Large or smaller within 20 feet, making it an animated object. This animated object's level can be no higher than the ghost's level \u2013 2. If the target object is being held by a creature, the bearer can attempt a Will save to prevent the possession. This possession ends when the object is destroyed or the ghost leaves it. At this point, the ghost reappears in the object's square and can't Inhabit an Object again for 1d4 rounds.  \n**Malevolent Possession** [##] The ghost attempts to possess an adjacent corporeal creature. This has the same effect as the *possession* spell, except since the ghost doesn't have a physical body, it is unaffected by that restriction of the spell.  \n**Telekinetic Assault** [##] (divine) The ghost cries out in pain and anguish as small objects and debris fly about in a 30-foot emanation. Creatures in this area take 1d6 bludgeoning damage + 1d6 per 2 levels the ghost has, with a basic Reflex save.",
       "type": "section"
     }
   ],

--- a/monster_families/monster_core/ghoul.json
+++ b/monster_families/monster_core/ghoul.json
@@ -154,296 +154,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Burrow",
-                "subtype": "ability",
-                "text": "The ghoul gains a burrow speed of 5 feet.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 526,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unarmed",
-                    "aonid": 719,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grab",
-                    "aonid": 45,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the creature had hands, it gains a claw Strike (an agile unarmed attack that deals slashing damage plus Grab). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Jaws",
-                "subtype": "ability",
-                "text": "If the creature had a mouth, it gains a jaws Strike (an unarmed attack that deals slashing damage). The damage amount should be the same as the creature's non-agile attacks.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ghoul devours a chunk of the corpse and regains 1d6 Hit Points plus 1d6 for every 2 levels the ghoul has. It can regain Hit Points from any given corpse only once.",
-                "links": [
-                  {
-                    "alt": "manipulate",
-                    "aonid": 2229,
-                    "game-obj": "Actions",
-                    "name": "manipulate",
-                    "type": "link"
-                  }
-                ],
-                "name": "Consume Flesh",
-                "requirement": "The ghoul is adjacent to the corpse of a creature that died within the last hour",
-                "subtype": "ability",
-                "text": "(manipulate);",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ghoul whispers dark thoughts and vile cravings into the creature's ears. The creature must save against the forbidden cravings curse.",
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 77,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 90,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ghoul Whispers",
-                "requirement": "A grabbed, paralyzed, restrained, or unconscious creature is within the ghoul's reach",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 541,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "linguistic",
-                      "aonid": 642,
-                      "game-obj": "Traits",
-                      "name": "linguistic",
-                      "type": "link"
-                    },
-                    "name": "linguistic",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "high spell DC for the ghoul's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high spell DC for the ghoul's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Forbidden Cravings",
-                "saving_throw": [
-                  {
-                    "save_type": "Will",
-                    "subtype": "save_dc",
-                    "text": "Will, using the high spell DC for the ghoul's level",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "carrier with no ill effects (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "2d6 void damage and the target is sickened 1 until it consumes raw meat (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "as stage 2",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 4",
-                    "subtype": "affliction_stage",
-                    "text": "as stage 2 unless the target has consumed raw meat in the past 24 hours, then it takes 4d6 void damage and is sickened 2 until it consumes raw meat",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 5",
-                    "subtype": "affliction_stage",
-                    "text": "if the creature has eaten raw meat in the past 24 hours, it dies and rises as a ghoul, if not, it returns to stage 4",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "A creature can still eat and drink while sickened by this curse;",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 566,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "effect": "The ghoul calls upon knowledge it retains from one creature it has consumed in the past 7 days. The ghoul attempts a skill check using a skill in which the consumed creature was trained (if it's unclear whether the creature was trained, the GM decides). The ghoul is treated  as trained and uses the high skill modifier for the ghoul's level. This takes the same amount of actions or time as usual for the check.",
-                "frequency": "once per hour",
-                "links": [
-                  {
-                    "alt": "high skill modifier for the ghoul's level",
-                    "aonid": 2885,
-                    "game-obj": "Rules",
-                    "name": "high skill modifier for the ghoul's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grave Knowledge",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Swift Leap",
-                "subtype": "ability",
-                "text": "The ghoul jumps up to half its Speed. This movement doesn't trigger reactions.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "move",
-                      "aonid": 658,
-                      "game-obj": "Traits",
-                      "name": "move",
-                      "type": "link"
-                    },
-                    "name": "move",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Ghoul Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -531,6 +246,118 @@
                 "game-obj": "Rules",
                 "name": "moderate spell DC for the ghoul's level",
                 "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 526,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 719,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 45,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 2229,
+                "game-obj": "Actions",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "linguistic",
+                "aonid": 642,
+                "game-obj": "Traits",
+                "name": "linguistic",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 77,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 90,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "high spell DC for the ghoul's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high spell DC for the ghoul's level",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "high skill modifier for the ghoul's level",
+                "aonid": 2885,
+                "game-obj": "Rules",
+                "name": "high skill modifier for the ghoul's level",
+                "type": "link"
+              },
+              {
+                "alt": "move",
+                "aonid": 658,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -540,7 +367,6 @@
         ],
         "name": "Ghoul Abilities",
         "subtype": "monster_family",
-        "text": "A ghoul gains the undead and ghoul traits, and it usually becomes unholy. If the base creature has any abilities that come from it being a living creature, it loses them. It also loses any traits that represent its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the theme of a ghoul. All ghouls gain the following abilities. The save DC for all abilities uses the high spell DC of the ghoul's level.  \n  \nDarkvision  \nVoid Healing  \n Immunities bleed, death effects, disease, paralyzed, poison, unconscious  \nStench (aura, olfactory) 10 feet. Use the moderate spell DC for the ghoul's level.",
         "type": "stat_block_section"
       }
     ],
@@ -573,6 +399,543 @@
         }
       ],
       "text": "The monsters in this section are built from the ground up. Custom-building ghouls is recommended if you have time, using the special abilities listed here but creating the other statistics to match what you want the ghoul to be. You can also turn a living creature into a ghoul by completing the following steps. First, increase the creature's level by 1 and change its statistics as follows.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Burrow",
+          "subtype": "ability",
+          "text": "The ghoul gains a burrow speed of 5 feet.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 526,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "unarmed",
+              "aonid": 719,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            },
+            {
+              "alt": "Grab",
+              "aonid": 45,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Claws",
+          "subtype": "ability",
+          "text": "If the creature had hands, it gains a claw Strike (an agile unarmed attack that deals slashing damage plus Grab). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Jaws",
+          "subtype": "ability",
+          "text": "If the creature had a mouth, it gains a jaws Strike (an unarmed attack that deals slashing damage). The damage amount should be the same as the creature's non-agile attacks.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The ghoul devours a chunk of the corpse and regains 1d6 Hit Points plus 1d6 for every 2 levels the ghoul has. It can regain Hit Points from any given corpse only once.",
+          "links": [
+            {
+              "alt": "manipulate",
+              "aonid": 2229,
+              "game-obj": "Actions",
+              "name": "manipulate",
+              "type": "link"
+            }
+          ],
+          "name": "Consume Flesh",
+          "requirement": "The ghoul is adjacent to the corpse of a creature that died within the last hour",
+          "subtype": "ability",
+          "text": "(manipulate);",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The ghoul whispers dark thoughts and vile cravings into the creature's ears. The creature must save against the forbidden cravings curse.",
+          "links": [
+            {
+              "alt": "grabbed",
+              "aonid": 77,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 90,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Ghoul Whispers",
+          "requirement": "A grabbed, paralyzed, restrained, or unconscious creature is within the ghoul's reach",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              "name": "auditory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "linguistic",
+                "aonid": 642,
+                "game-obj": "Traits",
+                "name": "linguistic",
+                "type": "link"
+              },
+              "name": "linguistic",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "affliction",
+          "links": [
+            {
+              "alt": "high spell DC for the ghoul's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high spell DC for the ghoul's level",
+              "type": "link"
+            }
+          ],
+          "name": "Forbidden Cravings",
+          "saving_throw": [
+            {
+              "save_type": "Will",
+              "subtype": "save_dc",
+              "text": "Will, using the high spell DC for the ghoul's level",
+              "type": "stat_block_section"
+            }
+          ],
+          "stages": [
+            {
+              "name": "Stage 1",
+              "subtype": "affliction_stage",
+              "text": "carrier with no ill effects (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 2",
+              "subtype": "affliction_stage",
+              "text": "2d6 void damage and the target is sickened 1 until it consumes raw meat (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 3",
+              "subtype": "affliction_stage",
+              "text": "as stage 2",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 4",
+              "subtype": "affliction_stage",
+              "text": "as stage 2 unless the target has consumed raw meat in the past 24 hours, then it takes 4d6 void damage and is sickened 2 until it consumes raw meat",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 5",
+              "subtype": "affliction_stage",
+              "text": "if the creature has eaten raw meat in the past 24 hours, it dies and rises as a ghoul, if not, it returns to stage 4",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "A creature can still eat and drink while sickened by this curse;",
+          "traits": [
+            {
+              "link": {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              "name": "curse",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "effect": "The ghoul calls upon knowledge it retains from one creature it has consumed in the past 7 days. The ghoul attempts a skill check using a skill in which the consumed creature was trained (if it's unclear whether the creature was trained, the GM decides). The ghoul is treated  as trained and uses the high skill modifier for the ghoul's level. This takes the same amount of actions or time as usual for the check.",
+          "frequency": "once per hour",
+          "links": [
+            {
+              "alt": "high skill modifier for the ghoul's level",
+              "aonid": 2885,
+              "game-obj": "Rules",
+              "name": "high skill modifier for the ghoul's level",
+              "type": "link"
+            }
+          ],
+          "name": "Grave Knowledge",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Swift Leap",
+          "subtype": "ability",
+          "text": "The ghoul jumps up to half its Speed. This movement doesn't trigger reactions.",
+          "traits": [
+            {
+              "link": {
+                "alt": "move",
+                "aonid": 658,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
+              },
+              "name": "move",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "high spell DC of the ghoul's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high spell DC of the ghoul's level",
+          "type": "link"
+        },
+        {
+          "alt": "Darkvision",
+          "aonid": 59,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "Stench",
+          "aonid": 76,
+          "game-obj": "MonsterAbilities",
+          "name": "Stench",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "olfactory",
+          "aonid": 664,
+          "game-obj": "Traits",
+          "name": "olfactory",
+          "type": "link"
+        },
+        {
+          "alt": "moderate spell DC for the ghoul's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "moderate spell DC for the ghoul's level",
+          "type": "link"
+        },
+        {
+          "alt": "agile",
+          "aonid": 526,
+          "game-obj": "Traits",
+          "name": "agile",
+          "type": "link"
+        },
+        {
+          "alt": "unarmed",
+          "aonid": 719,
+          "game-obj": "Traits",
+          "name": "unarmed",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 45,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 2229,
+          "game-obj": "Actions",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "auditory",
+          "aonid": 541,
+          "game-obj": "Traits",
+          "name": "auditory",
+          "type": "link"
+        },
+        {
+          "alt": "linguistic",
+          "aonid": 642,
+          "game-obj": "Traits",
+          "name": "linguistic",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "grabbed",
+          "aonid": 77,
+          "game-obj": "Conditions",
+          "name": "grabbed",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 90,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 566,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "high spell DC for the ghoul's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high spell DC for the ghoul's level",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "high skill modifier for the ghoul's level",
+          "aonid": 2885,
+          "game-obj": "Rules",
+          "name": "high skill modifier for the ghoul's level",
+          "type": "link"
+        },
+        {
+          "alt": "move",
+          "aonid": 658,
+          "game-obj": "Traits",
+          "name": "move",
+          "type": "link"
+        }
+      ],
+      "name": "Ghoul Abilities",
+      "sections": [
+        {
+          "name": "Ghoulish Society",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 162",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 162",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 162,
+              "type": "source"
+            }
+          ],
+          "text": "Ghouls are quite intelligent and, more so than almost any other undead, prone to forming societies and cultures (if vile and repugnant ones centered around flesh eating and other acts of depravity) in tangled warrens below boneyards, or even entire cities hidden away in the depths of the Darklands.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 162",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 162",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 162,
+          "type": "source"
+        }
+      ],
+      "text": "A ghoul gains the undead and ghoul traits, and it usually becomes unholy. If the base creature has any abilities that come from it being a living creature, it loses them. It also loses any traits that represent its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the theme of a ghoul. All ghouls gain the following abilities. The save DC for all abilities uses the high spell DC of the ghoul's level.  \n  \nDarkvision  \nVoid Healing  \n Immunities bleed, death effects, disease, paralyzed, poison, unconscious  \nStench (aura, olfactory) 10 feet. Use the moderate spell DC for the ghoul's level.  \n**Burrow** The ghoul gains a burrow speed of 5 feet.  \n**Claws** If the creature had hands, it gains a claw Strike (an agile unarmed attack that deals slashing damage plus Grab). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.  \n**Jaws** If the creature had a mouth, it gains a jaws Strike (an unarmed attack that deals slashing damage). The damage amount should be the same as the creature's non-agile attacks.  \n**Consume Flesh** [#] (manipulate); **Requirements** The ghoul is adjacent to the corpse of a creature that died within the last hour; **Effect** The ghoul devours a chunk of the corpse and regains 1d6 Hit Points plus 1d6 for every 2 levels the ghoul has. It can regain Hit Points from any given corpse only once.  \n**Ghoul Whispers** [#] (auditory, linguistic, occult); **Requirement** A grabbed, paralyzed, restrained, or unconscious creature is within the ghoul's reach; **Effect** The ghoul whispers dark thoughts and vile cravings into the creature's ears. The creature must save against the forbidden cravings curse.  \n**Forbidden Cravings** (curse) A creature can still eat and drink while sickened by this curse; **Saving Throw** Will, using the high spell DC for the ghoul's level; **Stage 1** carrier with no ill effects (1 day); **Stage 2** 2d6 void damage and the target is sickened 1 until it consumes raw meat (1 day); **Stage 3** as stage 2; **Stage 4** as stage 2 unless the target has consumed raw meat in the past 24 hours, then it takes 4d6 void damage and is sickened 2 until it consumes raw meat; **Stage 5** if the creature has eaten raw meat in the past 24 hours, it dies and rises as a ghoul, if not, it returns to stage 4  \n**Grave Knowledge** (occult) **Frequency** once per hour; **Effect** The ghoul calls upon knowledge it retains from one creature it has consumed in the past 7 days. The ghoul attempts a skill check using a skill in which the consumed creature was trained (if it's unclear whether the creature was trained, the GM decides). The ghoul is treated as trained and uses the high skill modifier for the ghoul's level. This takes the same amount of actions or time as usual for the check.  \n  \n The ghoul can instead automatically learn something specific known by a creature it consumed in the last 7 days, like the location of a hidden treasure or the name of a loved one. The ghoul can do this only once for a given creature, no matter how much of its flesh the ghoul consumed.  \n**Swift Leap** [#] (move) The ghoul jumps up to half its Speed. This movement doesn't trigger reactions.",
       "type": "section"
     }
   ],

--- a/monster_families/monster_core/gnome.json
+++ b/monster_families/monster_core/gnome.json
@@ -76,31 +76,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "emotion",
-                    "aonid": 590,
-                    "game-obj": "Traits",
-                    "name": "emotion",
-                    "type": "link"
-                  }
-                ],
-                "name": "Unflappable",
-                "subtype": "ability",
-                "text": "When the bleachling gnome rolls a critical failure on a check with the emotion trait, they get a failure instead.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Bleachlings')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -110,7 +100,6 @@
         ],
         "name": "Bleachlings",
         "subtype": "monster_family",
-        "text": "Surviving the worst affliction known to gnomekind is no small feat, and those who do suffer through the bleaching are changed by their experience. You can add the following ability to any gnome stat block to represent a bleachling gnome.",
         "type": "stat_block_section"
       }
     ],
@@ -143,6 +132,60 @@
         }
       ],
       "text": "Many gnomes love the trill that comes with gambling and betting. These bets do not need to be money related for a gnome to enjoy either. A gnome may place bets with interesting items, teaching new skills, or even public embarrassment on the line.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "emotion",
+              "aonid": 590,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            }
+          ],
+          "name": "Unflappable",
+          "subtype": "ability",
+          "text": "When the bleachling gnome rolls a critical failure on a check with the emotion trait, they get a failure instead.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        }
+      ],
+      "name": "Bleachlings",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 172",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 172",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 172,
+          "type": "source"
+        }
+      ],
+      "text": "Surviving the worst affliction known to gnomekind is no small feat, and those who do suffer through the bleaching are changed by their experience. You can add the following ability to any gnome stat block to represent a bleachling gnome.  \n  \n**Unflappable** When the bleachling gnome rolls a critical failure on a check with the emotion trait, they get a failure instead.",
       "type": "section"
     },
     {

--- a/monster_families/monster_core/graveknight.json
+++ b/monster_families/monster_core/graveknight.json
@@ -117,485 +117,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 59,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 83,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "disintegrate",
-                    "aonid": 1492,
-                    "game-obj": "Spells",
-                    "name": "disintegrate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Forge of Creation",
-                    "aonid": 27,
-                    "game-obj": "Planes",
-                    "name": "Forge of Creation",
-                    "type": "link"
-                  }
-                ],
-                "name": "Rejuvenation",
-                "subtype": "ability",
-                "text": "When a graveknight is destroyed, their armor rebuilds their body over the course of 1d10 days\u2014or more quickly if the armor is worn by a living host (see Graveknight Armor). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating their armor (such as with *disintegrate*), transporting it to the Forge of Creation, or throwing it into the heart of a volcano.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "bleed, death effects, disease, paralyzed, poison, unconscious, plus one energy type (same type as ruinous weapons).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "vitality",
-                    "aonid": 509,
-                    "game-obj": "Traits",
-                    "name": "vitality",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteract",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Sacrilegious Aura",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "When a creature in the aura uses a vitality spell or ability, the graveknight automatically attempts to counteract it, with the listed counteract modifier.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    },
-                    "name": "void",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "limited use area damage for a creature of the graveknight's level",
-                    "aonid": 2897,
-                    "game-obj": "Rules",
-                    "name": "limited use area damage for a creature of the graveknight's level",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high DC of the graveknight's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high DC of the graveknight's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Devastating Blast",
-                "subtype": "ability",
-                "text": "The graveknight unleashes a 30-foot cone of energy. Creatures in the area take limited use area damage for a creature of the graveknight's level with a basic Reflex save based on a high DC of the graveknight's level. The graveknight can use this ability once every 1d4 rounds. This energy damage is of the same type as that of their ruinous weapons, and Devastating Blast gains the associated trait.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "marvelous mount",
-                    "aonid": 1594,
-                    "game-obj": "Spells",
-                    "name": "marvelous mount",
-                    "type": "link"
-                  }
-                ],
-                "name": "Phantom Mount",
-                "subtype": "ability",
-                "text": "The graveknight summons a supernatural mount, as *marvelous mount* heightened to a rank equal to half the graveknight's level. Unlike *marvelous mount*, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down). If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "summon",
-                      "aonid": 520,
-                      "game-obj": "Traits",
-                      "name": "summon",
-                      "type": "link"
-                    },
-                    "name": "summon",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unarmed",
-                    "aonid": 719,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "corrosive",
-                    "aonid": 2834,
-                    "game-obj": "Equipment",
-                    "name": "corrosive",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frost",
-                    "aonid": 2839,
-                    "game-obj": "Equipment",
-                    "name": "frost",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "shock",
-                    "aonid": 2847,
-                    "game-obj": "Equipment",
-                    "name": "shock",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "flaming",
-                    "aonid": 2838,
-                    "game-obj": "Equipment",
-                    "name": "flaming",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "striking",
-                    "aonid": 2829,
-                    "game-obj": "Equipment",
-                    "name": "striking",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ruinous Weapons",
-                "subtype": "ability",
-                "text": "When created, a graveknight chooses one of the following energy types that was relevant to their life or death: acid, cold, electricity, or fire. Any weapon the graveknight wields or unarmed attack the graveknight uses gains the effects of the *corrosive*, *frost*, *shock*, or *flaming* weapon rune, respectively, in addition to a *+1 striking weapon* rune. If the graveknight is 14th level or higher, their weapons instead gain the effects of the greater versions of both of these runes",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "critical specialization effects",
-                    "aonid": 235,
-                    "game-obj": "Rules",
-                    "name": "critical specialization effects",
-                    "type": "link"
-                  }
-                ],
-                "name": "Weapon Master",
-                "subtype": "ability",
-                "text": "The graveknight has access to the critical specialization effects of any weapons they wield.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Graveknight Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -634,6 +160,209 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 59,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 83,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "disintegrate",
+                "aonid": 1492,
+                "game-obj": "Spells",
+                "name": "disintegrate",
+                "type": "link"
+              },
+              {
+                "alt": "Forge of Creation",
+                "aonid": 27,
+                "game-obj": "Planes",
+                "name": "Forge of Creation",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "limited use area damage for a creature of the graveknight's level",
+                "aonid": 2897,
+                "game-obj": "Rules",
+                "name": "limited use area damage for a creature of the graveknight's level",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "high DC of the graveknight's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high DC of the graveknight's level",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "summon",
+                "aonid": 520,
+                "game-obj": "Traits",
+                "name": "summon",
+                "type": "link"
+              },
+              {
+                "alt": "marvelous mount",
+                "aonid": 1594,
+                "game-obj": "Spells",
+                "name": "marvelous mount",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 719,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "corrosive",
+                "aonid": 2834,
+                "game-obj": "Equipment",
+                "name": "corrosive",
+                "type": "link"
+              },
+              {
+                "alt": "frost",
+                "aonid": 2839,
+                "game-obj": "Equipment",
+                "name": "frost",
+                "type": "link"
+              },
+              {
+                "alt": "shock",
+                "aonid": 2847,
+                "game-obj": "Equipment",
+                "name": "shock",
+                "type": "link"
+              },
+              {
+                "alt": "flaming",
+                "aonid": 2838,
+                "game-obj": "Equipment",
+                "name": "flaming",
+                "type": "link"
+              },
+              {
+                "alt": "striking",
+                "aonid": 2829,
+                "game-obj": "Equipment",
+                "name": "striking",
+                "type": "link"
+              },
+              {
+                "alt": "critical specialization effects",
+                "aonid": 235,
+                "game-obj": "Rules",
+                "name": "critical specialization effects",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -643,339 +372,180 @@
         ],
         "name": "Graveknight Abilities",
         "subtype": "monster_family",
-        "text": "A graveknight gains the graveknight, undead, and unholy traits. They lose any abilities that come from being a living creature and any traits that represent their life, such as human and humanoid.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "mental",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "mental",
-                    "aonid": 647,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Betrayed Revivification",
-                "subtype": "ability",
-                "text": "The graveknight died after being deeply betrayed. Instead of being immune to a type of energy damage, they're immune to mental damage, their weapons deal 1d6 additional mental damage, and their Devastating Blast deals mental damage with a Will saving throw instead of Reflex.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "frequency": "1d4 rounds",
-                "name": "Channel Magic",
-                "subtype": "ability",
-                "text": "The graveknight redirects magical energies through its armor, allowing it to deliver magic through an attack. The graveknight Casts a Spell that takes 1 or 2 actions to cast and requires a spell attack modifier. The effects of the spell don\u2019t occur immediately but are imbued into an attack instead. The graveknight then makes a melee Strike with a weapon or unarmed attack. The spell is coupled with the attack, using the attack roll result to determine the effects of both the Strike and the spell. This counts as two attacks for the graveknight\u2019s multiple attack penalty but doesn\u2019t apply the penalty until after they\u2019ve completed Channeling Magic. The graveknight can\u2019t use Channel Magic again for 1d4 rounds.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The graveknight\u2019s armor animates and attempts to Grab the triggering creature. It makes an Athletics check to Grapple using the graveknight\u2019s Athletics modifier \u2013 2. The armor can continue to Grapple the creature normally. Since the armor is grappling the creature, the graveknight doesn\u2019t need a free hand to do so.",
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 45,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 36,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grapple",
-                    "aonid": 2376,
-                    "game-obj": "Actions",
-                    "name": "Grapple",
-                    "type": "link"
-                  }
-                ],
-                "name": "Clutching Armor",
-                "subtype": "ability",
-                "text": "(arcane)",
-                "trigger": "A creature attempts to move away from the graveknight",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "communication",
-                "ability_type": "ability",
-                "name": "Create Grave Squire",
-                "subtype": "ability",
-                "text": "The graveknight can gift a piece of their armor to another creature, which becomes their grave squire. The graveknight can communicate telepathically with their squire at any distance, see through the squire's senses, and cast suggestion as a divine innate spell through the telepathic link at will; the squire treats their degree of success as one step worse. If the graveknight's main armor is destroyed, the squire's piece expands to cover the squire's body over 1d10 days, after which point it becomes the graveknight's new body. The graveknight can have only one squire at a time and must recover the armor piece to create a new squire.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Dark Deliverance",
-                "subtype": "ability",
-                "text": "The graveknight has vitality resistance equal to their level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "quickened",
-                    "aonid": 89,
-                    "game-obj": "Conditions",
-                    "name": "quickened",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Step",
-                    "aonid": 2304,
-                    "game-obj": "Actions",
-                    "name": "Step",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Stride",
-                    "aonid": 2305,
-                    "game-obj": "Actions",
-                    "name": "Stride",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Strike",
-                    "aonid": 1167,
-                    "game-obj": "Actions",
-                    "name": "Strike",
-                    "type": "link"
-                  }
-                ],
-                "name": "Eager for Battle",
-                "subtype": "ability",
-                "text": "When the graveknight rolls initiative, they roll twice and take the better result. They\u2019re quickened during their first round after rolling initiative and can use this extra action to Step, Stride, or Strike.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "fortune",
-                      "aonid": 612,
-                      "game-obj": "Traits",
-                      "name": "fortune",
-                      "type": "link"
-                    },
-                    "name": "fortune",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "stupefied",
-                    "aonid": 94,
-                    "game-obj": "Conditions",
-                    "name": "stupefied",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "weakness",
-                    "aonid": 2317,
-                    "game-obj": "Rules",
-                    "name": "weakness",
-                    "type": "link"
-                  }
-                ],
-                "name": "Empty Save for Dust",
-                "subtype": "ability",
-                "text": "The graveknight\u2019s armor contains nothing more than swirling dust that puffs out from joints in their armor. A living creature that touches or is touched by the graveknight (including one hit by the graveknight\u2019s fist Strike) must succeed at a Reflex saving throw or become contaminated with the dust. While contaminated, the targeted creature is stupefied 1 and gains weakness to the graveknight\u2019s energy damage equal to half the graveknight\u2019s level. The contamination ends after 1 minute or when the creature is doused with water, whichever occurs first.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sturdy shield",
-                    "aonid": 2828,
-                    "game-obj": "Equipment",
-                    "name": "sturdy shield",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Shield Block",
-                    "aonid": 75,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Shield Block",
-                    "type": "link"
-                  }
-                ],
-                "name": "Graveknight\u2019s Shield",
-                "subtype": "ability",
-                "text": "The graveknight\u2019s curse extends to their shield, or the graveknight\u2019s armor uses a portion of itself to produce a shield. The graveknight has a shield that uses the statistics of a sturdy shield of a level no higher than the graveknight\u2019s level \u2013 1. The shield is quasi-independent of the graveknight and automatically protects the graveknight from harm. When the shield is raised, it automatically uses Shield Block to reduce the damage of the first attack against the graveknight each round without the graveknight needing to spend their reaction to do so. The shield automatically rejuvenates with the rest of the graveknight and must be destroyed in the same manner as the graveknight\u2019s armor.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "doomed",
-                    "aonid": 67,
-                    "game-obj": "Conditions",
-                    "name": "doomed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Interact",
-                    "aonid": 2297,
-                    "game-obj": "Actions",
-                    "name": "Interact",
-                    "type": "link"
-                  }
-                ],
-                "name": "Portentous Glare",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The graveknight\u2019s visage is one of overwhelming menace. When a creature ends its turn in the aura, it must attempt a Will saving throw. A creature that fails is doomed 1 (or doomed 1 and frightened 2 on a critical failure). The graveknight can activate or deactivate the aura by using an Interact action to open or close their helmet visor.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Graveknight Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 45,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 36,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "Grapple",
+                "aonid": 2376,
+                "game-obj": "Actions",
+                "name": "Grapple",
+                "type": "link"
+              },
+              {
+                "alt": "fortune",
+                "aonid": 612,
+                "game-obj": "Traits",
+                "name": "fortune",
+                "type": "link"
+              },
+              {
+                "alt": "quickened",
+                "aonid": 89,
+                "game-obj": "Conditions",
+                "name": "quickened",
+                "type": "link"
+              },
+              {
+                "alt": "Step",
+                "aonid": 2304,
+                "game-obj": "Actions",
+                "name": "Step",
+                "type": "link"
+              },
+              {
+                "alt": "Stride",
+                "aonid": 2305,
+                "game-obj": "Actions",
+                "name": "Stride",
+                "type": "link"
+              },
+              {
+                "alt": "Strike",
+                "aonid": 1167,
+                "game-obj": "Actions",
+                "name": "Strike",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied",
+                "aonid": 94,
+                "game-obj": "Conditions",
+                "name": "stupefied",
+                "type": "link"
+              },
+              {
+                "alt": "weakness",
+                "aonid": 2317,
+                "game-obj": "Rules",
+                "name": "weakness",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "sturdy shield",
+                "aonid": 2828,
+                "game-obj": "Equipment",
+                "name": "sturdy shield",
+                "type": "link"
+              },
+              {
+                "alt": "Shield Block",
+                "aonid": 75,
+                "game-obj": "MonsterAbilities",
+                "name": "Shield Block",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "doomed",
+                "aonid": 67,
+                "game-obj": "Conditions",
+                "name": "doomed",
+                "type": "link"
+              },
+              {
+                "alt": "frightened",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened",
+                "type": "link"
+              },
+              {
+                "alt": "Interact",
+                "aonid": 2297,
+                "game-obj": "Actions",
+                "name": "Interact",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -985,92 +555,40 @@
         ],
         "name": "Alternate Graveknight Abilities",
         "subtype": "monster_family",
-        "text": "Although the abilities listed above are standard for a graveknight, you can create a more unusual graveknight by substituting one of the aforementioned abilities (except for darkvision, void healing, rejuvenation, or immunities) with one of the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "doomed 1",
-                    "aonid": 67,
-                    "game-obj": "Conditions",
-                    "name": "doomed 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Graveknight's Curse",
-                "onset": "1 hour",
-                "saving_throw": [
-                  {
-                    "save_type": "Will",
-                    "subtype": "save_dc",
-                    "text": "Will save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 1 and can't remove armor (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 2, \u201310-foot status penalty to Speeds, and can't remove armor (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "dies and transforms into the armor's graveknight.",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "This curse affects anyone who wears a graveknight's armor for at least 1 hour;",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 566,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Graveknight Armor')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "doomed 1",
+                "aonid": 67,
+                "game-obj": "Conditions",
+                "name": "doomed 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1084,37 +602,21 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_type": "ability",
-                    "name": "Lictor Shokneir",
-                    "subtype": "ability",
-                    "text": ": Once the Hellknight leader of the notorious Order of the Crux, Lictor Shokneir was disgraced when he refused a royal order to disband his army of butchers. The other Hellknights surrounded him and razed his castle, Citadel Gheisteno, to the ground. However, Shokneir's determination sustains his now-undead form, and he and his undead legions have rebuilt the citadel in all its haunting glory.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "Iomedae's",
-                        "aonid": 285,
-                        "game-obj": "Deities",
-                        "name": "Iomedae's",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "The Black Prince",
-                    "subtype": "ability",
-                    "text": ": Although the graveknight known simply as the Black Prince was redeemed centuries ago as part of Iomedae's 11 Acts, it is said that the prince's armor remains intact\u2014and that vile forces conspire to reclaim it. If the armor is donned by one of the Black Prince's descendants, the Inner Sea will be beset by a terrible villain indeed.",
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Graveknight Armor')].sections[?(@.name=='Infamous Graveknights')].abilities",
                     "target": "$.defense.automatic_abilities"
+                  }
+                ],
+                "links": [
+                  {
+                    "alt": "Iomedae's",
+                    "aonid": 285,
+                    "game-obj": "Deities",
+                    "name": "Iomedae's",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -1124,11 +626,9 @@
             ],
             "name": "Infamous Graveknights",
             "subtype": "monster_family",
-            "text": "Several of Golarion's most notorious villains are graveknights. The following examples are among the world's most infamous graveknights at large and may inspire or serve as villains in your own games.",
             "type": "stat_block_section"
           }
         ],
-        "text": "Wearing graveknight armor is very risky, for the graveknight's essence inevitably kills the host, transforming their flesh into the graveknight's new body. Removing the curse allows a character to remove the armor, but if they ever wear the armor again, the curse returns. If the wearer dies from another cause while wearing the armor, or if the graveknight's rejuvenation completes before the wearer dies from the curse, the wearer immediately progresses to stage 3.",
         "type": "stat_block_section"
       }
     ],
@@ -1161,6 +661,1441 @@
         }
       ],
       "text": "You can turn an existing, living creature into a graveknight by completing the following steps. It's best to build a graveknight from scratch, but if you don't have the time, simply apply the following template. A creature should be at least level 5 before being converted to a graveknight.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Darkvision",
+            "aonid": 59,
+            "game-obj": "MonsterAbilities",
+            "name": "Darkvision",
+            "type": "link"
+          },
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 83,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "disintegrate",
+              "aonid": 1492,
+              "game-obj": "Spells",
+              "name": "disintegrate",
+              "type": "link"
+            },
+            {
+              "alt": "Forge of Creation",
+              "aonid": 27,
+              "game-obj": "Planes",
+              "name": "Forge of Creation",
+              "type": "link"
+            }
+          ],
+          "name": "Rejuvenation",
+          "subtype": "ability",
+          "text": "When a graveknight is destroyed, their armor rebuilds their body over the course of 1d10 days\u2014or more quickly if the armor is worn by a living host (see Graveknight Armor). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating their armor (such as with *disintegrate*), transporting it to the Forge of Creation, or throwing it into the heart of a volcano.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "bleed, death effects, disease, paralyzed, poison, unconscious, plus one energy type (same type as ruinous weapons).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "vitality",
+              "aonid": 509,
+              "game-obj": "Traits",
+              "name": "vitality",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            }
+          ],
+          "name": "Sacrilegious Aura",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "When a creature in the aura uses a vitality spell or ability, the graveknight automatically attempts to counteract it, with the listed counteract modifier.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              "name": "void",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "cone",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot cone",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "limited use area damage for a creature of the graveknight's level",
+              "aonid": 2897,
+              "game-obj": "Rules",
+              "name": "limited use area damage for a creature of the graveknight's level",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "high DC of the graveknight's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high DC of the graveknight's level",
+              "type": "link"
+            }
+          ],
+          "name": "Devastating Blast",
+          "subtype": "ability",
+          "text": "The graveknight unleashes a 30-foot cone of energy. Creatures in the area take limited use area damage for a creature of the graveknight's level with a basic Reflex save based on a high DC of the graveknight's level. The graveknight can use this ability once every 1d4 rounds. This energy damage is of the same type as that of their ruinous weapons, and Devastating Blast gains the associated trait.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "marvelous mount",
+              "aonid": 1594,
+              "game-obj": "Spells",
+              "name": "marvelous mount",
+              "type": "link"
+            }
+          ],
+          "name": "Phantom Mount",
+          "subtype": "ability",
+          "text": "The graveknight summons a supernatural mount, as *marvelous mount* heightened to a rank equal to half the graveknight's level. Unlike *marvelous mount*, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down). If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "summon",
+                "aonid": 520,
+                "game-obj": "Traits",
+                "name": "summon",
+                "type": "link"
+              },
+              "name": "summon",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "unarmed",
+              "aonid": 719,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            },
+            {
+              "alt": "corrosive",
+              "aonid": 2834,
+              "game-obj": "Equipment",
+              "name": "corrosive",
+              "type": "link"
+            },
+            {
+              "alt": "frost",
+              "aonid": 2839,
+              "game-obj": "Equipment",
+              "name": "frost",
+              "type": "link"
+            },
+            {
+              "alt": "shock",
+              "aonid": 2847,
+              "game-obj": "Equipment",
+              "name": "shock",
+              "type": "link"
+            },
+            {
+              "alt": "flaming",
+              "aonid": 2838,
+              "game-obj": "Equipment",
+              "name": "flaming",
+              "type": "link"
+            },
+            {
+              "alt": "striking",
+              "aonid": 2829,
+              "game-obj": "Equipment",
+              "name": "striking",
+              "type": "link"
+            }
+          ],
+          "name": "Ruinous Weapons",
+          "subtype": "ability",
+          "text": "When created, a graveknight chooses one of the following energy types that was relevant to their life or death: acid, cold, electricity, or fire. Any weapon the graveknight wields or unarmed attack the graveknight uses gains the effects of the *corrosive*, *frost*, *shock*, or *flaming* weapon rune, respectively, in addition to a *+1 striking weapon* rune. If the graveknight is 14th level or higher, their weapons instead gain the effects of the greater versions of both of these runes",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "critical specialization effects",
+              "aonid": 235,
+              "game-obj": "Rules",
+              "name": "critical specialization effects",
+              "type": "link"
+            }
+          ],
+          "name": "Weapon Master",
+          "subtype": "ability",
+          "text": "The graveknight has access to the critical specialization effects of any weapons they wield.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "graveknight",
+          "aonid": 755,
+          "game-obj": "Traits",
+          "name": "graveknight",
+          "type": "link"
+        },
+        {
+          "alt": "undead",
+          "aonid": 722,
+          "game-obj": "Traits",
+          "name": "undead",
+          "type": "link"
+        },
+        {
+          "alt": "unholy",
+          "aonid": 521,
+          "game-obj": "Traits",
+          "name": "unholy",
+          "type": "link"
+        },
+        {
+          "alt": "human",
+          "aonid": 627,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Darkvision",
+          "aonid": 59,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "disintegrate",
+          "aonid": 1492,
+          "game-obj": "Spells",
+          "name": "disintegrate",
+          "type": "link"
+        },
+        {
+          "alt": "Forge of Creation",
+          "aonid": 27,
+          "game-obj": "Planes",
+          "name": "Forge of Creation",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        },
+        {
+          "alt": "vitality",
+          "aonid": 509,
+          "game-obj": "Traits",
+          "name": "vitality",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 371,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "limited use area damage for a creature of the graveknight's level",
+          "aonid": 2897,
+          "game-obj": "Rules",
+          "name": "limited use area damage for a creature of the graveknight's level",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "high DC of the graveknight's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high DC of the graveknight's level",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "summon",
+          "aonid": 520,
+          "game-obj": "Traits",
+          "name": "summon",
+          "type": "link"
+        },
+        {
+          "alt": "marvelous mount",
+          "aonid": 1594,
+          "game-obj": "Spells",
+          "name": "marvelous mount",
+          "type": "link"
+        },
+        {
+          "alt": "unarmed",
+          "aonid": 719,
+          "game-obj": "Traits",
+          "name": "unarmed",
+          "type": "link"
+        },
+        {
+          "alt": "corrosive",
+          "aonid": 2834,
+          "game-obj": "Equipment",
+          "name": "corrosive",
+          "type": "link"
+        },
+        {
+          "alt": "frost",
+          "aonid": 2839,
+          "game-obj": "Equipment",
+          "name": "frost",
+          "type": "link"
+        },
+        {
+          "alt": "shock",
+          "aonid": 2847,
+          "game-obj": "Equipment",
+          "name": "shock",
+          "type": "link"
+        },
+        {
+          "alt": "flaming",
+          "aonid": 2838,
+          "game-obj": "Equipment",
+          "name": "flaming",
+          "type": "link"
+        },
+        {
+          "alt": "striking",
+          "aonid": 2829,
+          "game-obj": "Equipment",
+          "name": "striking",
+          "type": "link"
+        },
+        {
+          "alt": "critical specialization effects",
+          "aonid": 235,
+          "game-obj": "Rules",
+          "name": "critical specialization effects",
+          "type": "link"
+        }
+      ],
+      "name": "Graveknight Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 178",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 178",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 178,
+          "type": "source"
+        }
+      ],
+      "text": "A graveknight gains the graveknight, undead, and unholy traits. They lose any abilities that come from being a living creature and any traits that represent their life, such as human and humanoid.  \n  \n**Darkvision**  \n**Void Healing**  \n**Rejuvenation** (divine) When a graveknight is destroyed, their armor rebuilds their body over the course of 1d10 days\u2014or more quickly if the armor is worn by a living host (see Graveknight Armor). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating their armor (such as with *disintegrate*), transporting it to the Forge of Creation, or throwing it into the heart of a volcano.  \n**Immunities** bleed, death effects, disease, paralyzed, poison, unconscious, plus one energy type (same type as ruinous weapons).  \n**Sacrilegious Aura** (aura, divine, void) 30 feet. When a creature in the aura uses a vitality spell or ability, the graveknight automatically attempts to counteract it, with the listed counteract modifier.  \n**Devastating Blast** [##] (arcane) The graveknight unleashes a 30-foot cone of energy. Creatures in the area take limited use area damage for a creature of the graveknight's level with a basic Reflex save based on a high DC of the graveknight's level. The graveknight can use this ability once every 1d4 rounds. This energy damage is of the same type as that of their ruinous weapons, and Devastating Blast gains the associated trait.  \n**Phantom Mount** [###] (arcane, summon) The graveknight summons a supernatural mount, as *marvelous mount* heightened to a rank equal to half the graveknight's level. Unlike *marvelous mount*, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down). If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.  \n**Ruinous Weapons** When created, a graveknight chooses one of the following energy types that was relevant to their life or death: acid, cold, electricity, or fire. Any weapon the graveknight wields or unarmed attack the graveknight uses gains the effects of the *corrosive*, *frost*, *shock*, or *flaming* weapon rune, respectively, in addition to a *+1 striking weapon* rune. If the graveknight is 14th level or higher, their weapons instead gain the effects of the greater versions of both of these runes  \n**Weapon Master** The graveknight has access to the critical specialization effects of any weapons they wield.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "mental",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            }
+          ],
+          "name": "Betrayed Revivification",
+          "subtype": "ability",
+          "text": "The graveknight died after being deeply betrayed. Instead of being immune to a type of energy damage, they're immune to mental damage, their weapons deal 1d6 additional mental damage, and their Devastating Blast deals mental damage with a Will saving throw instead of Reflex.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "frequency": "1d4 rounds",
+          "name": "Channel Magic",
+          "subtype": "ability",
+          "text": "The graveknight redirects magical energies through its armor, allowing it to deliver magic through an attack. The graveknight Casts a Spell that takes 1 or 2 actions to cast and requires a spell attack modifier. The effects of the spell don\u2019t occur immediately but are imbued into an attack instead. The graveknight then makes a melee Strike with a weapon or unarmed attack. The spell is coupled with the attack, using the attack roll result to determine the effects of both the Strike and the spell. This counts as two attacks for the graveknight\u2019s multiple attack penalty but doesn\u2019t apply the penalty until after they\u2019ve completed Channeling Magic. The graveknight can\u2019t use Channel Magic again for 1d4 rounds.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The graveknight\u2019s armor animates and attempts to Grab the triggering creature. It makes an Athletics check to Grapple using the graveknight\u2019s Athletics modifier \u2013 2. The armor can continue to Grapple the creature normally. Since the armor is grappling the creature, the graveknight doesn\u2019t need a free hand to do so.",
+          "links": [
+            {
+              "alt": "Grab",
+              "aonid": 45,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 36,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "Grapple",
+              "aonid": 2376,
+              "game-obj": "Actions",
+              "name": "Grapple",
+              "type": "link"
+            }
+          ],
+          "name": "Clutching Armor",
+          "subtype": "ability",
+          "text": "(arcane)",
+          "trigger": "A creature attempts to move away from the graveknight",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "communication",
+          "ability_type": "ability",
+          "name": "Create Grave Squire",
+          "subtype": "ability",
+          "text": "The graveknight can gift a piece of their armor to another creature, which becomes their grave squire. The graveknight can communicate telepathically with their squire at any distance, see through the squire's senses, and cast suggestion as a divine innate spell through the telepathic link at will; the squire treats their degree of success as one step worse. If the graveknight's main armor is destroyed, the squire's piece expands to cover the squire's body over 1d10 days, after which point it becomes the graveknight's new body. The graveknight can have only one squire at a time and must recover the armor piece to create a new squire.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Dark Deliverance",
+          "subtype": "ability",
+          "text": "The graveknight has vitality resistance equal to their level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "quickened",
+              "aonid": 89,
+              "game-obj": "Conditions",
+              "name": "quickened",
+              "type": "link"
+            },
+            {
+              "alt": "Step",
+              "aonid": 2304,
+              "game-obj": "Actions",
+              "name": "Step",
+              "type": "link"
+            },
+            {
+              "alt": "Stride",
+              "aonid": 2305,
+              "game-obj": "Actions",
+              "name": "Stride",
+              "type": "link"
+            },
+            {
+              "alt": "Strike",
+              "aonid": 1167,
+              "game-obj": "Actions",
+              "name": "Strike",
+              "type": "link"
+            }
+          ],
+          "name": "Eager for Battle",
+          "subtype": "ability",
+          "text": "When the graveknight rolls initiative, they roll twice and take the better result. They\u2019re quickened during their first round after rolling initiative and can use this extra action to Step, Stride, or Strike.",
+          "traits": [
+            {
+              "link": {
+                "alt": "fortune",
+                "aonid": 612,
+                "game-obj": "Traits",
+                "name": "fortune",
+                "type": "link"
+              },
+              "name": "fortune",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "stupefied",
+              "aonid": 94,
+              "game-obj": "Conditions",
+              "name": "stupefied",
+              "type": "link"
+            },
+            {
+              "alt": "weakness",
+              "aonid": 2317,
+              "game-obj": "Rules",
+              "name": "weakness",
+              "type": "link"
+            }
+          ],
+          "name": "Empty Save for Dust",
+          "subtype": "ability",
+          "text": "The graveknight\u2019s armor contains nothing more than swirling dust that puffs out from joints in their armor. A living creature that touches or is touched by the graveknight (including one hit by the graveknight\u2019s fist Strike) must succeed at a Reflex saving throw or become contaminated with the dust. While contaminated, the targeted creature is stupefied 1 and gains weakness to the graveknight\u2019s energy damage equal to half the graveknight\u2019s level. The contamination ends after 1 minute or when the creature is doused with water, whichever occurs first.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "sturdy shield",
+              "aonid": 2828,
+              "game-obj": "Equipment",
+              "name": "sturdy shield",
+              "type": "link"
+            },
+            {
+              "alt": "Shield Block",
+              "aonid": 75,
+              "game-obj": "MonsterAbilities",
+              "name": "Shield Block",
+              "type": "link"
+            }
+          ],
+          "name": "Graveknight\u2019s Shield",
+          "subtype": "ability",
+          "text": "The graveknight\u2019s curse extends to their shield, or the graveknight\u2019s armor uses a portion of itself to produce a shield. The graveknight has a shield that uses the statistics of a sturdy shield of a level no higher than the graveknight\u2019s level \u2013 1. The shield is quasi-independent of the graveknight and automatically protects the graveknight from harm. When the shield is raised, it automatically uses Shield Block to reduce the damage of the first attack against the graveknight each round without the graveknight needing to spend their reaction to do so. The shield automatically rejuvenates with the rest of the graveknight and must be destroyed in the same manner as the graveknight\u2019s armor.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "doomed",
+              "aonid": 67,
+              "game-obj": "Conditions",
+              "name": "doomed",
+              "type": "link"
+            },
+            {
+              "alt": "frightened",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened",
+              "type": "link"
+            },
+            {
+              "alt": "Interact",
+              "aonid": 2297,
+              "game-obj": "Actions",
+              "name": "Interact",
+              "type": "link"
+            }
+          ],
+          "name": "Portentous Glare",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The graveknight\u2019s visage is one of overwhelming menace. When a creature ends its turn in the aura, it must attempt a Will saving throw. A creature that fails is doomed 1 (or doomed 1 and frightened 2 on a critical failure). The graveknight can activate or deactivate the aura by using an Interact action to open or close their helmet visor.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 45,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 36,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "Grapple",
+          "aonid": 2376,
+          "game-obj": "Actions",
+          "name": "Grapple",
+          "type": "link"
+        },
+        {
+          "alt": "fortune",
+          "aonid": 612,
+          "game-obj": "Traits",
+          "name": "fortune",
+          "type": "link"
+        },
+        {
+          "alt": "quickened",
+          "aonid": 89,
+          "game-obj": "Conditions",
+          "name": "quickened",
+          "type": "link"
+        },
+        {
+          "alt": "Step",
+          "aonid": 2304,
+          "game-obj": "Actions",
+          "name": "Step",
+          "type": "link"
+        },
+        {
+          "alt": "Stride",
+          "aonid": 2305,
+          "game-obj": "Actions",
+          "name": "Stride",
+          "type": "link"
+        },
+        {
+          "alt": "Strike",
+          "aonid": 1167,
+          "game-obj": "Actions",
+          "name": "Strike",
+          "type": "link"
+        },
+        {
+          "alt": "stupefied",
+          "aonid": 94,
+          "game-obj": "Conditions",
+          "name": "stupefied",
+          "type": "link"
+        },
+        {
+          "alt": "weakness",
+          "aonid": 2317,
+          "game-obj": "Rules",
+          "name": "weakness",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "sturdy shield",
+          "aonid": 2828,
+          "game-obj": "Equipment",
+          "name": "sturdy shield",
+          "type": "link"
+        },
+        {
+          "alt": "Shield Block",
+          "aonid": 75,
+          "game-obj": "MonsterAbilities",
+          "name": "Shield Block",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "doomed",
+          "aonid": 67,
+          "game-obj": "Conditions",
+          "name": "doomed",
+          "type": "link"
+        },
+        {
+          "alt": "frightened",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened",
+          "type": "link"
+        },
+        {
+          "alt": "Interact",
+          "aonid": 2297,
+          "game-obj": "Actions",
+          "name": "Interact",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Graveknight Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 178",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 178",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 178,
+          "type": "source"
+        }
+      ],
+      "text": "Although the abilities listed above are standard for a graveknight, you can create a more unusual graveknight by substituting one of the aforementioned abilities (except for darkvision, void healing, rejuvenation, or immunities) with one of the following.  \n  \n**Betrayed Revivification** The graveknight died after being deeply betrayed. Instead of being immune to a type of energy damage, they're immune to mental damage, their weapons deal 1d6 additional mental damage, and their Devastating Blast deals mental damage with a Will saving throw instead of Reflex.  \n**Channel Magic** [##] The graveknight redirects magical energies through its armor, allowing it to deliver magic through an attack. The graveknight Casts a Spell that takes 1 or 2 actions to cast and requires a spell attack modifier. The effects of the spell don\u2019t occur immediately but are imbued into an attack instead. The graveknight then makes a melee Strike with a weapon or unarmed attack. The spell is coupled with the attack, using the attack roll result to determine the effects of both the Strike and the spell. This counts as two attacks for the graveknight\u2019s multiple attack penalty but doesn\u2019t apply the penalty until after they\u2019ve completed Channeling Magic. The graveknight can\u2019t use Channel Magic again for 1d4 rounds.   \n**Clutching Armor** [@] (arcane) **Trigger** A creature attempts to move away from the graveknight; **Effect** The graveknight\u2019s armor animates and attempts to Grab the triggering creature. It makes an Athletics check to Grapple using the graveknight\u2019s Athletics modifier \u2013 2. The armor can continue to Grapple the creature normally. Since the armor is grappling the creature, the graveknight doesn\u2019t need a free hand to do so.  \n**Create Grave Squire** The graveknight can gift a piece of their armor to another creature, which becomes their grave squire. The graveknight can communicate telepathically with their squire at any distance, see through the squire's senses, and cast suggestion as a divine innate spell through the telepathic link at will; the squire treats their degree of success as one step worse. If the graveknight's main armor is destroyed, the squire's piece expands to cover the squire's body over 1d10 days, after which point it becomes the graveknight's new body. The graveknight can have only one squire at a time and must recover the armor piece to create a new squire.  \n**Dark Deliverance** The graveknight has vitality resistance equal to their level.  \n**Eager for Battle** (fortune) When the graveknight rolls initiative, they roll twice and take the better result. They\u2019re quickened during their first round after rolling initiative and can use this extra action to Step, Stride, or Strike.   \n**Empty Save for Dust** The graveknight\u2019s armor contains nothing more than swirling dust that puffs out from joints in their armor. A living creature that touches or is touched by the graveknight (including one hit by the graveknight\u2019s fist Strike) must succeed at a Reflex saving throw or become contaminated with the dust. While contaminated, the targeted creature is stupefied 1 and gains weakness to the graveknight\u2019s energy damage equal to half the graveknight\u2019s level. The contamination ends after 1 minute or when the creature is doused with water, whichever occurs first.  \n**Graveknight\u2019s Shield** (arcane) The graveknight\u2019s curse extends to their shield, or the graveknight\u2019s armor uses a portion of itself to produce a shield. The graveknight has a shield that uses the statistics of a sturdy shield of a level no higher than the graveknight\u2019s level \u2013 1. The shield is quasi-independent of the graveknight and automatically protects the graveknight from harm. When the shield is raised, it automatically uses Shield Block to reduce the damage of the first attack against the graveknight each round without the graveknight needing to spend their reaction to do so. The shield automatically rejuvenates with the rest of the graveknight and must be destroyed in the same manner as the graveknight\u2019s armor.  \n**Portentous Glare** (aura, divine, emotion, fear, mental, visual) 30 feet. The graveknight\u2019s visage is one of overwhelming menace. When a creature ends its turn in the aura, it must attempt a Will saving throw. A creature that fails is doomed 1 (or doomed 1 and frightened 2 on a critical failure). The graveknight can activate or deactivate the aura by using an Interact action to open or close their helmet visor.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "affliction",
+          "links": [
+            {
+              "alt": "doomed 1",
+              "aonid": 67,
+              "game-obj": "Conditions",
+              "name": "doomed 1",
+              "type": "link"
+            }
+          ],
+          "name": "Graveknight's Curse",
+          "onset": "1 hour",
+          "saving_throw": [
+            {
+              "save_type": "Will",
+              "subtype": "save_dc",
+              "text": "Will save",
+              "type": "stat_block_section"
+            }
+          ],
+          "stages": [
+            {
+              "name": "Stage 1",
+              "subtype": "affliction_stage",
+              "text": "doomed 1 and can't remove armor (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 2",
+              "subtype": "affliction_stage",
+              "text": "doomed 2, \u201310-foot status penalty to Speeds, and can't remove armor (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 3",
+              "subtype": "affliction_stage",
+              "text": "dies and transforms into the armor's graveknight.",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "This curse affects anyone who wears a graveknight's armor for at least 1 hour;",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              "name": "curse",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 566,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "doomed 1",
+          "aonid": 67,
+          "game-obj": "Conditions",
+          "name": "doomed 1",
+          "type": "link"
+        }
+      ],
+      "name": "Graveknight Armor",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Lictor Shokneir",
+              "subtype": "ability",
+              "text": ": Once the Hellknight leader of the notorious Order of the Crux, Lictor Shokneir was disgraced when he refused a royal order to disband his army of butchers. The other Hellknights surrounded him and razed his castle, Citadel Gheisteno, to the ground. However, Shokneir's determination sustains his now-undead form, and he and his undead legions have rebuilt the citadel in all its haunting glory.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "Iomedae's",
+                  "aonid": 285,
+                  "game-obj": "Deities",
+                  "name": "Iomedae's",
+                  "type": "link"
+                }
+              ],
+              "name": "The Black Prince",
+              "subtype": "ability",
+              "text": ": Although the graveknight known simply as the Black Prince was redeemed centuries ago as part of Iomedae's 11 Acts, it is said that the prince's armor remains intact\u2014and that vile forces conspire to reclaim it. If the armor is donned by one of the Black Prince's descendants, the Inner Sea will be beset by a terrible villain indeed.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Iomedae's",
+              "aonid": 285,
+              "game-obj": "Deities",
+              "name": "Iomedae's",
+              "type": "link"
+            }
+          ],
+          "name": "Infamous Graveknights",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 178",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 178",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 178,
+              "type": "source"
+            }
+          ],
+          "text": "Several of Golarion's most notorious villains are graveknights. The following examples are among the world's most infamous graveknights at large and may inspire or serve as villains in your own games.  \n  \n**Lictor Shokneir**: Once the Hellknight leader of the notorious Order of the Crux, Lictor Shokneir was disgraced when he refused a royal order to disband his army of butchers. The other Hellknights surrounded him and razed his castle, Citadel Gheisteno, to the ground. However, Shokneir's determination sustains his now-undead form, and he and his undead legions have rebuilt the citadel in all its haunting glory.  \n  \n**The Black Prince**: Although the graveknight known simply as the Black Prince was redeemed centuries ago as part of Iomedae's 11 Acts, it is said that the prince's armor remains intact\u2014and that vile forces conspire to reclaim it. If the armor is donned by one of the Black Prince's descendants, the Inner Sea will be beset by a terrible villain indeed.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 178",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 178",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 178,
+          "type": "source"
+        }
+      ],
+      "text": "Wearing graveknight armor is very risky, for the graveknight's essence inevitably kills the host, transforming their flesh into the graveknight's new body. Removing the curse allows a character to remove the armor, but if they ever wear the armor again, the curse returns. If the wearer dies from another cause while wearing the armor, or if the graveknight's rejuvenation completes before the wearer dies from the curse, the wearer immediately progresses to stage 3.  \n**Graveknight's Curse** (arcane, curse) This curse affects anyone who wears a graveknight's armor for at least 1 hour; **Saving Throw** Will save; **Onset** 1 hour; **Stage 1** doomed 1 and can't remove armor (1 day); **Stage 2** doomed 2, \u201310-foot status penalty to Speeds, and can't remove armor (1 day); **Stage 3** dies and transforms into the armor's graveknight.",
       "type": "section"
     }
   ],

--- a/monster_families/monster_core/lich.json
+++ b/monster_families/monster_core/lich.json
@@ -133,593 +133,147 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "vitality",
-                    "aonid": 509,
-                    "game-obj": "Traits",
-                    "name": "vitality",
-                    "type": "link"
-                  }
-                ],
-                "name": "Saving Throws",
-                "subtype": "ability",
-                "text": "+1 status bonus to all saves vs. vitality",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 83,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Rejuvenation",
-                "subtype": "ability",
-                "text": "When a lich is destroyed, their soul immediately transfers to their *soul cage*. A lich can be permanently destroyed only if their *soul cage* is found and destroyed.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "bleed, death effects, disease, paralyzed, poison, unconscious",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "magical",
-                    "aonid": 644,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "cold 10, physical 10 (except magical bludgeoning)",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Frightful Presence",
-                  "aonid": 64,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Frightful Presence",
-                  "type": "link"
-                },
-                "name": "Frightful Presence",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "saving_throw": [
-                  {
-                    "dc": 30,
-                    "subtype": "save_dc",
-                    "text": "DC 30",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 64,
-                  "critical_failure": "The creature is frightened 4.",
-                  "critical_success": "The creature is unaffected by the presence.",
-                  "edition": "remastered",
-                  "failure": "The creature is frightened 2.",
-                  "game-id": "5f2a1a3408b1d69586e06de4ba28ce6c",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "frightened 1",
-                      "aonid": 76,
-                      "game-obj": "Conditions",
-                      "name": "frightened 1",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Frightful Presence",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "success": "The creature is frightened 1.",
-                  "text": "A creature that first enters the area must attempt a Will save. Regardless of the result of the saving throw, the creature is temporarily immune to this monster's Frightful Presence for 1 minute.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 206,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "5315505cfd3f3ba2685e9747898193b2",
-                      "game-obj": "Traits",
-                      "name": "Aura",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 453",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 453",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 453,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An aura is an emanation that continually ebbs out from you, affecting creatures within a certain radius. Aura can also refer to the magical signature of an item.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 60,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "fb5f8b3d849b073e1514a6a025810470",
-                      "game-obj": "Traits",
-                      "name": "Emotion",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 455",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 455",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 455,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This effect alters a creature\u2019s emotions. Effects with this trait always have the mental trait as well. Creatures with special training or that have mechanical or artificial intelligence are immune to emotion effects.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 68,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "9a5cea6bfb849deb16206c68f8d113a5",
-                      "game-obj": "Traits",
-                      "name": "Fear",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 456",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 456",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 456,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "Fear effects evoke the emotion of fear. Effects with this trait always have the mental and emotion traits as well.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 106,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "6a1f80610baa3617c1597f49c6406313",
-                      "game-obj": "Traits",
-                      "name": "Mental",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 458",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 458",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 458,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "A mental effect can alter the target\u2019s mind. It has no effect on an object or a mindless creature.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "void",
-                    "formula": "1d8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "unarmed",
-                    "aonid": 719,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "finesse",
-                    "aonid": 602,
-                    "game-obj": "Traits",
-                    "name": "finesse",
-                    "type": "link"
-                  }
-                ],
-                "name": "Hand of the Lich",
-                "subtype": "ability",
-                "text": "All liches have a hand unarmed attack that deals 1d8 void damage for every 3 levels the lich has. This attack has the finesse trait.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The lich taps into their soul cage's power to cast any arcane spell up to the highest rank the lich can cast, even if the spell being cast is not one of the lich's prepared spells. The lich's soul cage doesn't need to be present for the lich to use this ability.",
-                "frequency": "once per day",
-                "name": "Drain Soul Cage",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "grabbed",
-                    "aonid": 77,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 90,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  }
-                ],
-                "name": "Siphon Life",
-                "subtype": "ability",
-                "text": "A lich's form draws forth life from those who come into contact with it. When the lich damages a living creature with an unarmed attack, the lich gains 5 temporary Hit Points and the creature must succeed at a Fortitude save against the lich's spell DC \u2013 2 or become drained 1. If the lich is grabbed or restrained at the start of its turn, each creature grabbing or restraining it must succeed at a Fortitude save or become drained 1. If the lich siphons a creature's life again, the drained value increase by 1, to a maximum of drained 4.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Lich Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 83,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 644,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "Frightful Presence",
+                "aonid": 64,
+                "game-obj": "MonsterAbilities",
+                "name": "Frightful Presence",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 719,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "finesse",
+                "aonid": 602,
+                "game-obj": "Traits",
+                "name": "finesse",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 77,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 90,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -729,194 +283,103 @@
         ],
         "name": "Lich Abilities",
         "subtype": "monster_family",
-        "text": "Liches lose all abilities that come from being a living creature. They also lose any traits that represented their life as a living creature, such as human and humanoid.  \n  \n A lich gains the following abilities.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mental",
-                    "aonid": 647,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concentrate",
-                    "aonid": 561,
-                    "game-obj": "Traits",
-                    "name": "concentrate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disrupted",
-                    "aonid": 394,
-                    "game-obj": "Rules",
-                    "name": "disrupted",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blasphemous Utterances",
-                "range": {
-                  "range": 10,
-                  "subtype": "range",
-                  "text": "10 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "saving_throw": [
-                  {
-                    "dc": 10,
-                    "save_type": "Flat Check",
-                    "subtype": "save_dc",
-                    "text": "DC 10 flat check",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The lich is accompanied by a constant echo of blasphemous murmurs and tainted whispers. A creature in the aura takes a \u20132 circumstance penalty to saves against mental effects and can't take actions that have the concentrate trait unless they succeed at a DC 10 flat check. On a failure, the action is disrupted.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "slowed 2",
-                    "aonid": 92,
-                    "game-obj": "Conditions",
-                    "name": "slowed 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cold Beyond Cold",
-                "subtype": "ability",
-                "text": "The lich's hand Strike deals cold damage instead of void and the target is slowed 2. A successful Fortitude save reduces this to slowed 1 (or negates it on a critical success).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Dark Deliverance",
-                "subtype": "ability",
-                "text": "The lich has resistance equal to their level to vitality.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fear",
-                    "aonid": 598,
-                    "game-obj": "Traits",
-                    "name": "fear",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "doomed 1",
-                    "aonid": 67,
-                    "game-obj": "Conditions",
-                    "name": "doomed 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Void Shroud",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The lich is surrounded by an aura of death, drawing forth souls to be consumed by the lich's constant hunger. Living creatures in the emanation take a \u20132 status penalty to saves against fear and death effects. In addition, any creature that starts its turn in the area gains the doomed 1 condition unless it succeeds at a Will save against the lich's spell DC \u2013 4.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "death",
-                      "aonid": 571,
-                      "game-obj": "Traits",
-                      "name": "death",
-                      "type": "link"
-                    },
-                    "name": "death",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Lich Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "disrupted",
+                "aonid": 394,
+                "game-obj": "Rules",
+                "name": "disrupted",
+                "type": "link"
+              },
+              {
+                "alt": "slowed 2",
+                "aonid": 92,
+                "game-obj": "Conditions",
+                "name": "slowed 2",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "doomed 1",
+                "aonid": 67,
+                "game-obj": "Conditions",
+                "name": "doomed 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -926,7 +389,6 @@
         ],
         "name": "Alternate Lich Abilities",
         "subtype": "monster_family",
-        "text": "You can create a more unusual lich by substituting any one of the following abilities for frightful presence, siphon life, or Drain Soul Cage.",
         "type": "stat_block_section"
       }
     ],
@@ -959,6 +421,1090 @@
         }
       ],
       "text": "A lich can be any type of spellcaster as long as they have the ability to perform a ritual of undeath as the primary caster (which can usually be performed only by a spellcaster capable of casting 6th-rank spells). To create a lich, increase the spellcaster's level by 1 and change their statistics as follows.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "vitality",
+              "aonid": 509,
+              "game-obj": "Traits",
+              "name": "vitality",
+              "type": "link"
+            }
+          ],
+          "name": "Saving Throws",
+          "subtype": "ability",
+          "text": "+1 status bonus to all saves vs. vitality",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 83,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Rejuvenation",
+          "subtype": "ability",
+          "text": "When a lich is destroyed, their soul immediately transfers to their *soul cage*. A lich can be permanently destroyed only if their *soul cage* is found and destroyed.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "bleed, death effects, disease, paralyzed, poison, unconscious",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "magical",
+              "aonid": 644,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            }
+          ],
+          "name": "Resistances",
+          "subtype": "ability",
+          "text": "cold 10, physical 10 (except magical bludgeoning)",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Frightful Presence",
+            "aonid": 64,
+            "game-obj": "MonsterAbilities",
+            "name": "Frightful Presence",
+            "type": "link"
+          },
+          "name": "Frightful Presence",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "saving_throw": [
+            {
+              "dc": 30,
+              "subtype": "save_dc",
+              "text": "DC 30",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 64,
+            "critical_failure": "The creature is frightened 4.",
+            "critical_success": "The creature is unaffected by the presence.",
+            "edition": "remastered",
+            "failure": "The creature is frightened 2.",
+            "game-id": "5f2a1a3408b1d69586e06de4ba28ce6c",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "frightened 1",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened 1",
+                "type": "link"
+              }
+            ],
+            "name": "Frightful Presence",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "success": "The creature is frightened 1.",
+            "text": "A creature that first enters the area must attempt a Will save. Regardless of the result of the saving throw, the creature is temporarily immune to this monster's Frightful Presence for 1 minute.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 206,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "5315505cfd3f3ba2685e9747898193b2",
+                "game-obj": "Traits",
+                "name": "Aura",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 453",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 453",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 453,
+                    "type": "source"
+                  }
+                ],
+                "text": "An aura is an emanation that continually ebbs out from you, affecting creatures within a certain radius. Aura can also refer to the magical signature of an item.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 60,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "fb5f8b3d849b073e1514a6a025810470",
+                "game-obj": "Traits",
+                "name": "Emotion",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 455",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 455",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 455,
+                    "type": "source"
+                  }
+                ],
+                "text": "This effect alters a creature\u2019s emotions. Effects with this trait always have the mental trait as well. Creatures with special training or that have mechanical or artificial intelligence are immune to emotion effects.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 68,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "9a5cea6bfb849deb16206c68f8d113a5",
+                "game-obj": "Traits",
+                "name": "Fear",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 456",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 456",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 456,
+                    "type": "source"
+                  }
+                ],
+                "text": "Fear effects evoke the emotion of fear. Effects with this trait always have the mental and emotion traits as well.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 106,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "6a1f80610baa3617c1597f49c6406313",
+                "game-obj": "Traits",
+                "name": "Mental",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 458",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 458",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 458,
+                    "type": "source"
+                  }
+                ],
+                "text": "A mental effect can alter the target\u2019s mind. It has no effect on an object or a mindless creature.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "void",
+              "formula": "1d8",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "unarmed",
+              "aonid": 719,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            },
+            {
+              "alt": "finesse",
+              "aonid": 602,
+              "game-obj": "Traits",
+              "name": "finesse",
+              "type": "link"
+            }
+          ],
+          "name": "Hand of the Lich",
+          "subtype": "ability",
+          "text": "All liches have a hand unarmed attack that deals 1d8 void damage for every 3 levels the lich has. This attack has the finesse trait.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The lich taps into their soul cage's power to cast any arcane spell up to the highest rank the lich can cast, even if the spell being cast is not one of the lich's prepared spells. The lich's soul cage doesn't need to be present for the lich to use this ability.",
+          "frequency": "once per day",
+          "name": "Drain Soul Cage",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "grabbed",
+              "aonid": 77,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 90,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            }
+          ],
+          "name": "Siphon Life",
+          "subtype": "ability",
+          "text": "A lich's form draws forth life from those who come into contact with it. When the lich damages a living creature with an unarmed attack, the lich gains 5 temporary Hit Points and the creature must succeed at a Fortitude save against the lich's spell DC \u2013 2 or become drained 1. If the lich is grabbed or restrained at the start of its turn, each creature grabbing or restraining it must succeed at a Fortitude save or become drained 1. If the lich siphons a creature's life again, the drained value increase by 1, to a maximum of drained 4.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "vitality",
+          "aonid": 509,
+          "game-obj": "Traits",
+          "name": "vitality",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "magical",
+          "aonid": 644,
+          "game-obj": "Traits",
+          "name": "magical",
+          "type": "link"
+        },
+        {
+          "alt": "Frightful Presence",
+          "aonid": 64,
+          "game-obj": "MonsterAbilities",
+          "name": "Frightful Presence",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "unarmed",
+          "aonid": 719,
+          "game-obj": "Traits",
+          "name": "unarmed",
+          "type": "link"
+        },
+        {
+          "alt": "finesse",
+          "aonid": 602,
+          "game-obj": "Traits",
+          "name": "finesse",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "grabbed",
+          "aonid": 77,
+          "game-obj": "Conditions",
+          "name": "grabbed",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 90,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        }
+      ],
+      "name": "Lich Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 218",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 218",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 218,
+          "type": "source"
+        }
+      ],
+      "text": "Liches lose all abilities that come from being a living creature. They also lose any traits that represented their life as a living creature, such as human and humanoid.  \n  \n A lich gains the following abilities.  \n  \n**Darkvision**  \n**Saving Throws** +1 status bonus to all saves vs. vitality  \n**Void Healing**  \n**Rejuvenation** (arcane) When a lich is destroyed, their soul immediately transfers to their *soul cage*. A lich can be permanently destroyed only if their *soul cage* is found and destroyed.  \n**Immunities** bleed, death effects, disease, paralyzed, poison, unconscious  \n**Resistances** cold 10, physical 10 (except magical bludgeoning)  \n**Frightful Presence** (aura, emotion, fear, mental) 60 feet, DC 30  \n**Hand of the Lich** All liches have a hand unarmed attack that deals 1d8 void damage for every 3 levels the lich has. This attack has the finesse trait.  \n**Drain Soul Cage** [-] **Frequency** once per day; **Effect** The lich taps into their soul cage's power to cast any arcane spell up to the highest rank the lich can cast, even if the spell being cast is not one of the lich's prepared spells. The lich's soul cage doesn't need to be present for the lich to use this ability.  \n**Siphon Life** A lich's form draws forth life from those who come into contact with it. When the lich damages a living creature with an unarmed attack, the lich gains 5 temporary Hit Points and the creature must succeed at a Fortitude save against the lich's spell DC \u2013 2 or become drained 1. If the lich is grabbed or restrained at the start of its turn, each creature grabbing or restraining it must succeed at a Fortitude save or become drained 1. If the lich siphons a creature's life again, the drained value increase by 1, to a maximum of drained 4.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "disrupted",
+              "aonid": 394,
+              "game-obj": "Rules",
+              "name": "disrupted",
+              "type": "link"
+            }
+          ],
+          "name": "Blasphemous Utterances",
+          "range": {
+            "range": 10,
+            "subtype": "range",
+            "text": "10 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "saving_throw": [
+            {
+              "dc": 10,
+              "save_type": "Flat Check",
+              "subtype": "save_dc",
+              "text": "DC 10 flat check",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The lich is accompanied by a constant echo of blasphemous murmurs and tainted whispers. A creature in the aura takes a \u20132 circumstance penalty to saves against mental effects and can't take actions that have the concentrate trait unless they succeed at a DC 10 flat check. On a failure, the action is disrupted.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "slowed 2",
+              "aonid": 92,
+              "game-obj": "Conditions",
+              "name": "slowed 2",
+              "type": "link"
+            }
+          ],
+          "name": "Cold Beyond Cold",
+          "subtype": "ability",
+          "text": "The lich's hand Strike deals cold damage instead of void and the target is slowed 2. A successful Fortitude save reduces this to slowed 1 (or negates it on a critical success).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Dark Deliverance",
+          "subtype": "ability",
+          "text": "The lich has resistance equal to their level to vitality.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "fear",
+              "aonid": 598,
+              "game-obj": "Traits",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "doomed 1",
+              "aonid": 67,
+              "game-obj": "Conditions",
+              "name": "doomed 1",
+              "type": "link"
+            }
+          ],
+          "name": "Void Shroud",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The lich is surrounded by an aura of death, drawing forth souls to be consumed by the lich's constant hunger. Living creatures in the emanation take a \u20132 status penalty to saves against fear and death effects. In addition, any creature that starts its turn in the area gains the doomed 1 condition unless it succeeds at a Will save against the lich's spell DC \u2013 4.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              "name": "death",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "disrupted",
+          "aonid": 394,
+          "game-obj": "Rules",
+          "name": "disrupted",
+          "type": "link"
+        },
+        {
+          "alt": "slowed 2",
+          "aonid": 92,
+          "game-obj": "Conditions",
+          "name": "slowed 2",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "doomed 1",
+          "aonid": 67,
+          "game-obj": "Conditions",
+          "name": "doomed 1",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Lich Abilities",
+      "sections": [
+        {
+          "name": "Lich Lairs",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 218",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 218",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 218,
+              "type": "source"
+            }
+          ],
+          "text": "After their metamorphosis, a lich often finds some quiet place to dwell, typically protected by a variety of guardians and traps, for two primary purposes. First, a lich requires solitude to plan their elaborate schemes, and second, few mortals (if any) deign to interact with these legendarily corrupt necromancers. One reason begets the other, as a lich's self-imposed isolation often drives them toward detachment and disdain for mortal life, further solidifying their separation from civilization. The longer a lich lives, the more meticulous a planner they become, secreting themself within a labyrinth of deadly puzzles, misdirection, and monsters. A lich's servants and guardians are absolutely loyal, either due to their nature (such as constructs or other undead) or as a result of compulsion from powerful magic. Many liches sink into their own warped worldviews; the nature of a lich's lair is a good indicator of their outlook on life itself.",
+          "type": "section"
+        },
+        {
+          "name": "Unique Lichdom",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 218",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 218",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 218,
+              "type": "source"
+            }
+          ],
+          "text": "The exact ritual, ingredients for deadly concoctions, and magical conditions required to become a lich are unique and different for every living creature. Understanding a spellcaster's path to lichdom can help, but is no guarantee of success for others.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 218",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 218",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 218,
+          "type": "source"
+        }
+      ],
+      "text": "You can create a more unusual lich by substituting any one of the following abilities for frightful presence, siphon life, or Drain Soul Cage.  \n  \n**Blasphemous Utterances** (arcane, aura, mental) 10 feet. The lich is accompanied by a constant echo of blasphemous murmurs and tainted whispers. A creature in the aura takes a \u20132 circumstance penalty to saves against mental effects and can't take actions that have the concentrate trait unless they succeed at a DC 10 flat check. On a failure, the action is disrupted.  \n**Cold Beyond Cold** The lich's hand Strike deals cold damage instead of void and the target is slowed 2. A successful Fortitude save reduces this to slowed 1 (or negates it on a critical success).  \n**Dark Deliverance** The lich has resistance equal to their level to vitality.   \n**Void Shroud** (aura, death) 30 feet. The lich is surrounded by an aura of death, drawing forth souls to be consumed by the lich's constant hunger. Living creatures in the emanation take a \u20132 status penalty to saves against fear and death effects. In addition, any creature that starts its turn in the area gains the doomed 1 condition unless it succeeds at a Will save against the lich's spell DC \u2013 4.",
       "type": "section"
     }
   ],

--- a/monster_families/monster_core/nymph.json
+++ b/monster_families/monster_core/nymph.json
@@ -64,488 +64,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "counteract",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "blight",
-                    "aonid": 111,
-                    "game-obj": "Rituals",
-                    "name": "blight",
-                    "type": "link"
-                  }
-                ],
-                "name": "Tied to the Land",
-                "subtype": "ability",
-                "text": "A nymph queen is intrinsically tied to a specific region. As long as the queen is healthy, the environment is exceptionally resilient, allowing the nymph queen to automatically attempt to counteract any spell that would harm the environment (such as the *blight* ritual), using her spell DC with a counteract rank equal to the highest-rank druid spell she can cast. When the nymph queen becomes physically or psychologically unhealthy, however, her warded region eventually becomes twisted or unhealthy as well. In that case, restoring the nymph queen swiftly heals the entire region.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Nymph's Beauty",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "Creatures that start their turn in the aura must succeed at a Will save or suffer an effect described in the nymph queen's entry.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "Nymph queens can transform between their original form, which looks much like a typical nymph of their kind, and any Small or Medium humanoid form, typically choosing a more humanoid-looking version of their natural form.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "frequency": "once per turn",
-                "name": "Focus Beauty",
-                "subtype": "ability",
-                "text": "The nymph queen focuses her beauty upon a target, who must attempt a save against her nymph's beauty aura. If the creature fails and was already affected by the aura, it takes a greater effect described in the nymph queen's entry. A nymph queen can Focus Beauty on a given creature only once per turn.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Crafting",
-                    "aonid": 37,
-                    "game-obj": "Skills",
-                    "name": "Crafting",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Performance",
-                    "aonid": 45,
-                    "game-obj": "Skills",
-                    "name": "Performance",
-                    "type": "link"
-                  }
-                ],
-                "name": "Inspiration",
-                "subtype": "ability",
-                "text": "The nymph queen inspires a single intelligent creature by giving that creature a token of her favor, typically a lock of her hair, though it can be some other significant object as well. As long as the creature carries her token and remains in good standing with her, the creature gains a +1 status bonus to all Crafting checks, Performance checks, and Will saves.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Nymph Queens')].sections[?(@.name=='Nymph Queen Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -556,6 +79,167 @@
                 "game-obj": "Classes",
                 "name": "druid",
                 "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "blight",
+                "aonid": 111,
+                "game-obj": "Rituals",
+                "name": "blight",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "Crafting",
+                "aonid": 37,
+                "game-obj": "Skills",
+                "name": "Crafting",
+                "type": "link"
+              },
+              {
+                "alt": "Performance",
+                "aonid": 45,
+                "game-obj": "Skills",
+                "name": "Performance",
+                "type": "link"
+              },
+              {
+                "alt": "bard",
+                "aonid": 3,
+                "game-obj": "Classes",
+                "name": "bard",
+                "type": "link"
+              },
+              {
+                "alt": "Lore",
+                "aonid": 41,
+                "game-obj": "Skills",
+                "name": "Lore",
+                "type": "link"
+              },
+              {
+                "alt": "fey",
+                "aonid": 599,
+                "game-obj": "Traits",
+                "name": "fey",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -565,7 +249,6 @@
         ],
         "name": "Nymph Queen Abilities",
         "subtype": "monster_family",
-        "text": "A nymph queen is 6 to 10 levels higher than an ordinary nymph of the same type, with enhanced numerical statistics and improved Strikes to match. A nymph queen's ward is a significant region, and she strengthens and vivifies this territory with her presence. Nymph queens are not dependent on their wards and lose the corresponding ability (such as a dryad's tree dependent ability); instead, they gain the tied to the land ability, as described below. A nymph queen also gains the nymph's beauty aura and the Focus Beauty action, which have varying effects based on the queen's original type. She gains the Inspiration ability, allowing her to bestow a gift of inspiration on those who catch her fancy, and the Change Shape ability to change her form. Finally, she gains primal prepared spells as a druid of her level.",
         "type": "stat_block_section"
       }
     ],
@@ -577,6 +260,679 @@
     {
       "name": "Nymph Queens",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "interaction",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "counteract",
+                  "aonid": 371,
+                  "game-obj": "Rules",
+                  "name": "counteract",
+                  "type": "link"
+                },
+                {
+                  "alt": "blight",
+                  "aonid": 111,
+                  "game-obj": "Rituals",
+                  "name": "blight",
+                  "type": "link"
+                }
+              ],
+              "name": "Tied to the Land",
+              "subtype": "ability",
+              "text": "A nymph queen is intrinsically tied to a specific region. As long as the queen is healthy, the environment is exceptionally resilient, allowing the nymph queen to automatically attempt to counteract any spell that would harm the environment (such as the *blight* ritual), using her spell DC with a counteract rank equal to the highest-rank druid spell she can cast. When the nymph queen becomes physically or psychologically unhealthy, however, her warded region eventually becomes twisted or unhealthy as well. In that case, restoring the nymph queen swiftly heals the entire region.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Nymph's Beauty",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "Creatures that start their turn in the aura must succeed at a Will save or suffer an effect described in the nymph queen's entry.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 542,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 590,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 647,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 676,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "visual",
+                    "aonid": 727,
+                    "game-obj": "Traits",
+                    "name": "visual",
+                    "type": "link"
+                  },
+                  "name": "visual",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "Nymph queens can transform between their original form, which looks much like a typical nymph of their kind, and any Small or Medium humanoid form, typically choosing a more humanoid-looking version of their natural form.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 676,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "frequency": "once per turn",
+              "name": "Focus Beauty",
+              "subtype": "ability",
+              "text": "The nymph queen focuses her beauty upon a target, who must attempt a save against her nymph's beauty aura. If the creature fails and was already affected by the aura, it takes a greater effect described in the nymph queen's entry. A nymph queen can Focus Beauty on a given creature only once per turn.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 590,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 647,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 676,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "visual",
+                    "aonid": 727,
+                    "game-obj": "Traits",
+                    "name": "visual",
+                    "type": "link"
+                  },
+                  "name": "visual",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Three Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "Crafting",
+                  "aonid": 37,
+                  "game-obj": "Skills",
+                  "name": "Crafting",
+                  "type": "link"
+                },
+                {
+                  "alt": "Performance",
+                  "aonid": 45,
+                  "game-obj": "Skills",
+                  "name": "Performance",
+                  "type": "link"
+                }
+              ],
+              "name": "Inspiration",
+              "subtype": "ability",
+              "text": "The nymph queen inspires a single intelligent creature by giving that creature a token of her favor, typically a lock of her hair, though it can be some other significant object as well. As long as the creature carries her token and remains in good standing with her, the creature gains a +1 status bonus to all Crafting checks, Performance checks, and Will saves.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 590,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 647,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "primal",
+                    "aonid": 676,
+                    "game-obj": "Traits",
+                    "name": "primal",
+                    "type": "link"
+                  },
+                  "name": "primal",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "druid",
+              "aonid": 6,
+              "game-obj": "Classes",
+              "name": "druid",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            },
+            {
+              "alt": "blight",
+              "aonid": 111,
+              "game-obj": "Rituals",
+              "name": "blight",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 542,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 590,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 676,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 727,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 676,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 590,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 676,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 727,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 590,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 676,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "Crafting",
+              "aonid": 37,
+              "game-obj": "Skills",
+              "name": "Crafting",
+              "type": "link"
+            },
+            {
+              "alt": "Performance",
+              "aonid": 45,
+              "game-obj": "Skills",
+              "name": "Performance",
+              "type": "link"
+            },
+            {
+              "alt": "bard",
+              "aonid": 3,
+              "game-obj": "Classes",
+              "name": "bard",
+              "type": "link"
+            },
+            {
+              "alt": "Lore",
+              "aonid": 41,
+              "game-obj": "Skills",
+              "name": "Lore",
+              "type": "link"
+            },
+            {
+              "alt": "fey",
+              "aonid": 599,
+              "game-obj": "Traits",
+              "name": "fey",
+              "type": "link"
+            }
+          ],
+          "name": "Nymph Queen Abilities",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 244",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 244",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 244,
+              "type": "source"
+            }
+          ],
+          "text": "A nymph queen is 6 to 10 levels higher than an ordinary nymph of the same type, with enhanced numerical statistics and improved Strikes to match. A nymph queen's ward is a significant region, and she strengthens and vivifies this territory with her presence. Nymph queens are not dependent on their wards and lose the corresponding ability (such as a dryad's tree dependent ability); instead, they gain the tied to the land ability, as described below. A nymph queen also gains the nymph's beauty aura and the Focus Beauty action, which have varying effects based on the queen's original type. She gains the Inspiration ability, allowing her to bestow a gift of inspiration on those who catch her fancy, and the Change Shape ability to change her form. Finally, she gains primal prepared spells as a druid of her level.  \n  \n**Tied to the Land** A nymph queen is intrinsically tied to a specific region. As long as the queen is healthy, the environment is exceptionally resilient, allowing the nymph queen to automatically attempt to counteract any spell that would harm the environment (such as the *blight* ritual), using her spell DC with a counteract rank equal to the highest-rank druid spell she can cast. When the nymph queen becomes physically or psychologically unhealthy, however, her warded region eventually becomes twisted or unhealthy as well. In that case, restoring the nymph queen swiftly heals the entire region.  \n**Nymph's Beauty** (aura, emotion, mental, primal, visual) 30 feet. Creatures that start their turn in the aura must succeed at a Will save or suffer an effect described in the nymph queen's entry.  \n**Change Shape** [#] (polymorph, primal) Nymph queens can transform between their original form, which looks much like a typical nymph of their kind, and any Small or Medium humanoid form, typically choosing a more humanoid-looking version of their natural form.  \n**Focus Beauty** [#] (emotion, mental, primal, visual) The nymph queen focuses her beauty upon a target, who must attempt a save against her nymph's beauty aura. If the creature fails and was already affected by the aura, it takes a greater effect described in the nymph queen's entry. A nymph queen can Focus Beauty on a given creature only once per turn.  \n**Inspiration** [###] (emotion, mental, primal) The nymph queen inspires a single intelligent creature by giving that creature a token of her favor, typically a lock of her hair, though it can be some other significant object as well. As long as the creature carries her token and remains in good standing with her, the creature gains a +1 status bonus to all Crafting checks, Performance checks, and Will saves.  \n If the nymph grants her token to a bard, and she's the bard's muse, the queen chooses one additional benefit granted by her token: a +1 status bonus to all Lore checks, a +2 status bonus to Performance checks when determining the effects of compositions, a +4 status bonus to untrained skill checks, or a +2 status bonus to Will saves against fey.",
+          "type": "section"
+        },
         {
           "name": "Artistic Treasures",
           "sources": [

--- a/monster_families/monster_core/serpentfolk.json
+++ b/monster_families/monster_core/serpentfolk.json
@@ -75,138 +75,84 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mislead",
-                    "aonid": 1605,
-                    "game-obj": "Spells",
-                    "name": "mislead",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "zealous conviction",
-                    "aonid": 1760,
-                    "game-obj": "Spells",
-                    "name": "zealous conviction",
-                    "type": "link"
-                  }
-                ],
-                "name": "6th",
-                "subtype": "ability",
-                "text": "*mislead*, *zealous conviction*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mind probe",
-                    "aonid": 1601,
-                    "game-obj": "Spells",
-                    "name": "mind probe",
-                    "type": "link"
-                  }
-                ],
-                "name": "5th",
-                "subtype": "ability",
-                "text": "*mind probe*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "honeyed words",
-                    "aonid": 1558,
-                    "game-obj": "Spells",
-                    "name": "honeyed words",
-                    "type": "link"
-                  }
-                ],
-                "name": "4th",
-                "subtype": "ability",
-                "text": "*honeyed words*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "dream message",
-                    "aonid": 1503,
-                    "game-obj": "Spells",
-                    "name": "dream message",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enthrall",
-                    "aonid": 1516,
-                    "game-obj": "Spells",
-                    "name": "enthrall",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "mind reading",
-                    "aonid": 1602,
-                    "game-obj": "Spells",
-                    "name": "mind reading",
-                    "type": "link"
-                  }
-                ],
-                "name": "3rd",
-                "subtype": "ability",
-                "text": "*dream message*, *enthrall*, *mind reading*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "invisibility",
-                    "aonid": 1577,
-                    "game-obj": "Spells",
-                    "name": "invisibility",
-                    "type": "link"
-                  }
-                ],
-                "name": "2nd",
-                "subtype": "ability",
-                "text": "*invisibility* (self only);",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mindlink",
-                    "aonid": 1603,
-                    "game-obj": "Spells",
-                    "name": "mindlink",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "phantom pain",
-                    "aonid": 1632,
-                    "game-obj": "Spells",
-                    "name": "phantom pain",
-                    "type": "link"
-                  }
-                ],
-                "name": "1st",
-                "subtype": "ability",
-                "text": "*mindlink*, *phantom pain*. Aapoph serpentfolk lack innate spells.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Serpentfolk Magic')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mislead",
+                "aonid": 1605,
+                "game-obj": "Spells",
+                "name": "mislead",
+                "type": "link"
+              },
+              {
+                "alt": "zealous conviction",
+                "aonid": 1760,
+                "game-obj": "Spells",
+                "name": "zealous conviction",
+                "type": "link"
+              },
+              {
+                "alt": "mind probe",
+                "aonid": 1601,
+                "game-obj": "Spells",
+                "name": "mind probe",
+                "type": "link"
+              },
+              {
+                "alt": "honeyed words",
+                "aonid": 1558,
+                "game-obj": "Spells",
+                "name": "honeyed words",
+                "type": "link"
+              },
+              {
+                "alt": "dream message",
+                "aonid": 1503,
+                "game-obj": "Spells",
+                "name": "dream message",
+                "type": "link"
+              },
+              {
+                "alt": "enthrall",
+                "aonid": 1516,
+                "game-obj": "Spells",
+                "name": "enthrall",
+                "type": "link"
+              },
+              {
+                "alt": "mind reading",
+                "aonid": 1602,
+                "game-obj": "Spells",
+                "name": "mind reading",
+                "type": "link"
+              },
+              {
+                "alt": "invisibility",
+                "aonid": 1577,
+                "game-obj": "Spells",
+                "name": "invisibility",
+                "type": "link"
+              },
+              {
+                "alt": "mindlink",
+                "aonid": 1603,
+                "game-obj": "Spells",
+                "name": "mindlink",
+                "type": "link"
+              },
+              {
+                "alt": "phantom pain",
+                "aonid": 1632,
+                "game-obj": "Spells",
+                "name": "phantom pain",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -216,7 +162,6 @@
         ],
         "name": "Serpentfolk Magic",
         "subtype": "monster_family",
-        "text": "Some serpentfolk might have entirely different innate spells. These alternative spells are typically illusions, mental spells, or divinatory magic. Examples, listed by their minimum rank, include:",
         "type": "stat_block_section"
       }
     ],
@@ -249,6 +194,230 @@
         }
       ],
       "text": "A small number of serpentfolk settlements dot Golarion's surface, most of them in humid, remote jungles, far-flung islands, or at the mouths of caverns. It's rare for such a settlement to number more than a few dozen serpentfolk. They rely primarily on aapophs to build their power bases, to defend them, and to perform essentially all the practical functions of their society. This includes providing food, crafting goods, and tending to the zyss's every need.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "mislead",
+              "aonid": 1605,
+              "game-obj": "Spells",
+              "name": "mislead",
+              "type": "link"
+            },
+            {
+              "alt": "zealous conviction",
+              "aonid": 1760,
+              "game-obj": "Spells",
+              "name": "zealous conviction",
+              "type": "link"
+            }
+          ],
+          "name": "6th",
+          "subtype": "ability",
+          "text": "*mislead*, *zealous conviction*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "mind probe",
+              "aonid": 1601,
+              "game-obj": "Spells",
+              "name": "mind probe",
+              "type": "link"
+            }
+          ],
+          "name": "5th",
+          "subtype": "ability",
+          "text": "*mind probe*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "honeyed words",
+              "aonid": 1558,
+              "game-obj": "Spells",
+              "name": "honeyed words",
+              "type": "link"
+            }
+          ],
+          "name": "4th",
+          "subtype": "ability",
+          "text": "*honeyed words*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "dream message",
+              "aonid": 1503,
+              "game-obj": "Spells",
+              "name": "dream message",
+              "type": "link"
+            },
+            {
+              "alt": "enthrall",
+              "aonid": 1516,
+              "game-obj": "Spells",
+              "name": "enthrall",
+              "type": "link"
+            },
+            {
+              "alt": "mind reading",
+              "aonid": 1602,
+              "game-obj": "Spells",
+              "name": "mind reading",
+              "type": "link"
+            }
+          ],
+          "name": "3rd",
+          "subtype": "ability",
+          "text": "*dream message*, *enthrall*, *mind reading*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "invisibility",
+              "aonid": 1577,
+              "game-obj": "Spells",
+              "name": "invisibility",
+              "type": "link"
+            }
+          ],
+          "name": "2nd",
+          "subtype": "ability",
+          "text": "*invisibility* (self only);",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "mindlink",
+              "aonid": 1603,
+              "game-obj": "Spells",
+              "name": "mindlink",
+              "type": "link"
+            },
+            {
+              "alt": "phantom pain",
+              "aonid": 1632,
+              "game-obj": "Spells",
+              "name": "phantom pain",
+              "type": "link"
+            }
+          ],
+          "name": "1st",
+          "subtype": "ability",
+          "text": "*mindlink*, *phantom pain*. Aapoph serpentfolk lack innate spells.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "mislead",
+          "aonid": 1605,
+          "game-obj": "Spells",
+          "name": "mislead",
+          "type": "link"
+        },
+        {
+          "alt": "zealous conviction",
+          "aonid": 1760,
+          "game-obj": "Spells",
+          "name": "zealous conviction",
+          "type": "link"
+        },
+        {
+          "alt": "mind probe",
+          "aonid": 1601,
+          "game-obj": "Spells",
+          "name": "mind probe",
+          "type": "link"
+        },
+        {
+          "alt": "honeyed words",
+          "aonid": 1558,
+          "game-obj": "Spells",
+          "name": "honeyed words",
+          "type": "link"
+        },
+        {
+          "alt": "dream message",
+          "aonid": 1503,
+          "game-obj": "Spells",
+          "name": "dream message",
+          "type": "link"
+        },
+        {
+          "alt": "enthrall",
+          "aonid": 1516,
+          "game-obj": "Spells",
+          "name": "enthrall",
+          "type": "link"
+        },
+        {
+          "alt": "mind reading",
+          "aonid": 1602,
+          "game-obj": "Spells",
+          "name": "mind reading",
+          "type": "link"
+        },
+        {
+          "alt": "invisibility",
+          "aonid": 1577,
+          "game-obj": "Spells",
+          "name": "invisibility",
+          "type": "link"
+        },
+        {
+          "alt": "mindlink",
+          "aonid": 1603,
+          "game-obj": "Spells",
+          "name": "mindlink",
+          "type": "link"
+        },
+        {
+          "alt": "phantom pain",
+          "aonid": 1632,
+          "game-obj": "Spells",
+          "name": "phantom pain",
+          "type": "link"
+        }
+      ],
+      "name": "Serpentfolk Magic",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 302",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 302",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 302,
+          "type": "source"
+        }
+      ],
+      "text": "Some serpentfolk might have entirely different innate spells. These alternative spells are typically illusions, mental spells, or divinatory magic. Examples, listed by their minimum rank, include: **6th** *mislead*, *zealous conviction*; **5th** *mind probe*; **4th** *honeyed words*; **3rd** *dream message*, *enthrall*, *mind reading*; **2nd** *invisibility* (self only); **1st** *mindlink*, *phantom pain*. Aapoph serpentfolk lack innate spells.",
       "type": "section"
     },
     {

--- a/monster_families/monster_core/sinspawn.json
+++ b/monster_families/monster_core/sinspawn.json
@@ -68,279 +68,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d10+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d8+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d10+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d12+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d8+4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 684,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "versatile S",
-                    "aonid": 724,
-                    "game-obj": "Traits",
-                    "name": "versatile S",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enfeebled 2",
-                    "aonid": 71,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Survival",
-                    "aonid": 49,
-                    "game-obj": "Skills",
-                    "name": "Survival",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "scythe",
-                    "aonid": 394,
-                    "game-obj": "Weapons",
-                    "name": "scythe",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "deadly d10",
-                    "aonid": 570,
-                    "game-obj": "Traits",
-                    "name": "deadly d10",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "trip",
-                    "aonid": 2382,
-                    "game-obj": "Actions",
-                    "name": "trip",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Thievery",
-                    "aonid": 50,
-                    "game-obj": "Skills",
-                    "name": "Thievery",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "glaive",
-                    "aonid": 375,
-                    "game-obj": "Weapons",
-                    "name": "glaive",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "deadly d8",
-                    "aonid": 570,
-                    "game-obj": "Traits",
-                    "name": "deadly d8",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "forceful",
-                    "aonid": 611,
-                    "game-obj": "Traits",
-                    "name": "forceful",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 684,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "clumsy 2",
-                    "aonid": 61,
-                    "game-obj": "Conditions",
-                    "name": "clumsy 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Diplomacy",
-                    "aonid": 39,
-                    "game-obj": "Skills",
-                    "name": "Diplomacy",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "guisarme",
-                    "aonid": 380,
-                    "game-obj": "Weapons",
-                    "name": "guisarme",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 684,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "trip",
-                    "aonid": 2382,
-                    "game-obj": "Actions",
-                    "name": "trip",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied 2",
-                    "aonid": 94,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Intimidation",
-                    "aonid": 40,
-                    "game-obj": "Skills",
-                    "name": "Intimidation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "maul",
-                    "aonid": 388,
-                    "game-obj": "Weapons",
-                    "name": "maul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "shove",
-                    "aonid": 2380,
-                    "game-obj": "Actions",
-                    "name": "shove",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "clumsy 1",
-                    "aonid": 61,
-                    "game-obj": "Conditions",
-                    "name": "clumsy 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enfeebled 1",
-                    "aonid": 71,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Society",
-                    "aonid": 47,
-                    "game-obj": "Skills",
-                    "name": "Society",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "longspear",
-                    "aonid": 361,
-                    "game-obj": "Weapons",
-                    "name": "longspear",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 684,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 36,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ranseur",
-                    "aonid": 390,
-                    "game-obj": "Weapons",
-                    "name": "ranseur",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "reach 10 feet",
-                    "aonid": 684,
-                    "game-obj": "Traits",
-                    "name": "reach 10 feet",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enfeebled 1",
-                    "aonid": 71,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Melee",
-                "subtype": "ability",
-                "text": "halberd +10 (reach 10 feet, versatile S), **Damage** 1d10+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against an envyspawn's sinful bite are enfeebled 2 for 1 minute. ### Gluttonyspawn\n\n A gluttonyspawn has Survival +10 and usually carries a scythe. They are corpulent, hardy, and strong. **Melee** scythe +10 (deadly d10, trip), **Damage** 1d10+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a gluttonyspawn's sinful bite are drained 1. ### Greedspawn\n\n A greedspawn has Thievery +9 and typically wields a glaive. They are the tallest of sinspawn, often 7 feet in height, and with gold-tinged veins. **Melee** glaive +10 (deadly d8, forceful, reach 10 feet), **Damage** 1d8+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a greedspawn's sinful bite are clumsy 2 for 1 minute. ### Lustspawn\n\n A lustspawn has Diplomacy +7 and usually carries a guisarme. They move gracefully, but have hideous faces. **Melee** guisarme +10 (reach 10 feet, trip), **Damage** 1d10+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a lustspawn's sinful bite are stupefied 2 for 1 minute. ### Pridespawn\n\n A pridespawn has Intimidation +7 and often wields a maul. They are nearly skeletal in their gauntness, and often seek out fine clothes or jewelry to wear, taking pleasure in appearing elegant and regal. **Melee** maul +10 (shove), **Damage** 1d12+4 bludgeoning   \n**Sinful Bite** Creatures that critically fail their saves against a pridespawn's sinful bite are clumsy 1 and enfeebled 1 for 1 minute. ### Slothspawn\n\n A slothspawn has Society +6 and usually carries a longspear. Thick rolls of excess skin drape the slothspawn's hunched frame. **Melee** longspear +10 (reach 10 feet), **Damage** 1d8+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against a slothspawn's sinful bite take a \u201310-foot status penalty to their Speeds for 1 minute. ### Wrathspawn\n\n The most commonly encountered of the sinspawn, a wrathspawn has Athletics +12 and typically wields a ranseur. These sinspawn are the most muscular of their kind.  \n**Melee** ranseur +10 (disarm, reach 10 feet), **Damage** 1d10+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against a wrathspawn's sinful bite are drained 1 as well as enfeebled 1 for 1 minute. ###  Born of Sin\n\nSinspawn retreated from the world for many centuries following the collapse of the runelords' empire, but in recent years they have emerged from ancient dungeons, strange magical pools, and other forgotten ruins. Sinspawn cannot procreate, but in certain cases, incredibly powerful artifacts crafted by the runelords known as runewells can siphon off fragments of sinful memories and emotions related to the runewells' associated sins from the souls of people dying nearby, fueling the spontaneous creation of new sinspawn. When enough sinful energies have been gathered within a runewell, it vomits forth a full-grown sinspawn with no prior loyalty to a long-lost runelord. All sinspawn inherently understand the runewells' role in the propagation of their kind, and they often establish small villages near awakened runewells, hunting down sentient beings they can use to propagate their communities.###  Sinspawn Locations\n\nSinspawn are found in regions where sources for their creation remain buried in ancient ruins\u2014in Golarion, this currently limits them to the frontier lands of Varisia. But as they spread, so too does the potential knowledge of crafting more of them, and fleshwarpers around the world are hoping to craft new sinspawn of their own someday soon.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Sinspawn Sins')].sections[?(@.name=='Envyspawn')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -358,6 +90,230 @@
                 "game-obj": "Weapons",
                 "name": "halberd",
                 "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 684,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "versatile S",
+                "aonid": 724,
+                "game-obj": "Traits",
+                "name": "versatile S",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled 2",
+                "aonid": 71,
+                "game-obj": "Conditions",
+                "name": "enfeebled 2",
+                "type": "link"
+              },
+              {
+                "alt": "Survival",
+                "aonid": 49,
+                "game-obj": "Skills",
+                "name": "Survival",
+                "type": "link"
+              },
+              {
+                "alt": "scythe",
+                "aonid": 394,
+                "game-obj": "Weapons",
+                "name": "scythe",
+                "type": "link"
+              },
+              {
+                "alt": "deadly d10",
+                "aonid": 570,
+                "game-obj": "Traits",
+                "name": "deadly d10",
+                "type": "link"
+              },
+              {
+                "alt": "trip",
+                "aonid": 2382,
+                "game-obj": "Actions",
+                "name": "trip",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "Thievery",
+                "aonid": 50,
+                "game-obj": "Skills",
+                "name": "Thievery",
+                "type": "link"
+              },
+              {
+                "alt": "glaive",
+                "aonid": 375,
+                "game-obj": "Weapons",
+                "name": "glaive",
+                "type": "link"
+              },
+              {
+                "alt": "deadly d8",
+                "aonid": 570,
+                "game-obj": "Traits",
+                "name": "deadly d8",
+                "type": "link"
+              },
+              {
+                "alt": "forceful",
+                "aonid": 611,
+                "game-obj": "Traits",
+                "name": "forceful",
+                "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 684,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "clumsy 2",
+                "aonid": 61,
+                "game-obj": "Conditions",
+                "name": "clumsy 2",
+                "type": "link"
+              },
+              {
+                "alt": "Diplomacy",
+                "aonid": 39,
+                "game-obj": "Skills",
+                "name": "Diplomacy",
+                "type": "link"
+              },
+              {
+                "alt": "guisarme",
+                "aonid": 380,
+                "game-obj": "Weapons",
+                "name": "guisarme",
+                "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 684,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "trip",
+                "aonid": 2382,
+                "game-obj": "Actions",
+                "name": "trip",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 2",
+                "aonid": 94,
+                "game-obj": "Conditions",
+                "name": "stupefied 2",
+                "type": "link"
+              },
+              {
+                "alt": "Intimidation",
+                "aonid": 40,
+                "game-obj": "Skills",
+                "name": "Intimidation",
+                "type": "link"
+              },
+              {
+                "alt": "maul",
+                "aonid": 388,
+                "game-obj": "Weapons",
+                "name": "maul",
+                "type": "link"
+              },
+              {
+                "alt": "shove",
+                "aonid": 2380,
+                "game-obj": "Actions",
+                "name": "shove",
+                "type": "link"
+              },
+              {
+                "alt": "clumsy 1",
+                "aonid": 61,
+                "game-obj": "Conditions",
+                "name": "clumsy 1",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled 1",
+                "aonid": 71,
+                "game-obj": "Conditions",
+                "name": "enfeebled 1",
+                "type": "link"
+              },
+              {
+                "alt": "Society",
+                "aonid": 47,
+                "game-obj": "Skills",
+                "name": "Society",
+                "type": "link"
+              },
+              {
+                "alt": "longspear",
+                "aonid": 361,
+                "game-obj": "Weapons",
+                "name": "longspear",
+                "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 684,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 36,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "ranseur",
+                "aonid": 390,
+                "game-obj": "Weapons",
+                "name": "ranseur",
+                "type": "link"
+              },
+              {
+                "alt": "reach 10 feet",
+                "aonid": 684,
+                "game-obj": "Traits",
+                "name": "reach 10 feet",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled 1",
+                "aonid": 71,
+                "game-obj": "Conditions",
+                "name": "enfeebled 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -367,7 +323,6 @@
         ],
         "name": "Envyspawn",
         "subtype": "monster_family",
-        "text": "An envyspawn has Deception +7 and typically carries a halberd. They tend to be shorter and thinner than other sinspawn.",
         "type": "stat_block_section"
       }
     ],
@@ -378,6 +333,542 @@
   "sections": [
     {
       "name": "Sinspawn Sins",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "piercing",
+                  "formula": "1d10+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "slashing",
+                  "formula": "1d8+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "slashing",
+                  "formula": "1d10+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "bludgeoning",
+                  "formula": "1d12+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                },
+                {
+                  "damage_type": "piercing",
+                  "formula": "1d8+4",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 684,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "versatile S",
+                  "aonid": 724,
+                  "game-obj": "Traits",
+                  "name": "versatile S",
+                  "type": "link"
+                },
+                {
+                  "alt": "enfeebled 2",
+                  "aonid": 71,
+                  "game-obj": "Conditions",
+                  "name": "enfeebled 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "Survival",
+                  "aonid": 49,
+                  "game-obj": "Skills",
+                  "name": "Survival",
+                  "type": "link"
+                },
+                {
+                  "alt": "scythe",
+                  "aonid": 394,
+                  "game-obj": "Weapons",
+                  "name": "scythe",
+                  "type": "link"
+                },
+                {
+                  "alt": "deadly d10",
+                  "aonid": 570,
+                  "game-obj": "Traits",
+                  "name": "deadly d10",
+                  "type": "link"
+                },
+                {
+                  "alt": "trip",
+                  "aonid": 2382,
+                  "game-obj": "Actions",
+                  "name": "trip",
+                  "type": "link"
+                },
+                {
+                  "alt": "drained 1",
+                  "aonid": 68,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "Thievery",
+                  "aonid": 50,
+                  "game-obj": "Skills",
+                  "name": "Thievery",
+                  "type": "link"
+                },
+                {
+                  "alt": "glaive",
+                  "aonid": 375,
+                  "game-obj": "Weapons",
+                  "name": "glaive",
+                  "type": "link"
+                },
+                {
+                  "alt": "deadly d8",
+                  "aonid": 570,
+                  "game-obj": "Traits",
+                  "name": "deadly d8",
+                  "type": "link"
+                },
+                {
+                  "alt": "forceful",
+                  "aonid": 611,
+                  "game-obj": "Traits",
+                  "name": "forceful",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 684,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "clumsy 2",
+                  "aonid": 61,
+                  "game-obj": "Conditions",
+                  "name": "clumsy 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "Diplomacy",
+                  "aonid": 39,
+                  "game-obj": "Skills",
+                  "name": "Diplomacy",
+                  "type": "link"
+                },
+                {
+                  "alt": "guisarme",
+                  "aonid": 380,
+                  "game-obj": "Weapons",
+                  "name": "guisarme",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 684,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "trip",
+                  "aonid": 2382,
+                  "game-obj": "Actions",
+                  "name": "trip",
+                  "type": "link"
+                },
+                {
+                  "alt": "stupefied 2",
+                  "aonid": 94,
+                  "game-obj": "Conditions",
+                  "name": "stupefied 2",
+                  "type": "link"
+                },
+                {
+                  "alt": "Intimidation",
+                  "aonid": 40,
+                  "game-obj": "Skills",
+                  "name": "Intimidation",
+                  "type": "link"
+                },
+                {
+                  "alt": "maul",
+                  "aonid": 388,
+                  "game-obj": "Weapons",
+                  "name": "maul",
+                  "type": "link"
+                },
+                {
+                  "alt": "shove",
+                  "aonid": 2380,
+                  "game-obj": "Actions",
+                  "name": "shove",
+                  "type": "link"
+                },
+                {
+                  "alt": "clumsy 1",
+                  "aonid": 61,
+                  "game-obj": "Conditions",
+                  "name": "clumsy 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "enfeebled 1",
+                  "aonid": 71,
+                  "game-obj": "Conditions",
+                  "name": "enfeebled 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "Society",
+                  "aonid": 47,
+                  "game-obj": "Skills",
+                  "name": "Society",
+                  "type": "link"
+                },
+                {
+                  "alt": "longspear",
+                  "aonid": 361,
+                  "game-obj": "Weapons",
+                  "name": "longspear",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 684,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "Athletics",
+                  "aonid": 36,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                },
+                {
+                  "alt": "ranseur",
+                  "aonid": 390,
+                  "game-obj": "Weapons",
+                  "name": "ranseur",
+                  "type": "link"
+                },
+                {
+                  "alt": "reach 10 feet",
+                  "aonid": 684,
+                  "game-obj": "Traits",
+                  "name": "reach 10 feet",
+                  "type": "link"
+                },
+                {
+                  "alt": "drained 1",
+                  "aonid": 68,
+                  "game-obj": "Conditions",
+                  "name": "drained 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "enfeebled 1",
+                  "aonid": 71,
+                  "game-obj": "Conditions",
+                  "name": "enfeebled 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Melee",
+              "subtype": "ability",
+              "text": "halberd +10 (reach 10 feet, versatile S), **Damage** 1d10+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against an envyspawn's sinful bite are enfeebled 2 for 1 minute. ### Gluttonyspawn\n\n A gluttonyspawn has Survival +10 and usually carries a scythe. They are corpulent, hardy, and strong. **Melee** scythe +10 (deadly d10, trip), **Damage** 1d10+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a gluttonyspawn's sinful bite are drained 1. ### Greedspawn\n\n A greedspawn has Thievery +9 and typically wields a glaive. They are the tallest of sinspawn, often 7 feet in height, and with gold-tinged veins. **Melee** glaive +10 (deadly d8, forceful, reach 10 feet), **Damage** 1d8+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a greedspawn's sinful bite are clumsy 2 for 1 minute. ### Lustspawn\n\n A lustspawn has Diplomacy +7 and usually carries a guisarme. They move gracefully, but have hideous faces. **Melee** guisarme +10 (reach 10 feet, trip), **Damage** 1d10+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a lustspawn's sinful bite are stupefied 2 for 1 minute. ### Pridespawn\n\n A pridespawn has Intimidation +7 and often wields a maul. They are nearly skeletal in their gauntness, and often seek out fine clothes or jewelry to wear, taking pleasure in appearing elegant and regal. **Melee** maul +10 (shove), **Damage** 1d12+4 bludgeoning   \n**Sinful Bite** Creatures that critically fail their saves against a pridespawn's sinful bite are clumsy 1 and enfeebled 1 for 1 minute. ### Slothspawn\n\n A slothspawn has Society +6 and usually carries a longspear. Thick rolls of excess skin drape the slothspawn's hunched frame. **Melee** longspear +10 (reach 10 feet), **Damage** 1d8+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against a slothspawn's sinful bite take a \u201310-foot status penalty to their Speeds for 1 minute. ### Wrathspawn\n\n The most commonly encountered of the sinspawn, a wrathspawn has Athletics +12 and typically wields a ranseur. These sinspawn are the most muscular of their kind.  \n**Melee** ranseur +10 (disarm, reach 10 feet), **Damage** 1d10+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against a wrathspawn's sinful bite are drained 1 as well as enfeebled 1 for 1 minute. ###  Born of Sin\n\nSinspawn retreated from the world for many centuries following the collapse of the runelords' empire, but in recent years they have emerged from ancient dungeons, strange magical pools, and other forgotten ruins. Sinspawn cannot procreate, but in certain cases, incredibly powerful artifacts crafted by the runelords known as runewells can siphon off fragments of sinful memories and emotions related to the runewells' associated sins from the souls of people dying nearby, fueling the spontaneous creation of new sinspawn. When enough sinful energies have been gathered within a runewell, it vomits forth a full-grown sinspawn with no prior loyalty to a long-lost runelord. All sinspawn inherently understand the runewells' role in the propagation of their kind, and they often establish small villages near awakened runewells, hunting down sentient beings they can use to propagate their communities.###  Sinspawn Locations\n\nSinspawn are found in regions where sources for their creation remain buried in ancient ruins\u2014in Golarion, this currently limits them to the frontier lands of Varisia. But as they spread, so too does the potential knowledge of crafting more of them, and fleshwarpers around the world are hoping to craft new sinspawn of their own someday soon.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Deception",
+              "aonid": 38,
+              "game-obj": "Skills",
+              "name": "Deception",
+              "type": "link"
+            },
+            {
+              "alt": "halberd",
+              "aonid": 381,
+              "game-obj": "Weapons",
+              "name": "halberd",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "versatile S",
+              "aonid": 724,
+              "game-obj": "Traits",
+              "name": "versatile S",
+              "type": "link"
+            },
+            {
+              "alt": "enfeebled 2",
+              "aonid": 71,
+              "game-obj": "Conditions",
+              "name": "enfeebled 2",
+              "type": "link"
+            },
+            {
+              "alt": "Survival",
+              "aonid": 49,
+              "game-obj": "Skills",
+              "name": "Survival",
+              "type": "link"
+            },
+            {
+              "alt": "scythe",
+              "aonid": 394,
+              "game-obj": "Weapons",
+              "name": "scythe",
+              "type": "link"
+            },
+            {
+              "alt": "deadly d10",
+              "aonid": 570,
+              "game-obj": "Traits",
+              "name": "deadly d10",
+              "type": "link"
+            },
+            {
+              "alt": "trip",
+              "aonid": 2382,
+              "game-obj": "Actions",
+              "name": "trip",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "Thievery",
+              "aonid": 50,
+              "game-obj": "Skills",
+              "name": "Thievery",
+              "type": "link"
+            },
+            {
+              "alt": "glaive",
+              "aonid": 375,
+              "game-obj": "Weapons",
+              "name": "glaive",
+              "type": "link"
+            },
+            {
+              "alt": "deadly d8",
+              "aonid": 570,
+              "game-obj": "Traits",
+              "name": "deadly d8",
+              "type": "link"
+            },
+            {
+              "alt": "forceful",
+              "aonid": 611,
+              "game-obj": "Traits",
+              "name": "forceful",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "clumsy 2",
+              "aonid": 61,
+              "game-obj": "Conditions",
+              "name": "clumsy 2",
+              "type": "link"
+            },
+            {
+              "alt": "Diplomacy",
+              "aonid": 39,
+              "game-obj": "Skills",
+              "name": "Diplomacy",
+              "type": "link"
+            },
+            {
+              "alt": "guisarme",
+              "aonid": 380,
+              "game-obj": "Weapons",
+              "name": "guisarme",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "trip",
+              "aonid": 2382,
+              "game-obj": "Actions",
+              "name": "trip",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied 2",
+              "aonid": 94,
+              "game-obj": "Conditions",
+              "name": "stupefied 2",
+              "type": "link"
+            },
+            {
+              "alt": "Intimidation",
+              "aonid": 40,
+              "game-obj": "Skills",
+              "name": "Intimidation",
+              "type": "link"
+            },
+            {
+              "alt": "maul",
+              "aonid": 388,
+              "game-obj": "Weapons",
+              "name": "maul",
+              "type": "link"
+            },
+            {
+              "alt": "shove",
+              "aonid": 2380,
+              "game-obj": "Actions",
+              "name": "shove",
+              "type": "link"
+            },
+            {
+              "alt": "clumsy 1",
+              "aonid": 61,
+              "game-obj": "Conditions",
+              "name": "clumsy 1",
+              "type": "link"
+            },
+            {
+              "alt": "enfeebled 1",
+              "aonid": 71,
+              "game-obj": "Conditions",
+              "name": "enfeebled 1",
+              "type": "link"
+            },
+            {
+              "alt": "Society",
+              "aonid": 47,
+              "game-obj": "Skills",
+              "name": "Society",
+              "type": "link"
+            },
+            {
+              "alt": "longspear",
+              "aonid": 361,
+              "game-obj": "Weapons",
+              "name": "longspear",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 36,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "ranseur",
+              "aonid": 390,
+              "game-obj": "Weapons",
+              "name": "ranseur",
+              "type": "link"
+            },
+            {
+              "alt": "reach 10 feet",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach 10 feet",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "enfeebled 1",
+              "aonid": 71,
+              "game-obj": "Conditions",
+              "name": "enfeebled 1",
+              "type": "link"
+            }
+          ],
+          "name": "Envyspawn",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 310",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 310",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 310,
+              "type": "source"
+            }
+          ],
+          "text": "An envyspawn has Deception +7 and typically carries a halberd. They tend to be shorter and thinner than other sinspawn.  \n**Melee** halberd +10 (reach 10 feet, versatile S), **Damage** 1d10+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against an envyspawn's sinful bite are enfeebled 2 for 1 minute. ### Gluttonyspawn\n\n A gluttonyspawn has Survival +10 and usually carries a scythe. They are corpulent, hardy, and strong. **Melee** scythe +10 (deadly d10, trip), **Damage** 1d10+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a gluttonyspawn's sinful bite are drained 1. ### Greedspawn\n\n A greedspawn has Thievery +9 and typically wields a glaive. They are the tallest of sinspawn, often 7 feet in height, and with gold-tinged veins. **Melee** glaive +10 (deadly d8, forceful, reach 10 feet), **Damage** 1d8+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a greedspawn's sinful bite are clumsy 2 for 1 minute. ### Lustspawn\n\n A lustspawn has Diplomacy +7 and usually carries a guisarme. They move gracefully, but have hideous faces. **Melee** guisarme +10 (reach 10 feet, trip), **Damage** 1d10+4 slashing   \n**Sinful Bite** Creatures that critically fail their saves against a lustspawn's sinful bite are stupefied 2 for 1 minute. ### Pridespawn\n\n A pridespawn has Intimidation +7 and often wields a maul. They are nearly skeletal in their gauntness, and often seek out fine clothes or jewelry to wear, taking pleasure in appearing elegant and regal. **Melee** maul +10 (shove), **Damage** 1d12+4 bludgeoning   \n**Sinful Bite** Creatures that critically fail their saves against a pridespawn's sinful bite are clumsy 1 and enfeebled 1 for 1 minute. ### Slothspawn\n\n A slothspawn has Society +6 and usually carries a longspear. Thick rolls of excess skin drape the slothspawn's hunched frame. **Melee** longspear +10 (reach 10 feet), **Damage** 1d8+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against a slothspawn's sinful bite take a \u201310-foot status penalty to their Speeds for 1 minute. ### Wrathspawn\n\n The most commonly encountered of the sinspawn, a wrathspawn has Athletics +12 and typically wields a ranseur. These sinspawn are the most muscular of their kind.  \n**Melee** ranseur +10 (disarm, reach 10 feet), **Damage** 1d10+4 piercing   \n**Sinful Bite** Creatures that critically fail their saves against a wrathspawn's sinful bite are drained 1 as well as enfeebled 1 for 1 minute. ###  Born of Sin\n\nSinspawn retreated from the world for many centuries following the collapse of the runelords' empire, but in recent years they have emerged from ancient dungeons, strange magical pools, and other forgotten ruins. Sinspawn cannot procreate, but in certain cases, incredibly powerful artifacts crafted by the runelords known as runewells can siphon off fragments of sinful memories and emotions related to the runewells' associated sins from the souls of people dying nearby, fueling the spontaneous creation of new sinspawn. When enough sinful energies have been gathered within a runewell, it vomits forth a full-grown sinspawn with no prior loyalty to a long-lost runelord. All sinspawn inherently understand the runewells' role in the propagation of their kind, and they often establish small villages near awakened runewells, hunting down sentient beings they can use to propagate their communities.###  Sinspawn Locations\n\nSinspawn are found in regions where sources for their creation remain buried in ancient ruins\u2014in Golarion, this currently limits them to the frontier lands of Varisia. But as they spread, so too does the potential knowledge of crafting more of them, and fleshwarpers around the world are hoping to craft new sinspawn of their own someday soon.",
+          "type": "section"
+        }
+      ],
       "sources": [
         {
           "errata": {

--- a/monster_families/monster_core/skeleton.json
+++ b/monster_families/monster_core/skeleton.json
@@ -59,493 +59,231 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Aquatic Ambush",
-                    "aonid": 51,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Aquatic Ambush",
-                    "type": "link"
-                  }
-                ],
-                "name": "Aquatic Bones",
-                "subtype": "ability",
-                "text": "The skeleton has bones from aquatic creatures, allowing it to swim using a simple tail, paddles, or similar appendage. The skeleton has a swim Speed of 20 feet and gains the aquatic trait and the Aquatic Ambush ability.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "cold",
-                    "aonid": 555,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent fire damage",
-                    "aonid": 86,
-                    "game-obj": "Conditions",
-                    "name": "persistent fire damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blaze",
-                "subtype": "ability",
-                "text": "The skeleton is wreathed with fire, which doesn't consume its bones or gear. The skeleton gains immunity to fire and weakness 5 to cold, loses its resistance to cold, and its Strikes deal additional persistent fire damage equal to half the skeleton's level (minimum 1 damage).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fast healing",
-                    "aonid": 62,
-                    "game-obj": "MonsterAbilities",
-                    "name": "fast healing",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bloody",
-                "subtype": "ability",
-                "text": "A coating of blood gives the skeleton fast healing equal to its level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "javelin",
-                    "aonid": 429,
-                    "game-obj": "Weapons",
-                    "name": "javelin",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bone Missile",
-                "subtype": "ability",
-                "text": "The skeleton yanks a rib from its ribcage to use as an arrow or javelin. The skeleton loses HP equal to its level (minimum 1), then makes a ranged Strike. This uses the attack bonus of whichever of the skeleton\u2019s other Strikes has the highest attack bonus and deals piercing damage equal to that Strike\u2019s damage plus the skeleton\u2019s level (minimum 1).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 5,
-                    "subtype": "area",
-                    "text": "5-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "poison",
-                    "formula": "1d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent poison damage",
-                    "aonid": 86,
-                    "game-obj": "Conditions",
-                    "name": "persistent poison damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bone Powder",
-                "subtype": "ability",
-                "text": "When the skeleton takes physical damage from a critical hit, one of its bones is pulverized into a fine powder. All creatures in a 5-foot emanation that breathe take 1d6 persistent poison damage (plus an additional 1d6 for every 6 levels the skeleton has).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "effect": "The skeleton transforms into a cyclone of bones, taking up the same space, but twice as tall. It then Strides up to double its Speed. It can move through spaces occupied by other creatures, and this movement doesn\u2019t trigger reactions. Creatures the Bone Storm moves through take 1d6 slashing damage for every 2 levels the skeleton has, with a basic Reflex save against the hard DC for the skeleton\u2019s level. A level 1 or lower skeleton only moves; it doesn\u2019t deal damage. A creature attempts this save only once even if the Bone Storm moved through its space multiple times. At the end of the movement, the skeleton reforms.",
-                "frequency": "once per day",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bone Storm",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The skeleton collapses into a pile of bones and the attack deals only normal damage. The skeleton can re-form in a standing position as an action, but until it does, it is immobilized and off-guard.",
-                "links": [
-                  {
-                    "alt": "immobilized",
-                    "aonid": 81,
-                    "game-obj": "Conditions",
-                    "name": "immobilized",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "off-guard",
-                    "aonid": 58,
-                    "game-obj": "Conditions",
-                    "name": "off-guard",
-                    "type": "link"
-                  }
-                ],
-                "name": "Collapse",
-                "subtype": "ability",
-                "trigger": "The skeleton is critically hit",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fly Speed",
-                    "aonid": 2350,
-                    "game-obj": "Rules",
-                    "name": "fly Speed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Crumbling Bones",
-                "subtype": "ability",
-                "text": "The skeleton is made from crumbling bones that drift in clouds of dust. The skeleton has a fly Speed of 20, but it must end its turn within no more than 5 feet off the ground, or it falls, taking damage as normal. In addition, the skeleton can move through any space that\u2019s large enough for its skull to fit through.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "slashing",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "moderate spell DC for the skeleton's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "moderate spell DC for the skeleton's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Explosive Death",
-                "subtype": "ability",
-                "text": "When the skeleton is destroyed, its bones shatter and explode. Adjacent creatures take 1d6 slashing damage per 2 levels (minimum 1d6) with a basic Reflex save against the moderate spell DC for the skeleton's level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "cold",
-                    "aonid": 555,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fire",
-                    "aonid": 604,
-                    "game-obj": "Traits",
-                    "name": "fire",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Frozen",
-                "subtype": "ability",
-                "text": "The skeleton\u2019s bones are covered in a thin layer of ice. The skeleton gains immunity to cold and weakness 5 to fire, and loses resistance to fire. The skeleton is surrounded by an aura of cold that deals cold damage equal to half the skeleton\u2019s level to all adjacent creatures at the start of the skeleton\u2019s turn (basic Reflex save with a standard DC for its level).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The skeleton erupts from the ground, Stands, and makes a melee Strike. The target is off-guard against this Strike. If the Strike hits, the target is frightened 1 (or frightened 2 on a critical hit).",
-                "links": [
-                  {
-                    "alt": "off-guard",
-                    "aonid": 58,
-                    "game-obj": "Conditions",
-                    "name": "off-guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grave Eruption",
-                "requirement": "The skeleton is undetected and buried in dirt, gravel, or other loose material",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "acid",
-                    "aonid": 524,
-                    "game-obj": "Traits",
-                    "name": "acid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Lacquered",
-                "subtype": "ability",
-                "text": "During the process to create the skeleton, it was covered with several layers of an alchemical lacquer, giving its bones a golden hue and granting additional protection. The skeleton gains acid resistance 5 and a +2 status bonus to saves against effects that age or erode the target.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "climb Speed",
-                    "aonid": 2349,
-                    "game-obj": "Rules",
-                    "name": "climb Speed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Nimble Dodge",
-                    "aonid": 4916,
-                    "game-obj": "Feats",
-                    "name": "Nimble Dodge",
-                    "type": "link"
-                  }
-                ],
-                "name": "Nimble",
-                "subtype": "ability",
-                "text": "The skeleton is particularly fast and nimble. Its land Speed increases by 10 feet, and it has a climb Speed of 20 feet. In addition, it gains the Nimble Dodge reaction.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "aura",
-                    "aonid": 53,
-                    "game-obj": "MonsterAbilities",
-                    "name": "aura",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sickened",
-                    "aonid": 91,
-                    "game-obj": "Conditions",
-                    "name": "sickened",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "slowed",
-                    "aonid": 92,
-                    "game-obj": "Conditions",
-                    "name": "slowed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Rotten",
-                "subtype": "ability",
-                "text": "The bones of this skeleton are black and rotten, having spent years in polluted water or some other foul substance. The skeleton loses its resistance to piercing and slashing damage and is surrounded by a horrific stench in a 10-foot aura. A creature entering or starting its turn in the aura must succeed at a Fortitude save against the standard DC of the skeleton\u2019s level or become sickened 1 (plus slowed 1 for as long as it remains sickened on a critical failure). While within the aura, affected creatures take a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute. This stench remains for 1 hour after the rotten skeleton has been destroyed.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "olfactory",
-                      "aonid": 664,
-                      "game-obj": "Traits",
-                      "name": "olfactory",
-                      "type": "link"
-                    },
-                    "name": "olfactory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Demoralize",
-                    "aonid": 2395,
-                    "game-obj": "Actions",
-                    "name": "Demoralize",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "blind",
-                    "aonid": 59,
-                    "game-obj": "Conditions",
-                    "name": "blind",
-                    "type": "link"
-                  }
-                ],
-                "name": "Screaming Skull",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "range of 20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The skeleton removes its skull and throws it, making a jaws attack with a range of 20 feet. It then attempts to Demoralize each foe within 10 feet of the target. The head bounces, rolls, or even flies back, returning to the skeleton at the start of its next turn. The skeleton is blind until then.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 541,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Skeleton of Roses",
-                "subtype": "ability",
-                "text": "Thick briars have grown through the skeleton\u2019s bones, covering it in red roses with inch-long thorns. The skeleton\u2019s unarmed melee Strikes deal additional piercing damage equal to one-third the skeleton\u2019s level (minimum 1 damage). At the end of each of its turns, if the skeleton has caused piercing damage with its thorns, it regains HP equal to its level (minimum 1). Each time the skeleton regains HP in this way, another rose blossoms.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Skeleton Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Aquatic Ambush",
+                "aonid": 51,
+                "game-obj": "MonsterAbilities",
+                "name": "Aquatic Ambush",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 555,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "persistent fire damage",
+                "aonid": 86,
+                "game-obj": "Conditions",
+                "name": "persistent fire damage",
+                "type": "link"
+              },
+              {
+                "alt": "fast healing",
+                "aonid": 62,
+                "game-obj": "MonsterAbilities",
+                "name": "fast healing",
+                "type": "link"
+              },
+              {
+                "alt": "javelin",
+                "aonid": 429,
+                "game-obj": "Weapons",
+                "name": "javelin",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "persistent poison damage",
+                "aonid": 86,
+                "game-obj": "Conditions",
+                "name": "persistent poison damage",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "immobilized",
+                "aonid": 81,
+                "game-obj": "Conditions",
+                "name": "immobilized",
+                "type": "link"
+              },
+              {
+                "alt": "off-guard",
+                "aonid": 58,
+                "game-obj": "Conditions",
+                "name": "off-guard",
+                "type": "link"
+              },
+              {
+                "alt": "fly Speed",
+                "aonid": 2350,
+                "game-obj": "Rules",
+                "name": "fly Speed",
+                "type": "link"
+              },
+              {
+                "alt": "moderate spell DC for the skeleton's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "moderate spell DC for the skeleton's level",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 555,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 604,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "off-guard",
+                "aonid": 58,
+                "game-obj": "Conditions",
+                "name": "off-guard",
+                "type": "link"
+              },
+              {
+                "alt": "frightened",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened",
+                "type": "link"
+              },
+              {
+                "alt": "acid",
+                "aonid": 524,
+                "game-obj": "Traits",
+                "name": "acid",
+                "type": "link"
+              },
+              {
+                "alt": "climb Speed",
+                "aonid": 2349,
+                "game-obj": "Rules",
+                "name": "climb Speed",
+                "type": "link"
+              },
+              {
+                "alt": "Nimble Dodge",
+                "aonid": 4916,
+                "game-obj": "Feats",
+                "name": "Nimble Dodge",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "olfactory",
+                "aonid": 664,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 53,
+                "game-obj": "MonsterAbilities",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "sickened",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened",
+                "type": "link"
+              },
+              {
+                "alt": "slowed",
+                "aonid": 92,
+                "game-obj": "Conditions",
+                "name": "slowed",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "Demoralize",
+                "aonid": 2395,
+                "game-obj": "Actions",
+                "name": "Demoralize",
+                "type": "link"
+              },
+              {
+                "alt": "blind",
+                "aonid": 59,
+                "game-obj": "Conditions",
+                "name": "blind",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -555,7 +293,6 @@
         ],
         "name": "Skeleton Abilities",
         "subtype": "monster_family",
-        "text": "Most skeletons have one of these abilities. If you give a skeleton more, you might want to increase its level and adjust its statistics.",
         "type": "stat_block_section"
       }
     ],
@@ -563,6 +300,889 @@
   },
   "name": "Skeleton",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Aquatic Ambush",
+              "aonid": 51,
+              "game-obj": "MonsterAbilities",
+              "name": "Aquatic Ambush",
+              "type": "link"
+            }
+          ],
+          "name": "Aquatic Bones",
+          "subtype": "ability",
+          "text": "The skeleton has bones from aquatic creatures, allowing it to swim using a simple tail, paddles, or similar appendage. The skeleton has a swim Speed of 20 feet and gains the aquatic trait and the Aquatic Ambush ability.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "cold",
+              "aonid": 555,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "persistent fire damage",
+              "aonid": 86,
+              "game-obj": "Conditions",
+              "name": "persistent fire damage",
+              "type": "link"
+            }
+          ],
+          "name": "Blaze",
+          "subtype": "ability",
+          "text": "The skeleton is wreathed with fire, which doesn't consume its bones or gear. The skeleton gains immunity to fire and weakness 5 to cold, loses its resistance to cold, and its Strikes deal additional persistent fire damage equal to half the skeleton's level (minimum 1 damage).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "fast healing",
+              "aonid": 62,
+              "game-obj": "MonsterAbilities",
+              "name": "fast healing",
+              "type": "link"
+            }
+          ],
+          "name": "Bloody",
+          "subtype": "ability",
+          "text": "A coating of blood gives the skeleton fast healing equal to its level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "javelin",
+              "aonid": 429,
+              "game-obj": "Weapons",
+              "name": "javelin",
+              "type": "link"
+            }
+          ],
+          "name": "Bone Missile",
+          "subtype": "ability",
+          "text": "The skeleton yanks a rib from its ribcage to use as an arrow or javelin. The skeleton loses HP equal to its level (minimum 1), then makes a ranged Strike. This uses the attack bonus of whichever of the skeleton\u2019s other Strikes has the highest attack bonus and deals piercing damage equal to that Strike\u2019s damage plus the skeleton\u2019s level (minimum 1).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 5,
+              "subtype": "area",
+              "text": "5-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "poison",
+              "formula": "1d6",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "persistent poison damage",
+              "aonid": 86,
+              "game-obj": "Conditions",
+              "name": "persistent poison damage",
+              "type": "link"
+            }
+          ],
+          "name": "Bone Powder",
+          "subtype": "ability",
+          "text": "When the skeleton takes physical damage from a critical hit, one of its bones is pulverized into a fine powder. All creatures in a 5-foot emanation that breathe take 1d6 persistent poison damage (plus an additional 1d6 for every 6 levels the skeleton has).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "slashing",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "effect": "The skeleton transforms into a cyclone of bones, taking up the same space, but twice as tall. It then Strides up to double its Speed. It can move through spaces occupied by other creatures, and this movement doesn\u2019t trigger reactions. Creatures the Bone Storm moves through take 1d6 slashing damage for every 2 levels the skeleton has, with a basic Reflex save against the hard DC for the skeleton\u2019s level. A level 1 or lower skeleton only moves; it doesn\u2019t deal damage. A creature attempts this save only once even if the Bone Storm moved through its space multiple times. At the end of the movement, the skeleton reforms.",
+          "frequency": "once per day",
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Bone Storm",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The skeleton collapses into a pile of bones and the attack deals only normal damage. The skeleton can re-form in a standing position as an action, but until it does, it is immobilized and off-guard.",
+          "links": [
+            {
+              "alt": "immobilized",
+              "aonid": 81,
+              "game-obj": "Conditions",
+              "name": "immobilized",
+              "type": "link"
+            },
+            {
+              "alt": "off-guard",
+              "aonid": 58,
+              "game-obj": "Conditions",
+              "name": "off-guard",
+              "type": "link"
+            }
+          ],
+          "name": "Collapse",
+          "subtype": "ability",
+          "trigger": "The skeleton is critically hit",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "fly Speed",
+              "aonid": 2350,
+              "game-obj": "Rules",
+              "name": "fly Speed",
+              "type": "link"
+            }
+          ],
+          "name": "Crumbling Bones",
+          "subtype": "ability",
+          "text": "The skeleton is made from crumbling bones that drift in clouds of dust. The skeleton has a fly Speed of 20, but it must end its turn within no more than 5 feet off the ground, or it falls, taking damage as normal. In addition, the skeleton can move through any space that\u2019s large enough for its skull to fit through.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "slashing",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "moderate spell DC for the skeleton's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "moderate spell DC for the skeleton's level",
+              "type": "link"
+            }
+          ],
+          "name": "Explosive Death",
+          "subtype": "ability",
+          "text": "When the skeleton is destroyed, its bones shatter and explode. Adjacent creatures take 1d6 slashing damage per 2 levels (minimum 1d6) with a basic Reflex save against the moderate spell DC for the skeleton's level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "cold",
+              "aonid": 555,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "fire",
+              "aonid": 604,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Frozen",
+          "subtype": "ability",
+          "text": "The skeleton\u2019s bones are covered in a thin layer of ice. The skeleton gains immunity to cold and weakness 5 to fire, and loses resistance to fire. The skeleton is surrounded by an aura of cold that deals cold damage equal to half the skeleton\u2019s level to all adjacent creatures at the start of the skeleton\u2019s turn (basic Reflex save with a standard DC for its level).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The skeleton erupts from the ground, Stands, and makes a melee Strike. The target is off-guard against this Strike. If the Strike hits, the target is frightened 1 (or frightened 2 on a critical hit).",
+          "links": [
+            {
+              "alt": "off-guard",
+              "aonid": 58,
+              "game-obj": "Conditions",
+              "name": "off-guard",
+              "type": "link"
+            },
+            {
+              "alt": "frightened",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened",
+              "type": "link"
+            }
+          ],
+          "name": "Grave Eruption",
+          "requirement": "The skeleton is undetected and buried in dirt, gravel, or other loose material",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "acid",
+              "aonid": 524,
+              "game-obj": "Traits",
+              "name": "acid",
+              "type": "link"
+            }
+          ],
+          "name": "Lacquered",
+          "subtype": "ability",
+          "text": "During the process to create the skeleton, it was covered with several layers of an alchemical lacquer, giving its bones a golden hue and granting additional protection. The skeleton gains acid resistance 5 and a +2 status bonus to saves against effects that age or erode the target.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "climb Speed",
+              "aonid": 2349,
+              "game-obj": "Rules",
+              "name": "climb Speed",
+              "type": "link"
+            },
+            {
+              "alt": "Nimble Dodge",
+              "aonid": 4916,
+              "game-obj": "Feats",
+              "name": "Nimble Dodge",
+              "type": "link"
+            }
+          ],
+          "name": "Nimble",
+          "subtype": "ability",
+          "text": "The skeleton is particularly fast and nimble. Its land Speed increases by 10 feet, and it has a climb Speed of 20 feet. In addition, it gains the Nimble Dodge reaction.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "aura",
+              "aonid": 53,
+              "game-obj": "MonsterAbilities",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "sickened",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened",
+              "type": "link"
+            },
+            {
+              "alt": "slowed",
+              "aonid": 92,
+              "game-obj": "Conditions",
+              "name": "slowed",
+              "type": "link"
+            }
+          ],
+          "name": "Rotten",
+          "subtype": "ability",
+          "text": "The bones of this skeleton are black and rotten, having spent years in polluted water or some other foul substance. The skeleton loses its resistance to piercing and slashing damage and is surrounded by a horrific stench in a 10-foot aura. A creature entering or starting its turn in the aura must succeed at a Fortitude save against the standard DC of the skeleton\u2019s level or become sickened 1 (plus slowed 1 for as long as it remains sickened on a critical failure). While within the aura, affected creatures take a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute. This stench remains for 1 hour after the rotten skeleton has been destroyed.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "olfactory",
+                "aonid": 664,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              "name": "olfactory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "Demoralize",
+              "aonid": 2395,
+              "game-obj": "Actions",
+              "name": "Demoralize",
+              "type": "link"
+            },
+            {
+              "alt": "blind",
+              "aonid": 59,
+              "game-obj": "Conditions",
+              "name": "blind",
+              "type": "link"
+            }
+          ],
+          "name": "Screaming Skull",
+          "range": {
+            "range": 20,
+            "subtype": "range",
+            "text": "range of 20 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The skeleton removes its skull and throws it, making a jaws attack with a range of 20 feet. It then attempts to Demoralize each foe within 10 feet of the target. The head bounces, rolls, or even flies back, returning to the skeleton at the start of its next turn. The skeleton is blind until then.",
+          "traits": [
+            {
+              "link": {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              "name": "auditory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Skeleton of Roses",
+          "subtype": "ability",
+          "text": "Thick briars have grown through the skeleton\u2019s bones, covering it in red roses with inch-long thorns. The skeleton\u2019s unarmed melee Strikes deal additional piercing damage equal to one-third the skeleton\u2019s level (minimum 1 damage). At the end of each of its turns, if the skeleton has caused piercing damage with its thorns, it regains HP equal to its level (minimum 1). Each time the skeleton regains HP in this way, another rose blossoms.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Aquatic Ambush",
+          "aonid": 51,
+          "game-obj": "MonsterAbilities",
+          "name": "Aquatic Ambush",
+          "type": "link"
+        },
+        {
+          "alt": "cold",
+          "aonid": 555,
+          "game-obj": "Traits",
+          "name": "cold",
+          "type": "link"
+        },
+        {
+          "alt": "persistent fire damage",
+          "aonid": 86,
+          "game-obj": "Conditions",
+          "name": "persistent fire damage",
+          "type": "link"
+        },
+        {
+          "alt": "fast healing",
+          "aonid": 62,
+          "game-obj": "MonsterAbilities",
+          "name": "fast healing",
+          "type": "link"
+        },
+        {
+          "alt": "javelin",
+          "aonid": 429,
+          "game-obj": "Weapons",
+          "name": "javelin",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "persistent poison damage",
+          "aonid": 86,
+          "game-obj": "Conditions",
+          "name": "persistent poison damage",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 2297,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "immobilized",
+          "aonid": 81,
+          "game-obj": "Conditions",
+          "name": "immobilized",
+          "type": "link"
+        },
+        {
+          "alt": "off-guard",
+          "aonid": 58,
+          "game-obj": "Conditions",
+          "name": "off-guard",
+          "type": "link"
+        },
+        {
+          "alt": "fly Speed",
+          "aonid": 2350,
+          "game-obj": "Rules",
+          "name": "fly Speed",
+          "type": "link"
+        },
+        {
+          "alt": "moderate spell DC for the skeleton's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "moderate spell DC for the skeleton's level",
+          "type": "link"
+        },
+        {
+          "alt": "cold",
+          "aonid": 555,
+          "game-obj": "Traits",
+          "name": "cold",
+          "type": "link"
+        },
+        {
+          "alt": "fire",
+          "aonid": 604,
+          "game-obj": "Traits",
+          "name": "fire",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 2297,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "off-guard",
+          "aonid": 58,
+          "game-obj": "Conditions",
+          "name": "off-guard",
+          "type": "link"
+        },
+        {
+          "alt": "frightened",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened",
+          "type": "link"
+        },
+        {
+          "alt": "acid",
+          "aonid": 524,
+          "game-obj": "Traits",
+          "name": "acid",
+          "type": "link"
+        },
+        {
+          "alt": "climb Speed",
+          "aonid": 2349,
+          "game-obj": "Rules",
+          "name": "climb Speed",
+          "type": "link"
+        },
+        {
+          "alt": "Nimble Dodge",
+          "aonid": 4916,
+          "game-obj": "Feats",
+          "name": "Nimble Dodge",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "olfactory",
+          "aonid": 664,
+          "game-obj": "Traits",
+          "name": "olfactory",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 53,
+          "game-obj": "MonsterAbilities",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "sickened",
+          "aonid": 91,
+          "game-obj": "Conditions",
+          "name": "sickened",
+          "type": "link"
+        },
+        {
+          "alt": "slowed",
+          "aonid": 92,
+          "game-obj": "Conditions",
+          "name": "slowed",
+          "type": "link"
+        },
+        {
+          "alt": "auditory",
+          "aonid": 541,
+          "game-obj": "Traits",
+          "name": "auditory",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "Demoralize",
+          "aonid": 2395,
+          "game-obj": "Actions",
+          "name": "Demoralize",
+          "type": "link"
+        },
+        {
+          "alt": "blind",
+          "aonid": 59,
+          "game-obj": "Conditions",
+          "name": "blind",
+          "type": "link"
+        }
+      ],
+      "name": "Skeleton Abilities",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "skeletal hulk",
+              "aonid": 376,
+              "game-obj": "Monsters",
+              "name": "skeletal hulk",
+              "type": "link"
+            },
+            {
+              "alt": "elite",
+              "aonid": 790,
+              "game-obj": "Rules",
+              "name": "elite",
+              "type": "link"
+            },
+            {
+              "alt": "chimera",
+              "aonid": 2879,
+              "game-obj": "Monsters",
+              "name": "chimera",
+              "type": "link"
+            }
+          ],
+          "name": "Creating Skeletons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 312",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 312",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 312,
+              "type": "source"
+            }
+          ],
+          "text": "Start with a skeleton of the appropriate size. (Gargantuan skeletons can use skeletal hulk with the elite adjustments, Gargantuan size, and 5 feet more reach.) Add Strikes, Speeds, or other abilities it would gain from its shape. For instance, a chimera skeleton might have a horn attack with its goat head and jaw attacks with its dragon and lion heads, but not a fist attack.",
+          "type": "section"
+        },
+        {
+          "name": "Patchwork Skeletons",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 312",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 312",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 312,
+              "type": "source"
+            }
+          ],
+          "text": "A skeleton\u2019s connection to its mortal remains is tenuous. One that\u2019s damaged can fairly easily replace a broken bone with a similar bone scavenged from another creature. A skeleton can eventually have its entire body replaced, bone by bone. Skeletons don\u2019t have much of an identity, making it unclear whether this is still considered the same creature.",
+          "type": "section"
+        },
+        {
+          "name": "Radiant Rebirth",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 312",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 312",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 312,
+              "type": "source"
+            }
+          ],
+          "text": "When the powerful lich called the Whispering Tyrant returned from imprisonment, he unleashed the Radiant Fire that laid waste to several towns and cities around his prison of Gallowspire. Most of the fallen were left where they died, slowly steeping in necromantic energy. In the early days after these attacks, zombies commonly roamed the area, but as the years pass, skeletons have become more and more numerous.",
+          "type": "section"
+        },
+        {
+          "name": "Skeleton Origins",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 312",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 312",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 312,
+              "type": "source"
+            }
+          ],
+          "text": "Necromancers occasionally add a little something extra to skeletons they animate, but sometimes skeletons can pick up aspects of their environment. Skeletons that spend centuries in an underground cavern with a lava lake often end up blazing. Corpses whose graves become overrun with briars and brambles sometimes rise with life-draining thorns, while skeletons in vermin-infested earth often take some of those vermin with them when animated.",
+          "type": "section"
+        },
+        {
+          "name": "Unlife Without Flesh",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 312",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 312",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 312,
+              "type": "source"
+            }
+          ],
+          "text": "The necromantic energies that infuse animated undead skeletons give them the ability to see without eyes and move without muscles. Despite being mindless, skeletons' instinct to do evil comes from their corrupt vital essence, perverting void energy for creation rather than destruction.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 312",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 312",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 312,
+          "type": "source"
+        }
+      ],
+      "text": "Most skeletons have one of these abilities. If you give a skeleton more, you might want to increase its level and adjust its statistics.  \n  \n**Aquatic Bones** The skeleton has bones from aquatic creatures, allowing it to swim using a simple tail, paddles, or similar appendage. The skeleton has a swim Speed of 20 feet and gains the aquatic trait and the Aquatic Ambush ability.  \n**Blaze** The skeleton is wreathed with fire, which doesn't consume its bones or gear. The skeleton gains immunity to fire and weakness 5 to cold, loses its resistance to cold, and its Strikes deal additional persistent fire damage equal to half the skeleton's level (minimum 1 damage).  \n**Bloody** A coating of blood gives the skeleton fast healing equal to its level.  \n**Bone Missile** [##] The skeleton yanks a rib from its ribcage to use as an arrow or javelin. The skeleton loses HP equal to its level (minimum 1), then makes a ranged Strike. This uses the attack bonus of whichever of the skeleton\u2019s other Strikes has the highest attack bonus and deals piercing damage equal to that Strike\u2019s damage plus the skeleton\u2019s level (minimum 1).  \n**Bone Powder** When the skeleton takes physical damage from a critical hit, one of its bones is pulverized into a fine powder. All creatures in a 5-foot emanation that breathe take 1d6 persistent poison damage (plus an additional 1d6 for every 6 levels the skeleton has).  \n**Bone Storm** [###] **Frequency** once per day; **Effect** The skeleton transforms into a cyclone of bones, taking up the same space, but twice as tall. It then Strides up to double its Speed. It can move through spaces occupied by other creatures, and this movement doesn\u2019t trigger reactions. Creatures the Bone Storm moves through take 1d6 slashing damage for every 2 levels the skeleton has, with a basic Reflex save against the hard DC for the skeleton\u2019s level. A level 1 or lower skeleton only moves; it doesn\u2019t deal damage. A creature attempts this save only once even if the Bone Storm moved through its space multiple times. At the end of the movement, the skeleton reforms.  \n**Collapse** [@] **Trigger** The skeleton is critically hit; **Effect** The skeleton collapses into a pile of bones and the attack deals only normal damage. The skeleton can re-form in a standing position as an action, but until it does, it is immobilized and off-guard.  \n**Crumbling Bones** The skeleton is made from crumbling bones that drift in clouds of dust. The skeleton has a fly Speed of 20, but it must end its turn within no more than 5 feet off the ground, or it falls, taking damage as normal. In addition, the skeleton can move through any space that\u2019s large enough for its skull to fit through.  \n**Explosive Death** When the skeleton is destroyed, its bones shatter and explode. Adjacent creatures take 1d6 slashing damage per 2 levels (minimum 1d6) with a basic Reflex save against the moderate spell DC for the skeleton's level.  \n**Frozen** The skeleton\u2019s bones are covered in a thin layer of ice. The skeleton gains immunity to cold and weakness 5 to fire, and loses resistance to fire. The skeleton is surrounded by an aura of cold that deals cold damage equal to half the skeleton\u2019s level to all adjacent creatures at the start of the skeleton\u2019s turn (basic Reflex save with a standard DC for its level).  \n**Grave Eruption** [##] **Requirements** The skeleton is undetected and buried in dirt, gravel, or other loose material; **Effect** The skeleton erupts from the ground, Stands, and makes a melee Strike. The target is off-guard against this Strike. If the Strike hits, the target is frightened 1 (or frightened 2 on a critical hit).  \n**Lacquered** During the process to create the skeleton, it was covered with several layers of an alchemical lacquer, giving its bones a golden hue and granting additional protection. The skeleton gains acid resistance 5 and a +2 status bonus to saves against effects that age or erode the target.  \n**Nimble** The skeleton is particularly fast and nimble. Its land Speed increases by 10 feet, and it has a climb Speed of 20 feet. In addition, it gains the Nimble Dodge reaction.  \n**Rotten** (aura, olfactory); The bones of this skeleton are black and rotten, having spent years in polluted water or some other foul substance. The skeleton loses its resistance to piercing and slashing damage and is surrounded by a horrific stench in a 10-foot aura. A creature entering or starting its turn in the aura must succeed at a Fortitude save against the standard DC of the skeleton\u2019s level or become sickened 1 (plus slowed 1 for as long as it remains sickened on a critical failure). While within the aura, affected creatures take a \u20132 circumstance penalty to saves against disease and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute. This stench remains for 1 hour after the rotten skeleton has been destroyed.  \n**Screaming Skull** [##] (auditory, emotion, fear, mental) The skeleton removes its skull and throws it, making a jaws attack with a range of 20 feet. It then attempts to Demoralize each foe within 10 feet of the target. The head bounces, rolls, or even flies back, returning to the skeleton at the start of its next turn. The skeleton is blind until then.  \n**Skeleton of Roses** Thick briars have grown through the skeleton\u2019s bones, covering it in red roses with inch-long thorns. The skeleton\u2019s unarmed melee Strikes deal additional piercing damage equal to one-third the skeleton\u2019s level (minimum 1 damage). At the end of each of its turns, if the skeleton has caused piercing damage with its thorns, it regains HP equal to its level (minimum 1). Each time the skeleton regains HP in this way, another rose blossoms.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "errata": {

--- a/monster_families/monster_core/vampire.json
+++ b/monster_families/monster_core/vampire.json
@@ -398,433 +398,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 59,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 83,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 696,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Coffin Restoration",
-                "subtype": "ability",
-                "text": "Unlike other undead, a vampire isn't destroyed at 0 HP. Instead, they fall unconscious. If their body rests in their coffin for 1 hour, the vampire gains 1 HP, after which their fast healing begins to function normally.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    },
-                    "name": "void",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Vampire Vulnerabilities",
-                "subtype": "ability",
-                "text": "All vampires possess the following vulnerabilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Climb Speed",
-                "subtype": "ability",
-                "text": "Vampires gain a climb Speed equal to their land Speed.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unarmed",
-                    "aonid": 719,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "agile",
-                    "aonid": 526,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the creature had hands, their fingernails thicken and grow, granting them an unarmed claw Strike that deals slashing damage and has the agile trait. If the monster had any agile attacks, the damage dealt by their claws should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their claws should deal three-quarters that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The vampire sinks their fangs into that creature to drink their blood. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the vampire regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary HP. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire but increases the victim's drained value by 1, killing the victim when it reaches drained 5. A vampire can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.",
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 77,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 90,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 36,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Blood",
-                "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vampire's reach",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 45,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grab",
-                "subtype": "ability",
-                "text": "The creature's claw attacks (or equivalent unarmed attacks) gain Grab.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 45,
-                  "edition": "remastered",
-                  "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
-                  "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "grabbed",
-                      "aonid": 20,
-                      "game-obj": "Conditions",
-                      "name": "grabbed",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "restrained",
-                      "aonid": 33,
-                      "game-obj": "Conditions",
-                      "name": "restrained",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Grapple",
-                      "aonid": 35,
-                      "game-obj": "Actions",
-                      "name": "Grapple",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Grab",
-                  "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Rage of Elements pg. 232",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "Rage of Elements pg. 232",
-                        "type": "link"
-                      },
-                      "name": "Rage of Elements",
-                      "page": 232,
-                      "type": "source"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Basic Vampire Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -842,6 +420,146 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 59,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 83,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 696,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 719,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 526,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 77,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 90,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 36,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 45,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -851,577 +569,201 @@
         ],
         "name": "Basic Vampire Abilities",
         "subtype": "monster_family",
-        "text": "All vampires gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vampire's theme, such as powers that rely on sunlight or which assume the presence of vitality.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "The vampire resists all physical damage except magical silver.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Create Servitor",
-                "subtype": "ability",
-                "text": "If a creature dies after being reduced to 0 HP by Drink Blood, the vampire can turn this victim into a vampire servitor by donating some of their own blood to the victim and burying the victim in earth for 3 nights. A vampiric servitor is compelled to obey its creator, but if a vampire controls too many vampiric servitors at once (as determined by the GM), or if the servitor is a higher level than the vampire that created it, strong-willed servitors can free themselves by succeeding at a Will saving throw against the vampire's Will DC.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "downtime",
-                      "aonid": 580,
-                      "game-obj": "Traits",
-                      "name": "downtime",
-                      "type": "link"
-                    },
-                    "name": "downtime",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The vampire uses Turn to Mist. They can take move actions to move toward their coffin even though they're at 0 HP. While at 0 HP in this form, the vampire is unaffected by further damage. They automatically return to their corporeal form, unconscious, if they reach their coffin or after 2 hours, whichever comes first.",
-                "links": [
-                  {
-                    "alt": "move",
-                    "aonid": 658,
-                    "game-obj": "Traits",
-                    "name": "move",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mist Escape",
-                "subtype": "ability",
-                "trigger": "The vampire is reduced to 0 HP",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "aerial form",
-                    "aonid": 1437,
-                    "game-obj": "Spells",
-                    "name": "aerial form",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "animal form",
-                    "aonid": 1440,
-                    "game-obj": "Spells",
-                    "name": "animal form",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The vampire transforms into one of their animal forms or back into their normal form. Most vampires can turn into a bat, but some can turn into a different creature, such as a rat or a wolf. Use the options in the *aerial form* and *animal form* spells as guidelines.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Children of the Night",
-                "range": {
-                  "range": 100,
-                  "subtype": "range",
-                  "text": "within 100 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The vampire's presence brings forth creatures of the night to do the master's bidding. These typically include rat swarms, bat swarms, and wolves but can include other creatures. The vampire can give telepathic orders to these creatures as long as they're within 100 feet, but they can't communicate back.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 1501,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "visual",
-                    "aonid": 727,
-                    "game-obj": "Traits",
-                    "name": "visual",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high spell DC of the vampire's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high spell DC of the vampire's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dominate",
-                "subtype": "ability",
-                "text": "The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the high spell DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 631,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drained 2",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Blood",
-                "subtype": "ability",
-                "text": "As a typical vampire, but the victim is drained 2 instead of 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "vapor form",
-                    "aonid": 1738,
-                    "game-obj": "Spells",
-                    "name": "vapor form",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fast healing",
-                    "aonid": 62,
-                    "game-obj": "MonsterAbilities",
-                    "name": "fast healing",
-                    "type": "link"
-                  }
-                ],
-                "name": "Turn to Mist",
-                "subtype": "ability",
-                "text": "The vampire turns into a cloud of vapor, as the *vapor form* spell, or back to their normal form. The vampire loses fast healing while turned to mist. The vampire can remain in this form indefinitely.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "air",
-                      "aonid": 527,
-                      "game-obj": "Traits",
-                      "name": "air",
-                      "type": "link"
-                    },
-                    "name": "air",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='True Vampire Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "downtime",
+                "aonid": 580,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              {
+                "alt": "move",
+                "aonid": 658,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "aerial form",
+                "aonid": 1437,
+                "game-obj": "Spells",
+                "name": "aerial form",
+                "type": "link"
+              },
+              {
+                "alt": "animal form",
+                "aonid": 1440,
+                "game-obj": "Spells",
+                "name": "animal form",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "high spell DC of the vampire's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high spell DC of the vampire's level",
+                "type": "link"
+              },
+              {
+                "alt": "drained 2",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 2",
+                "type": "link"
+              },
+              {
+                "alt": "air",
+                "aonid": 527,
+                "game-obj": "Traits",
+                "name": "air",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "vapor form",
+                "aonid": 1738,
+                "game-obj": "Spells",
+                "name": "vapor form",
+                "type": "link"
+              },
+              {
+                "alt": "fast healing",
+                "aonid": 62,
+                "game-obj": "MonsterAbilities",
+                "name": "fast healing",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1431,7 +773,6 @@
         ],
         "name": "True Vampire Abilities",
         "subtype": "monster_family",
-        "text": "Powerful vampires that can create and control vampires from their victims gain additional vampire abilities, as detailed below. A creature below level 5 is not a significant enough creature to become a true vampire\u2014you should instead simply make such a creature into a regular vampire servitor or rebuild the creature so that it's at least level 5 before becoming a true vampire.",
         "type": "stat_block_section"
       }
     ],
@@ -1464,6 +805,1510 @@
         }
       ],
       "text": "You can turn an existing living creature into a vampire using the following steps.  \n  \n Increase the creature's level by 1 and change its statistics as follows. \n\n|  |  |  |\n| --- | --- | --- |\n| Starting Level | HP Decrease | Fast Healing/Resistance |\n| 3\u20134 | \u201320 | 5 |\n| 5\u20137 | \u201330 | 7 |\n| 8\u201314 | \u201340 | 10 |\n| 15+ | \u201360 | 15 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Darkvision",
+            "aonid": 59,
+            "game-obj": "MonsterAbilities",
+            "name": "Darkvision",
+            "type": "link"
+          },
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 83,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 696,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "death effects, disease, paralyzed, poison, sleep",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Coffin Restoration",
+          "subtype": "ability",
+          "text": "Unlike other undead, a vampire isn't destroyed at 0 HP. Instead, they fall unconscious. If their body rests in their coffin for 1 hour, the vampire gains 1 HP, after which their fast healing begins to function normally.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              "name": "void",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Vampire Vulnerabilities",
+          "subtype": "ability",
+          "text": "All vampires possess the following vulnerabilities.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Climb Speed",
+          "subtype": "ability",
+          "text": "Vampires gain a climb Speed equal to their land Speed.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "unarmed",
+              "aonid": 719,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            },
+            {
+              "alt": "agile",
+              "aonid": 526,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            }
+          ],
+          "name": "Claws",
+          "subtype": "ability",
+          "text": "If the creature had hands, their fingernails thicken and grow, granting them an unarmed claw Strike that deals slashing damage and has the agile trait. If the monster had any agile attacks, the damage dealt by their claws should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their claws should deal three-quarters that damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The vampire sinks their fangs into that creature to drink their blood. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the vampire regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary HP. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire but increases the victim's drained value by 1, killing the victim when it reaches drained 5. A vampire can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.",
+          "links": [
+            {
+              "alt": "grabbed",
+              "aonid": 77,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 90,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 36,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Drink Blood",
+          "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vampire's reach",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Grab",
+              "aonid": 45,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Grab",
+          "subtype": "ability",
+          "text": "The creature's claw attacks (or equivalent unarmed attacks) gain Grab.",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 45,
+            "edition": "remastered",
+            "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
+            "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "Grapple",
+                "aonid": 35,
+                "game-obj": "Actions",
+                "name": "Grapple",
+                "type": "link"
+              }
+            ],
+            "name": "Grab",
+            "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "2.0",
+                  "aonid": 205,
+                  "game-obj": "Sources",
+                  "name": "2.0",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Rage of Elements pg. 232",
+                  "aonid": 205,
+                  "game-obj": "Sources",
+                  "name": "Rage of Elements pg. 232",
+                  "type": "link"
+                },
+                "name": "Rage of Elements",
+                "page": 232,
+                "type": "source"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "human",
+          "aonid": 627,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Darkvision",
+          "aonid": 59,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 696,
+          "game-obj": "Traits",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "unarmed",
+          "aonid": 719,
+          "game-obj": "Traits",
+          "name": "unarmed",
+          "type": "link"
+        },
+        {
+          "alt": "agile",
+          "aonid": 526,
+          "game-obj": "Traits",
+          "name": "agile",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "grabbed",
+          "aonid": 77,
+          "game-obj": "Conditions",
+          "name": "grabbed",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 90,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 36,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 45,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        }
+      ],
+      "name": "Basic Vampire Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 334",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 334",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 334,
+          "type": "source"
+        }
+      ],
+      "text": "All vampires gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the vampire's theme, such as powers that rely on sunlight or which assume the presence of vitality.  \n  \n**Darkvision**  \n**Void Healing**  \n**Immunities** death effects, disease, paralyzed, poison, sleep  \n**Coffin Restoration** (divine, void) Unlike other undead, a vampire isn't destroyed at 0 HP. Instead, they fall unconscious. If their body rests in their coffin for 1 hour, the vampire gains 1 HP, after which their fast healing begins to function normally.  \n**Vampire Vulnerabilities** All vampires possess the following vulnerabilities. **Climb Speed** Vampires gain a climb Speed equal to their land Speed.  \n**Claws** If the creature had hands, their fingernails thicken and grow, granting them an unarmed claw Strike that deals slashing damage and has the agile trait. If the monster had any agile attacks, the damage dealt by their claws should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their claws should deal three-quarters that damage.  \n**Drink Blood** [#] (divine) **Requirements** A grabbed, paralyzed, restrained, unconscious, or willing creature is within the vampire's reach; **Effect** The vampire sinks their fangs into that creature to drink their blood. This requires an Athletics check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and the vampire regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary HP. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire but increases the victim's drained value by 1, killing the victim when it reaches drained 5. A vampire can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.  \n A victim's drained condition decreases by 1 per week. A blood transfusion, which requires a DC 20 Medicine check and sufficient blood or a blood donor, reduces the drain by 1 after 10 minutes.  \n**Grab** The creature's claw attacks (or equivalent unarmed attacks) gain Grab.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Resistances",
+          "subtype": "ability",
+          "text": "The vampire resists all physical damage except magical silver.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Create Servitor",
+          "subtype": "ability",
+          "text": "If a creature dies after being reduced to 0 HP by Drink Blood, the vampire can turn this victim into a vampire servitor by donating some of their own blood to the victim and burying the victim in earth for 3 nights. A vampiric servitor is compelled to obey its creator, but if a vampire controls too many vampiric servitors at once (as determined by the GM), or if the servitor is a higher level than the vampire that created it, strong-willed servitors can free themselves by succeeding at a Will saving throw against the vampire's Will DC.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "downtime",
+                "aonid": 580,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              "name": "downtime",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The vampire uses Turn to Mist. They can take move actions to move toward their coffin even though they're at 0 HP. While at 0 HP in this form, the vampire is unaffected by further damage. They automatically return to their corporeal form, unconscious, if they reach their coffin or after 2 hours, whichever comes first.",
+          "links": [
+            {
+              "alt": "move",
+              "aonid": 658,
+              "game-obj": "Traits",
+              "name": "move",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Mist Escape",
+          "subtype": "ability",
+          "trigger": "The vampire is reduced to 0 HP",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 55,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "links": [
+            {
+              "alt": "aerial form",
+              "aonid": 1437,
+              "game-obj": "Spells",
+              "name": "aerial form",
+              "type": "link"
+            },
+            {
+              "alt": "animal form",
+              "aonid": 1440,
+              "game-obj": "Spells",
+              "name": "animal form",
+              "type": "link"
+            }
+          ],
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The vampire transforms into one of their animal forms or back into their normal form. Most vampires can turn into a bat, but some can turn into a different creature, such as a rat or a wolf. Use the options in the *aerial form* and *animal form* spells as guidelines.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 55,
+            "edition": "remastered",
+            "game-id": "cfccadd6ae22a706a897a80c7d209862",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 2388,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 38,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 358",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 358",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 358,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "classes": [
+                  "template"
+                ],
+                "edition": "legacy",
+                "game-id": "070ae8282a8ee960fa04002421f6d345",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  }
+                ],
+                "name": "[Magical Tradition]",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 628",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 628",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 628,
+                    "type": "source"
+                  }
+                ],
+                "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Children of the Night",
+          "range": {
+            "range": 100,
+            "subtype": "range",
+            "text": "within 100 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The vampire's presence brings forth creatures of the night to do the master's bidding. These typically include rat swarms, bat swarms, and wolves but can include other creatures. The vampire can give telepathic orders to these creatures as long as they're within 100 feet, but they can't communicate back.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "dominate",
+              "aonid": 1501,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 727,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "high spell DC of the vampire's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high spell DC of the vampire's level",
+              "type": "link"
+            }
+          ],
+          "name": "Dominate",
+          "subtype": "ability",
+          "text": "The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the high spell DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              "name": "incapacitation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "drained 2",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 2",
+              "type": "link"
+            }
+          ],
+          "name": "Drink Blood",
+          "subtype": "ability",
+          "text": "As a typical vampire, but the victim is drained 2 instead of 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "vapor form",
+              "aonid": 1738,
+              "game-obj": "Spells",
+              "name": "vapor form",
+              "type": "link"
+            },
+            {
+              "alt": "fast healing",
+              "aonid": 62,
+              "game-obj": "MonsterAbilities",
+              "name": "fast healing",
+              "type": "link"
+            }
+          ],
+          "name": "Turn to Mist",
+          "subtype": "ability",
+          "text": "The vampire turns into a cloud of vapor, as the *vapor form* spell, or back to their normal form. The vampire loses fast healing while turned to mist. The vampire can remain in this form indefinitely.",
+          "traits": [
+            {
+              "link": {
+                "alt": "air",
+                "aonid": 527,
+                "game-obj": "Traits",
+                "name": "air",
+                "type": "link"
+              },
+              "name": "air",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "downtime",
+          "aonid": 580,
+          "game-obj": "Traits",
+          "name": "downtime",
+          "type": "link"
+        },
+        {
+          "alt": "move",
+          "aonid": 658,
+          "game-obj": "Traits",
+          "name": "move",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "Change Shape",
+          "aonid": 55,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "aerial form",
+          "aonid": 1437,
+          "game-obj": "Spells",
+          "name": "aerial form",
+          "type": "link"
+        },
+        {
+          "alt": "animal form",
+          "aonid": 1440,
+          "game-obj": "Spells",
+          "name": "animal form",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "incapacitation",
+          "aonid": 631,
+          "game-obj": "Traits",
+          "name": "incapacitation",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "high spell DC of the vampire's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high spell DC of the vampire's level",
+          "type": "link"
+        },
+        {
+          "alt": "drained 2",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 2",
+          "type": "link"
+        },
+        {
+          "alt": "air",
+          "aonid": 527,
+          "game-obj": "Traits",
+          "name": "air",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "vapor form",
+          "aonid": 1738,
+          "game-obj": "Spells",
+          "name": "vapor form",
+          "type": "link"
+        },
+        {
+          "alt": "fast healing",
+          "aonid": 62,
+          "game-obj": "MonsterAbilities",
+          "name": "fast healing",
+          "type": "link"
+        }
+      ],
+      "name": "True Vampire Abilities",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "monster creation",
+              "aonid": 2874,
+              "game-obj": "Rules",
+              "name": "monster creation",
+              "type": "link"
+            },
+            {
+              "alt": "archetype",
+              "aonid": 181,
+              "game-obj": "Archetypes",
+              "name": "archetype",
+              "type": "link"
+            }
+          ],
+          "name": "Building Vampires",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 334",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 334",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 334,
+              "type": "source"
+            }
+          ],
+          "text": "Because vampires can inflict their nature on any creature whose blood they drink, almost any living creature can become one of these undead horrors. When you need to create a vampire for your game, you can do so in two ways. In most cases, it's more effective to build the vampire from the ground up, using the standard rules for monster creation (this is how the vampire count, vampire servitor, and vampire mastermind presented on these pages were built). Or you can use the guidelines presented under Creating a Vampire to turn an existing creature into a vampire, adjusting the monster as you see fit. In either case, specific vampire abilities like coffin restoration, Mist Escape, and Drink Blood work the same. *Pathfinder Book of the Dead* also includes rules for turning player characters into vampires via an archetype.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Dhampirs",
+              "aonid": 23,
+              "game-obj": "Ancestries",
+              "name": "Dhampirs",
+              "type": "link"
+            }
+          ],
+          "name": "Death Wears Many Cloaks",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 334",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 334",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 334,
+              "type": "source"
+            }
+          ],
+          "text": "The most common and traditional vampires, as presented here, are also known as \u201cmoroi.\u201d They are most prevalent on Golarion in the mistshrouded counties of Ustalav and found in small numbers in almost every nation of the Inner Sea. Other types of vampires include the withered nosferatu, the hopping jiang-shi, the feral vrykolakas, and the psychic vetalarana\u2014these vampires share many of the basic traits with moroi but possess new abilities of their own. Dhampirs can be born of any of these vampires, though moroi-born dhampirs known as svetochers are the most common, especially in the Inner Sea region.",
+          "type": "section"
+        },
+        {
+          "name": "The Noble Dead",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 334",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 334",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 334,
+              "type": "source"
+            }
+          ],
+          "text": "Most vampires suffer an inevitable slide into moral decay and ethical dissolution, unable to retain whatever empathy and kindness they may have had in life. Some vampires manage to retain a portion of their positive emotions, but this retention seems to always be accompanied by a reduction in their vampiric power, as though the hints of a soul remaining reject the completeness of their transformation to undeath.",
+          "type": "section"
+        },
+        {
+          "name": "Where Rise The Dead",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 334",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 334",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 334,
+              "type": "source"
+            }
+          ],
+          "text": "Vampires are inevitably drawn to the places and people they knew in life. A vampire who lives in a city with active nightlife may maintain their mortal guise for many years before their undead nature becomes apparent, while vampires from simpler towns and villages may stalk nearby woods and caverns, yearning for a life forever denied them.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 334",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 334",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 334,
+          "type": "source"
+        }
+      ],
+      "text": "Powerful vampires that can create and control vampires from their victims gain additional vampire abilities, as detailed below. A creature below level 5 is not a significant enough creature to become a true vampire\u2014you should instead simply make such a creature into a regular vampire servitor or rebuild the creature so that it's at least level 5 before becoming a true vampire.  \n  \n**Resistances** The vampire resists all physical damage except magical silver.  \n**Create Servitor** (divine, downtime) If a creature dies after being reduced to 0 HP by Drink Blood, the vampire can turn this victim into a vampire servitor by donating some of their own blood to the victim and burying the victim in earth for 3 nights. A vampiric servitor is compelled to obey its creator, but if a vampire controls too many vampiric servitors at once (as determined by the GM), or if the servitor is a higher level than the vampire that created it, strong-willed servitors can free themselves by succeeding at a Will saving throw against the vampire's Will DC.  \n**Mist Escape** [-] **Trigger** The vampire is reduced to 0 HP; **Effect** The vampire uses Turn to Mist. They can take move actions to move toward their coffin even though they're at 0 HP. While at 0 HP in this form, the vampire is unaffected by further damage. They automatically return to their corporeal form, unconscious, if they reach their coffin or after 2 hours, whichever comes first.  \n**Change Shape** [#] (concentrate, divine, polymorph) The vampire transforms into one of their animal forms or back into their normal form. Most vampires can turn into a bat, but some can turn into a different creature, such as a rat or a wolf. Use the options in the *aerial form* and *animal form* spells as guidelines. **Children of the Night** (divine, mental) The vampire's presence brings forth creatures of the night to do the master's bidding. These typically include rat swarms, bat swarms, and wolves but can include other creatures. The vampire can give telepathic orders to these creatures as long as they're within 100 feet, but they can't communicate back.  \n**Dominate** [##] (divine, incapacitation, mental, visual) The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the high spell DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.  \n**Drink Blood** As a typical vampire, but the victim is drained 2 instead of 1.  \n**Turn to Mist** [#] (air, concentrate, divine, polymorph) The vampire turns into a cloud of vapor, as the *vapor form* spell, or back to their normal form. The vampire loses fast healing while turned to mist. The vampire can remain in this form indefinitely.",
       "type": "section"
     }
   ],

--- a/monster_families/monster_core/werecreature.json
+++ b/monster_families/monster_core/werecreature.json
@@ -255,436 +255,126 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Senses",
-                "subtype": "ability",
-                "text": "The werecreature gains all the senses of the animal.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Diplomacy",
-                    "aonid": 39,
-                    "game-obj": "Skills",
-                    "name": "Diplomacy",
-                    "type": "link"
-                  }
-                ],
-                "name": "Animal Empathy",
-                "subtype": "ability",
-                "text": "The werecreature can ask questions of, receive answers from, and use the Diplomacy skill with animals of its general kind.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 526,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unarmed",
-                    "aonid": 719,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "The werecreature gains a claw Strike (an agile unarmed attack that deals slashing damage). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unarmed",
-                    "aonid": 719,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Jaws",
-                "subtype": "ability",
-                "text": "The creature gains a jaws Strike (an unarmed attack that deals piercing damage) that inflicts its curse of the werecreature. If it had any non-agile attacks, the damage dealt by its jaws should be roughly the same as the damage dealt by those attacks. If it had only agile attacks, its jaws should deal one-third more damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 45,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The werecreature changes into its humanoid, hybrid, or animal shape. Each shape has a specific, persistent appearance. A true werecreature's natural form is its hybrid shape. In humanoid shape, the werecreature uses its original humanoid size, loses its jaws and claws Strikes, and gains a melee fist Strike that deals bludgeoning damage equal to the slashing damage dealt by its claw. In animal shape, its Speed and size change to that of the animal, it gains any special Strike effects of the animal that it didn't already have (such as Grab), and it loses its weapon Strikes.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "humanoids",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoids",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "moderate spell DC for the werecreature's new level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "moderate spell DC for the werecreature's new level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Curse of the Werecreature",
-                "saving_throw": [
-                  {
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "Fortitude DC is the moderate spell DC for the werecreature's new level. On each full moon, the cursed creature must succeed at another Fortitude save or turn into the same kind of werecreature until dawn. The creature is under the GM's control and goes on a rampage for half the night before falling unconscious until dawn.",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "This curse affects only humanoids;",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 566,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fatigued",
-                    "aonid": 73,
-                    "game-obj": "Conditions",
-                    "name": "fatigued",
-                    "type": "link"
-                  }
-                ],
-                "name": "Moon Frenzy",
-                "subtype": "ability",
-                "text": "When a full moon appears in the night sky, the werecreature must enter hybrid form, can't Change Shape thereafter, becomes one size larger, increases its reach by 5 feet, and increases the damage of its jaws by 2. When the moon sets or the sun rises, the werecreature returns to humanoid form and is fatigued for 2d4 hours.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Werecreature Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Diplomacy",
+                "aonid": 39,
+                "game-obj": "Skills",
+                "name": "Diplomacy",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 526,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 719,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "unarmed",
+                "aonid": 719,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
+              },
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 45,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "humanoids",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoids",
+                "type": "link"
+              },
+              {
+                "alt": "moderate spell DC for the werecreature's new level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "moderate spell DC for the werecreature's new level",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "fatigued",
+                "aonid": 73,
+                "game-obj": "Conditions",
+                "name": "fatigued",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -694,7 +384,6 @@
         ],
         "name": "Werecreature Abilities",
         "subtype": "monster_family",
-        "text": "All werecreatures gain the following abilities, some of which match an ability of the animal the werecreature transforms into. You might also need to adjust some abilities that conflict with the theme of the werecreature.",
         "type": "stat_block_section"
       }
     ],
@@ -736,6 +425,570 @@
         }
       ],
       "text": "You can either create a werecreature using the creature-building rules from *GM Core* (similar to the creatures in this section), or you can turn an existing, living humanoid into a werecreature by completing the following steps. The latter is an excellent choice for a recurring NPC who becomes a werecreature during a campaign. These changes reflect a werecreature in its hybrid form.  \n  \n Increase the creature's level by 1 and change its statistics as follows. \n\n|  |  |  |\n| --- | --- | --- |\n| **Starting Level** | **HP Increase** | **Weakness to Silver** |\n| 4 or lower  | +25  | 5 |\n| 5\u20137  | +35  | 7 |\n| 8\u201314  | +50  | 10 |\n| 15+  | +75  | 15 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Senses",
+          "subtype": "ability",
+          "text": "The werecreature gains all the senses of the animal.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Diplomacy",
+              "aonid": 39,
+              "game-obj": "Skills",
+              "name": "Diplomacy",
+              "type": "link"
+            }
+          ],
+          "name": "Animal Empathy",
+          "subtype": "ability",
+          "text": "The werecreature can ask questions of, receive answers from, and use the Diplomacy skill with animals of its general kind.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 526,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "unarmed",
+              "aonid": 719,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            }
+          ],
+          "name": "Claws",
+          "subtype": "ability",
+          "text": "The werecreature gains a claw Strike (an agile unarmed attack that deals slashing damage). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "unarmed",
+              "aonid": 719,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            }
+          ],
+          "name": "Jaws",
+          "subtype": "ability",
+          "text": "The creature gains a jaws Strike (an unarmed attack that deals piercing damage) that inflicts its curse of the werecreature. If it had any non-agile attacks, the damage dealt by its jaws should be roughly the same as the damage dealt by those attacks. If it had only agile attacks, its jaws should deal one-third more damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 55,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "links": [
+            {
+              "alt": "Grab",
+              "aonid": 45,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The werecreature changes into its humanoid, hybrid, or animal shape. Each shape has a specific, persistent appearance. A true werecreature's natural form is its hybrid shape. In humanoid shape, the werecreature uses its original humanoid size, loses its jaws and claws Strikes, and gains a melee fist Strike that deals bludgeoning damage equal to the slashing damage dealt by its claw. In animal shape, its Speed and size change to that of the animal, it gains any special Strike effects of the animal that it didn't already have (such as Grab), and it loses its weapon Strikes.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 55,
+            "edition": "remastered",
+            "game-id": "cfccadd6ae22a706a897a80c7d209862",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 2388,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 38,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 358",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 358",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 358,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "classes": [
+                  "template"
+                ],
+                "edition": "legacy",
+                "game-id": "070ae8282a8ee960fa04002421f6d345",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  }
+                ],
+                "name": "[Magical Tradition]",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 628",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 628",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 628,
+                    "type": "source"
+                  }
+                ],
+                "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "affliction",
+          "links": [
+            {
+              "alt": "humanoids",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoids",
+              "type": "link"
+            },
+            {
+              "alt": "moderate spell DC for the werecreature's new level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "moderate spell DC for the werecreature's new level",
+              "type": "link"
+            }
+          ],
+          "name": "Curse of the Werecreature",
+          "saving_throw": [
+            {
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "Fortitude DC is the moderate spell DC for the werecreature's new level. On each full moon, the cursed creature must succeed at another Fortitude save or turn into the same kind of werecreature until dawn. The creature is under the GM's control and goes on a rampage for half the night before falling unconscious until dawn.",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "This curse affects only humanoids;",
+          "traits": [
+            {
+              "link": {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              "name": "curse",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "fatigued",
+              "aonid": 73,
+              "game-obj": "Conditions",
+              "name": "fatigued",
+              "type": "link"
+            }
+          ],
+          "name": "Moon Frenzy",
+          "subtype": "ability",
+          "text": "When a full moon appears in the night sky, the werecreature must enter hybrid form, can't Change Shape thereafter, becomes one size larger, increases its reach by 5 feet, and increases the damage of its jaws by 2. When the moon sets or the sun rises, the werecreature returns to humanoid form and is fatigued for 2d4 hours.",
+          "traits": [
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Diplomacy",
+          "aonid": 39,
+          "game-obj": "Skills",
+          "name": "Diplomacy",
+          "type": "link"
+        },
+        {
+          "alt": "agile",
+          "aonid": 526,
+          "game-obj": "Traits",
+          "name": "agile",
+          "type": "link"
+        },
+        {
+          "alt": "unarmed",
+          "aonid": 719,
+          "game-obj": "Traits",
+          "name": "unarmed",
+          "type": "link"
+        },
+        {
+          "alt": "unarmed",
+          "aonid": 719,
+          "game-obj": "Traits",
+          "name": "unarmed",
+          "type": "link"
+        },
+        {
+          "alt": "Change Shape",
+          "aonid": 55,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 45,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 566,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "humanoids",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoids",
+          "type": "link"
+        },
+        {
+          "alt": "moderate spell DC for the werecreature's new level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "moderate spell DC for the werecreature's new level",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "fatigued",
+          "aonid": 73,
+          "game-obj": "Conditions",
+          "name": "fatigued",
+          "type": "link"
+        }
+      ],
+      "name": "Werecreature Abilities",
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 344",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 344",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 344,
+          "type": "source"
+        }
+      ],
+      "text": "All werecreatures gain the following abilities, some of which match an ability of the animal the werecreature transforms into. You might also need to adjust some abilities that conflict with the theme of the werecreature.  \n  \n**Senses** The werecreature gains all the senses of the animal.  \n**Animal Empathy** The werecreature can ask questions of, receive answers from, and use the Diplomacy skill with animals of its general kind.  \n**Claws** The werecreature gains a claw Strike (an agile unarmed attack that deals slashing damage). If it had any agile attacks, the damage dealt by its claws should be roughly the same as the damage dealt by those attacks. If it had only non-agile attacks, its claws should deal three-quarters that damage.  \n**Jaws** The creature gains a jaws Strike (an unarmed attack that deals piercing damage) that inflicts its curse of the werecreature. If it had any non-agile attacks, the damage dealt by its jaws should be roughly the same as the damage dealt by those attacks. If it had only agile attacks, its jaws should deal one-third more damage.  \n**Change Shape** [#] (concentrate, polymorph, primal) The werecreature changes into its humanoid, hybrid, or animal shape. Each shape has a specific, persistent appearance. A true werecreature's natural form is its hybrid shape. In humanoid shape, the werecreature uses its original humanoid size, loses its jaws and claws Strikes, and gains a melee fist Strike that deals bludgeoning damage equal to the slashing damage dealt by its claw. In animal shape, its Speed and size change to that of the animal, it gains any special Strike effects of the animal that it didn't already have (such as Grab), and it loses its weapon Strikes.  \n**Curse of the Werecreature** (curse, primal) This curse affects only humanoids; **Saving Throw** Fortitude DC is the moderate spell DC for the werecreature's new level. On each full moon, the cursed creature must succeed at another Fortitude save or turn into the same kind of werecreature until dawn. The creature is under the GM's control and goes on a rampage for half the night before falling unconscious until dawn.  \n**Moon Frenzy** (polymorph, primal) When a full moon appears in the night sky, the werecreature must enter hybrid form, can't Change Shape thereafter, becomes one size larger, increases its reach by 5 feet, and increases the damage of its jaws by 2. When the moon sets or the sun rises, the werecreature returns to humanoid form and is fatigued for 2d4 hours.",
       "type": "section"
     }
   ],

--- a/monster_families/monster_core/zombie.json
+++ b/monster_families/monster_core/zombie.json
@@ -59,336 +59,175 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "prone",
-                    "aonid": 88,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "off-guard",
-                    "aonid": 58,
-                    "game-obj": "Conditions",
-                    "name": "off-guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 36,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Trip",
-                    "aonid": 716,
-                    "game-obj": "Traits",
-                    "name": "Trip",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Crawls",
-                    "aonid": 2293,
-                    "game-obj": "Actions",
-                    "name": "Crawls",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ankle Biter",
-                "subtype": "ability",
-                "text": "This zombie fights just as well on the ground as it does standing. While prone, the zombie isn\u2019t off-guard, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 91,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "moderate spell DC for the zombie's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "moderate spell DC for the zombie's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Disgusting Pustules",
-                "subtype": "ability",
-                "text": "The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. Adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save against the moderate spell DC for the zombie's level.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 578,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "restrained",
-                    "aonid": 90,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Feast",
-                "subtype": "ability",
-                "text": "If the zombie is adjacent to a restrained or unconscious creature, or a corpse that died in the past hour, the zombie can feast upon its flesh. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, fist, or claw damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 645,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "plague zombie's",
-                    "aonid": 424,
-                    "game-obj": "Monsters",
-                    "name": "plague zombie's",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high spell DC for the zombie's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high spell DC for the zombie's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Plague-Ridden",
-                "subtype": "ability",
-                "text": "The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie. Use the high spell DC for the zombie's level.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 578,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Stride",
-                    "aonid": 2305,
-                    "game-obj": "Actions",
-                    "name": "Stride",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Strike",
-                    "aonid": 2306,
-                    "game-obj": "Actions",
-                    "name": "Strike",
-                    "type": "link"
-                  }
-                ],
-                "name": "Persistent Limbs",
-                "subtype": "ability",
-                "text": "The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "save of a moderate or high DC",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "save of a moderate or high DC",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sickened",
-                    "aonid": 91,
-                    "game-obj": "Conditions",
-                    "name": "sickened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Putrid Stench",
-                "range": {
-                  "range": 15,
-                  "subtype": "range",
-                  "text": "15 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The zombie\u2019s rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save of a moderate or high DC for the zombie\u2019s level. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies\u2019 putrid stenches for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "olfactory",
-                      "aonid": 664,
-                      "game-obj": "Traits",
-                      "name": "olfactory",
-                      "type": "link"
-                    },
-                    "name": "olfactory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "void",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Rotting Aura",
-                "range": {
-                  "range": 10,
-                  "subtype": "range",
-                  "text": "within 10 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The zombie emits an aura of rot and disease that causes wounds to fester. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 void damage. This damage increases by 1d6 for every 6 levels the zombie has.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 578,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    },
-                    "name": "void",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Unkillable",
-                "subtype": "ability",
-                "text": "This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Unholy Speed",
-                "subtype": "ability",
-                "text": "The zombie gains a +10-foot status bonus to all its Speeds.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Zombie Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "prone",
+                "aonid": 88,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "off-guard",
+                "aonid": 58,
+                "game-obj": "Conditions",
+                "name": "off-guard",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 36,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "Trip",
+                "aonid": 716,
+                "game-obj": "Traits",
+                "name": "Trip",
+                "type": "link"
+              },
+              {
+                "alt": "Crawls",
+                "aonid": 2293,
+                "game-obj": "Actions",
+                "name": "Crawls",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "moderate spell DC for the zombie's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "moderate spell DC for the zombie's level",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 90,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "plague zombie's",
+                "aonid": 424,
+                "game-obj": "Monsters",
+                "name": "plague zombie's",
+                "type": "link"
+              },
+              {
+                "alt": "high spell DC for the zombie's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high spell DC for the zombie's level",
+                "type": "link"
+              },
+              {
+                "alt": "Stride",
+                "aonid": 2305,
+                "game-obj": "Actions",
+                "name": "Stride",
+                "type": "link"
+              },
+              {
+                "alt": "Strike",
+                "aonid": 2306,
+                "game-obj": "Actions",
+                "name": "Strike",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "olfactory",
+                "aonid": 664,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              {
+                "alt": "save of a moderate or high DC",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "save of a moderate or high DC",
+                "type": "link"
+              },
+              {
+                "alt": "sickened",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -398,7 +237,6 @@
         ],
         "name": "Zombie Abilities",
         "subtype": "monster_family",
-        "text": "You can modify zombies with the following zombie abilities. Most zombies have one of these abilities; if you give a zombie more, you might want to increase its level and adjust its statistics.",
         "type": "stat_block_section"
       }
     ],
@@ -406,6 +244,626 @@
   },
   "name": "Zombie",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "prone",
+              "aonid": 88,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            },
+            {
+              "alt": "off-guard",
+              "aonid": 58,
+              "game-obj": "Conditions",
+              "name": "off-guard",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 36,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "Trip",
+              "aonid": 716,
+              "game-obj": "Traits",
+              "name": "Trip",
+              "type": "link"
+            },
+            {
+              "alt": "Crawls",
+              "aonid": 2293,
+              "game-obj": "Actions",
+              "name": "Crawls",
+              "type": "link"
+            }
+          ],
+          "name": "Ankle Biter",
+          "subtype": "ability",
+          "text": "This zombie fights just as well on the ground as it does standing. While prone, the zombie isn\u2019t off-guard, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "sickened 1",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            },
+            {
+              "alt": "moderate spell DC for the zombie's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "moderate spell DC for the zombie's level",
+              "type": "link"
+            }
+          ],
+          "name": "Disgusting Pustules",
+          "subtype": "ability",
+          "text": "The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. Adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save against the moderate spell DC for the zombie's level.",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "restrained",
+              "aonid": 90,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Feast",
+          "subtype": "ability",
+          "text": "If the zombie is adjacent to a restrained or unconscious creature, or a corpse that died in the past hour, the zombie can feast upon its flesh. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, fist, or claw damage.",
+          "traits": [
+            {
+              "link": {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              "name": "manipulate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "plague zombie's",
+              "aonid": 424,
+              "game-obj": "Monsters",
+              "name": "plague zombie's",
+              "type": "link"
+            },
+            {
+              "alt": "high spell DC for the zombie's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high spell DC for the zombie's level",
+              "type": "link"
+            }
+          ],
+          "name": "Plague-Ridden",
+          "subtype": "ability",
+          "text": "The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie. Use the high spell DC for the zombie's level.",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Stride",
+              "aonid": 2305,
+              "game-obj": "Actions",
+              "name": "Stride",
+              "type": "link"
+            },
+            {
+              "alt": "Strike",
+              "aonid": 2306,
+              "game-obj": "Actions",
+              "name": "Strike",
+              "type": "link"
+            }
+          ],
+          "name": "Persistent Limbs",
+          "subtype": "ability",
+          "text": "The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "save of a moderate or high DC",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "save of a moderate or high DC",
+              "type": "link"
+            },
+            {
+              "alt": "sickened",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened",
+              "type": "link"
+            }
+          ],
+          "name": "Putrid Stench",
+          "range": {
+            "range": 15,
+            "subtype": "range",
+            "text": "15 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The zombie\u2019s rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save of a moderate or high DC for the zombie\u2019s level. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies\u2019 putrid stenches for 1 minute.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "olfactory",
+                "aonid": 664,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              "name": "olfactory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "void",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Rotting Aura",
+          "range": {
+            "range": 10,
+            "subtype": "range",
+            "text": "within 10 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The zombie emits an aura of rot and disease that causes wounds to fester. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 void damage. This damage increases by 1d6 for every 6 levels the zombie has.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              "name": "void",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Unkillable",
+          "subtype": "ability",
+          "text": "This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Unholy Speed",
+          "subtype": "ability",
+          "text": "The zombie gains a +10-foot status bonus to all its Speeds.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "prone",
+          "aonid": 88,
+          "game-obj": "Conditions",
+          "name": "prone",
+          "type": "link"
+        },
+        {
+          "alt": "off-guard",
+          "aonid": 58,
+          "game-obj": "Conditions",
+          "name": "off-guard",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 36,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "Trip",
+          "aonid": 716,
+          "game-obj": "Traits",
+          "name": "Trip",
+          "type": "link"
+        },
+        {
+          "alt": "Crawls",
+          "aonid": 2293,
+          "game-obj": "Actions",
+          "name": "Crawls",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "sickened 1",
+          "aonid": 91,
+          "game-obj": "Conditions",
+          "name": "sickened 1",
+          "type": "link"
+        },
+        {
+          "alt": "moderate spell DC for the zombie's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "moderate spell DC for the zombie's level",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 645,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 90,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "plague zombie's",
+          "aonid": 424,
+          "game-obj": "Monsters",
+          "name": "plague zombie's",
+          "type": "link"
+        },
+        {
+          "alt": "high spell DC for the zombie's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high spell DC for the zombie's level",
+          "type": "link"
+        },
+        {
+          "alt": "Stride",
+          "aonid": 2305,
+          "game-obj": "Actions",
+          "name": "Stride",
+          "type": "link"
+        },
+        {
+          "alt": "Strike",
+          "aonid": 2306,
+          "game-obj": "Actions",
+          "name": "Strike",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "olfactory",
+          "aonid": 664,
+          "game-obj": "Traits",
+          "name": "olfactory",
+          "type": "link"
+        },
+        {
+          "alt": "save of a moderate or high DC",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "save of a moderate or high DC",
+          "type": "link"
+        },
+        {
+          "alt": "sickened",
+          "aonid": 91,
+          "game-obj": "Conditions",
+          "name": "sickened",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        }
+      ],
+      "name": "Zombie Abilities",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "elite adjustments",
+              "aonid": 790,
+              "game-obj": "Rules",
+              "name": "elite adjustments",
+              "type": "link"
+            },
+            {
+              "alt": "reach",
+              "aonid": 684,
+              "game-obj": "Traits",
+              "name": "reach",
+              "type": "link"
+            }
+          ],
+          "name": "Creating Zombies",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 356",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 356",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 356,
+              "type": "source"
+            }
+          ],
+          "text": "To create a zombie creature, start with a zombie of the appropriate size. Then add any Strikes, Speeds, or other abilities it would gain from its shape. To create a Gargantuan zombie, begin with the zombie hulk, apply the elite adjustments, change its size to Gargantuan, and increase its reach by 5 feet.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 722,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            }
+          ],
+          "name": "Disposable Legions",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 356",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 356",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 356,
+              "type": "source"
+            }
+          ],
+          "text": "With the ancient lich Tar-Baphon now released from his ages-long imprisonment, the undead within his legions have been specifically repurposed. Zombies like the ones seen here fulfill particular roles, and evil necromancers deploy them much like living or intelligent undead troops. Necromancer experiments seek to produce various abilities and mix energies, with horrifying results that don\u2019t deter their creators.",
+          "type": "section"
+        },
+        {
+          "name": "Risen from the Grave",
+          "sources": [
+            {
+              "errata": {
+                "alt": "1.1",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "1.1",
+                "type": "link"
+              },
+              "link": {
+                "alt": "Monster Core pg. 356",
+                "aonid": 221,
+                "game-obj": "Sources",
+                "name": "Monster Core pg. 356",
+                "type": "link"
+              },
+              "name": "Monster Core",
+              "page": 356,
+              "type": "source"
+            }
+          ],
+          "text": "Zombies are often created using unwholesome necromantic rituals. Among the living dead, zombies are most often used as fodder, wearing down defenses and consuming resources before more powerful undead arrive to deal the killing blow. Zombies cannot speak or even truly think for themselves, but they can be commanded by other allied undead and powerful necromancers.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "errata": {
+            "alt": "1.1",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "1.1",
+            "type": "link"
+          },
+          "link": {
+            "alt": "Monster Core pg. 356",
+            "aonid": 221,
+            "game-obj": "Sources",
+            "name": "Monster Core pg. 356",
+            "type": "link"
+          },
+          "name": "Monster Core",
+          "page": 356,
+          "type": "source"
+        }
+      ],
+      "text": "You can modify zombies with the following zombie abilities. Most zombies have one of these abilities; if you give a zombie more, you might want to increase its level and adjust its statistics.  \n  \n**Ankle Biter** This zombie fights just as well on the ground as it does standing. While prone, the zombie isn\u2019t off-guard, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.  \n  \n**Disgusting Pustules** (disease) The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. Adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save against the moderate spell DC for the zombie's level.  \n  \n**Feast** [##] (manipulate) If the zombie is adjacent to a restrained or unconscious creature, or a corpse that died in the past hour, the zombie can feast upon its flesh. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, fist, or claw damage.  \n  \n**Plague-Ridden** (disease) The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie. Use the high spell DC for the zombie's level.  \n  \n**Persistent Limbs** The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.  \n  \n**Putrid Stench** (aura, olfactory) 15 feet. The zombie\u2019s rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save of a moderate or high DC for the zombie\u2019s level. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies\u2019 putrid stenches for 1 minute.  \n  \n**Rotting Aura** (aura, disease, void) The zombie emits an aura of rot and disease that causes wounds to fester. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 void damage. This damage increases by 1d6 for every 6 levels the zombie has.  \n  \n**Unkillable** This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.  \n  \n**Unholy Speed** The zombie gains a +10-foot status bonus to all its Speeds.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "errata": {

--- a/monster_families/monster_core_2/beheaded.json
+++ b/monster_families/monster_core_2/beheaded.json
@@ -59,142 +59,70 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 91,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Bleeding",
-                "subtype": "ability",
-                "text": "The beheaded is covered in slimy blood. The target of a successful Strike is splattered with gore and must succeed at a Fortitude save or become sickened 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 45,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Entangling",
-                "subtype": "ability",
-                "text": "Long, stringy hair clings to the beheaded's scalp. Its Strikes gain the Grab ability (page 361).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightened 1",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fiendish",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The beheaded has a twisted, unsettling countenance. Foes that begin their turn in the area must succeed at a Will save or be frightened 1.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Giant",
-                "subtype": "ability",
-                "text": "A beheaded created from the head of a giant is a Medium creature, gaining 2 levels and one or more additional beheaded abilities.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Beheaded Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "sickened 1",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 45,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 1",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -204,7 +132,6 @@
         ],
         "name": "Beheaded Abilities",
         "subtype": "monster_family",
-        "text": "Beheaded can manifest with a variety of abilities, such as those presented below.",
         "type": "stat_block_section"
       }
     ],
@@ -212,6 +139,259 @@
   },
   "name": "Beheaded",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "sickened 1",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Bleeding",
+          "subtype": "ability",
+          "text": "The beheaded is covered in slimy blood. The target of a successful Strike is splattered with gore and must succeed at a Fortitude save or become sickened 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Grab",
+              "aonid": 45,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Entangling",
+          "subtype": "ability",
+          "text": "Long, stringy hair clings to the beheaded's scalp. Its Strikes gain the Grab ability (page 361).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "frightened 1",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Fiendish",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The beheaded has a twisted, unsettling countenance. Foes that begin their turn in the area must succeed at a Will save or be frightened 1.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Giant",
+          "subtype": "ability",
+          "text": "A beheaded created from the head of a giant is a Medium creature, gaining 2 levels and one or more additional beheaded abilities.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "sickened 1",
+          "aonid": 91,
+          "game-obj": "Conditions",
+          "name": "sickened 1",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 45,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "frightened 1",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened 1",
+          "type": "link"
+        }
+      ],
+      "name": "Beheaded Abilities",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "skeletons",
+              "aonid": 472,
+              "game-obj": "MonsterFamilies",
+              "name": "skeletons",
+              "type": "link"
+            },
+            {
+              "alt": "zombies",
+              "aonid": 487,
+              "game-obj": "MonsterFamilies",
+              "name": "zombies",
+              "type": "link"
+            },
+            {
+              "alt": "here",
+              "aonid": 2874,
+              "game-obj": "Rules",
+              "name": "here",
+              "type": "link"
+            }
+          ],
+          "name": "More Beheaded Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 56",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 56",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 56,
+              "type": "source"
+            }
+          ],
+          "text": "Since beheaded are very similar to skeletons or zombies (or at least the heads from those creatures), you can also customize them with abilities from the skeleton and zombie entries, though take care to avoid abilities that require bodies or limbs. If you give the beheaded more than one additional ability, you might want to increase its level and adjust its statistics accordingly. Use the guidelines here to determine to determine its new statistics.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 56",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 56",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 56,
+          "type": "source"
+        }
+      ],
+      "text": "Beheaded can manifest with a variety of abilities, such as those presented below.  \n  \n**Bleeding** The beheaded is covered in slimy blood. The target of a successful Strike is splattered with gore and must succeed at a Fortitude save or become sickened 1.  \n**Entangling** Long, stringy hair clings to the beheaded's scalp. Its Strikes gain the Grab ability (page 361).  \n**Fiendish** (aura, divine, emotion, fear, mental) 30 feet. The beheaded has a twisted, unsettling countenance. Foes that begin their turn in the area must succeed at a Will save or be frightened 1.  \n**Giant** A beheaded created from the head of a giant is a Medium creature, gaining 2 levels and one or more additional beheaded abilities.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/monster_core_2/clockwork.json
+++ b/monster_families/monster_core_2/clockwork.json
@@ -59,35 +59,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Wind-Up",
-                "subtype": "ability",
-                "text": "For a clockwork to act, it must be wound with a unique key by another creature. This takes 1 minute. Once wound, it remains operational for the listed amount of time, usually 24 hours, after which time it becomes unaware of its surroundings and can't act until it's wound again. Some clockworks' abilities require them to spend some of their remaining operational time. They can't spend more than they have and shut down immediately once they have 0 time remaining. If it's unclear when a clockwork was last wound, most clockwork keepers wind all their clockworks at a set time, typically 8 a.m.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Enter Standby",
-                "subtype": "ability",
-                "text": "The clockwork enters standby mode. Its operational time doesn't decrease in standby, but it can sense its surroundings (with a \u20132 circumstance penalty to Perception). It can't act, with one exception: when it perceives a creature, it can exit standby as a reaction (rolling initiative if appropriate).",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Winding Clockworks')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Disable a Device",
+                "aonid": 2411,
+                "game-obj": "Actions",
+                "name": "Disable a Device",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -101,104 +87,42 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_category": "hp_automatic",
-                    "ability_type": "ability",
-                    "area": [
-                      {
-                        "shape": "cone",
-                        "size": 15,
-                        "subtype": "area",
-                        "text": "15-foot cone",
-                        "type": "stat_block_section",
-                        "unit": "feet"
-                      }
-                    ],
-                    "damage": [
-                      {
-                        "damage_type": "fire",
-                        "formula": "2d6",
-                        "subtype": "attack_damage",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "links": [
-                      {
-                        "alt": "flat check",
-                        "aonid": 333,
-                        "game-obj": "Rules",
-                        "name": "flat check",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "cone",
-                        "aonid": 2386,
-                        "game-obj": "Rules",
-                        "name": "cone",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "basic",
-                        "aonid": 2297,
-                        "game-obj": "Rules",
-                        "name": "basic",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "slowed",
-                        "aonid": 92,
-                        "game-obj": "Conditions",
-                        "name": "slowed",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Backfire:",
-                    "saving_throw": [
-                      {
-                        "dc": 5,
-                        "save_type": "Flat Check",
-                        "subtype": "save_dc",
-                        "text": "DC 5 flat check",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "ability",
-                    "text": "The clockwork rolls a DC 5 flat check at the start of each of its turns. On a failure, it backfires, dealing 2d6 fire damage in a 15-foot cone, including to itself (basic Reflex save at the standard DC for its level), and is slowed 1 this turn.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "hp_automatic",
-                    "ability_type": "ability",
-                    "name": "Damaged Propulsion:",
-                    "subtype": "ability",
-                    "text": "The clockwork loses 1d4 hours of operational time at the end of each of its turns.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "automatic",
-                    "ability_type": "ability",
-                    "name": "Loose Screws:",
-                    "saving_throw": [
-                      {
-                        "dc": 5,
-                        "save_type": "Flat Check",
-                        "subtype": "save_dc",
-                        "text": "DC 5 flat check",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "ability",
-                    "text": "When damaged, the clockwork attempts a DC 5 flat check. On a failure, a plate of its armor falls loose. It takes a status penalty to AC equal to the number of lost plates (up to \u20134).",
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Winding Clockworks')].sections[?(@.name=='Malfunction!')].abilities",
                     "target": "$.defense.automatic_abilities"
+                  }
+                ],
+                "links": [
+                  {
+                    "alt": "flat check",
+                    "aonid": 333,
+                    "game-obj": "Rules",
+                    "name": "flat check",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "cone",
+                    "aonid": 2386,
+                    "game-obj": "Rules",
+                    "name": "cone",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "basic",
+                    "aonid": 2297,
+                    "game-obj": "Rules",
+                    "name": "basic",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "slowed",
+                    "aonid": 92,
+                    "game-obj": "Conditions",
+                    "name": "slowed",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -208,11 +132,9 @@
             ],
             "name": "Malfunction!",
             "subtype": "monster_family",
-            "text": "Clockworks can be prone to errors if not well maintained or properly programmed. You might want to introduce one of the malfunctions listed on the facing page in a clockwork that is in disrepair or gets damaged heavily in battle (such as with a critical hit).",
             "type": "stat_block_section"
           }
         ],
-        "text": "A clockwork must be wound to remain operational. Each clockwork has the wind-up ability, with the specifics listed in its stat block.",
         "type": "stat_block_section"
       }
     ],
@@ -220,6 +142,240 @@
   },
   "name": "Clockwork",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Wind-Up",
+          "subtype": "ability",
+          "text": "For a clockwork to act, it must be wound with a unique key by another creature. This takes 1 minute. Once wound, it remains operational for the listed amount of time, usually 24 hours, after which time it becomes unaware of its surroundings and can't act until it's wound again. Some clockworks' abilities require them to spend some of their remaining operational time. They can't spend more than they have and shut down immediately once they have 0 time remaining. If it's unclear when a clockwork was last wound, most clockwork keepers wind all their clockworks at a set time, typically 8 a.m.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Enter Standby",
+          "subtype": "ability",
+          "text": "The clockwork enters standby mode. Its operational time doesn't decrease in standby, but it can sense its surroundings (with a \u20132 circumstance penalty to Perception). It can't act, with one exception: when it perceives a creature, it can exit standby as a reaction (rolling initiative if appropriate).",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Disable a Device",
+          "aonid": 2411,
+          "game-obj": "Actions",
+          "name": "Disable a Device",
+          "type": "link"
+        }
+      ],
+      "name": "Winding Clockworks",
+      "sections": [
+        {
+          "name": "Clockwork Research",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 70",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 70",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 70,
+              "type": "source"
+            }
+          ],
+          "text": "Clockworks were invented in ancient times, culminating in the clockwork army of Xin, the first emperor of ancient Thassilon, but were lost for millennia. Disparate peoples later rediscovered the techniques and began to alter and improve them. Today, the Clockwork Cathedral in Absalom is a center of clockwork research, with many breakthroughs also coming from the kingdom of Nex and the mechanically savvy Grand Duchy of Alkenstar. The Qadiran professor Hadia Al-Dannah, formerly of the Clockwork Cathedral, wrote the best-regarded modern text on clockwork design\u2014 Glorious Rhythms in Life and Mechanica.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "area": [
+                {
+                  "shape": "cone",
+                  "size": 15,
+                  "subtype": "area",
+                  "text": "15-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "damage_type": "fire",
+                  "formula": "2d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "flat check",
+                  "aonid": 333,
+                  "game-obj": "Rules",
+                  "name": "flat check",
+                  "type": "link"
+                },
+                {
+                  "alt": "cone",
+                  "aonid": 2386,
+                  "game-obj": "Rules",
+                  "name": "cone",
+                  "type": "link"
+                },
+                {
+                  "alt": "basic",
+                  "aonid": 2297,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                },
+                {
+                  "alt": "slowed",
+                  "aonid": 92,
+                  "game-obj": "Conditions",
+                  "name": "slowed",
+                  "type": "link"
+                }
+              ],
+              "name": "Backfire:",
+              "saving_throw": [
+                {
+                  "dc": 5,
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 5 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "The clockwork rolls a DC 5 flat check at the start of each of its turns. On a failure, it backfires, dealing 2d6 fire damage in a 15-foot cone, including to itself (basic Reflex save at the standard DC for its level), and is slowed 1 this turn.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Damaged Propulsion:",
+              "subtype": "ability",
+              "text": "The clockwork loses 1d4 hours of operational time at the end of each of its turns.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "name": "Loose Screws:",
+              "saving_throw": [
+                {
+                  "dc": 5,
+                  "save_type": "Flat Check",
+                  "subtype": "save_dc",
+                  "text": "DC 5 flat check",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "When damaged, the clockwork attempts a DC 5 flat check. On a failure, a plate of its armor falls loose. It takes a status penalty to AC equal to the number of lost plates (up to \u20134).",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "flat check",
+              "aonid": 333,
+              "game-obj": "Rules",
+              "name": "flat check",
+              "type": "link"
+            },
+            {
+              "alt": "cone",
+              "aonid": 2386,
+              "game-obj": "Rules",
+              "name": "cone",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "slowed",
+              "aonid": 92,
+              "game-obj": "Conditions",
+              "name": "slowed",
+              "type": "link"
+            }
+          ],
+          "name": "Malfunction!",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 70",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 70",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 70,
+              "type": "source"
+            }
+          ],
+          "text": "Clockworks can be prone to errors if not well maintained or properly programmed. You might want to introduce one of the malfunctions listed on the facing page in a clockwork that is in disrepair or gets damaged heavily in battle (such as with a critical hit).   \n  \n**Backfire:** The clockwork rolls a DC 5 flat check at the start of each of its turns. On a failure, it backfires, dealing 2d6 fire damage in a 15-foot cone, including to itself (basic Reflex save at the standard DC for its level), and is slowed 1 this turn.  \n  \n**Damaged Propulsion:** The clockwork loses 1d4 hours of operational time at the end of each of its turns.   \n  \n**Loose Screws:** When damaged, the clockwork attempts a DC 5 flat check. On a failure, a plate of its armor falls loose. It takes a status penalty to AC equal to the number of lost plates (up to \u20134).",
+          "type": "section"
+        },
+        {
+          "name": "Winding Routines",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 70",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 70",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 70,
+              "type": "source"
+            }
+          ],
+          "text": "Maintaining a group of clockworks that are meant to operate on a regular basis takes planning and attention. A cadre of clockwork soldiers set to patrol a location needs to be regularly wound. Typically, one or more servants are assigned to wind all the clockworks serving in one place at a standard time.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 70",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 70",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 70,
+          "type": "source"
+        }
+      ],
+      "text": "A clockwork must be wound to remain operational. Each clockwork has the wind-up ability, with the specifics listed in its stat block.  \n  \n**Wind-Up** For a clockwork to act, it must be wound with a unique key by another creature. This takes 1 minute. Once wound, it remains operational for the listed amount of time, usually 24 hours, after which time it becomes unaware of its surroundings and can't act until it's wound again. Some clockworks' abilities require them to spend some of their remaining operational time. They can't spend more than they have and shut down immediately once they have 0 time remaining. If it's unclear when a clockwork was last wound, most clockwork keepers wind all their clockworks at a set time, typically 8 a.m.  \n  \n A creature can attempt to Disable a Device to wind a clockwork down (with a DC listed in the wind-up entry). For each success, the clockwork loses 1 hour of operational time (or 2 hours on a critical success). This can be done even if the clockwork is in standby mode.  \n  \n A clockwork that lists standby in its wind-up entry has the following action.  \n  \n**Enter Standby** [###] The clockwork enters standby mode. Its operational time doesn't decrease in standby, but it can sense its surroundings (with a \u20132 circumstance penalty to Perception). It can't act, with one exception: when it perceives a creature, it can exit standby as a reaction (rolling initiative if appropriate).",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/monster_core_2/divine_warden.json
+++ b/monster_families/monster_core_2/divine_warden.json
@@ -159,252 +159,112 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "spirit",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Divine Destruction",
-                "subtype": "ability",
-                "text": "When the divine warden is reduced to 0 HP, it erupts with divine energy in a 30-foot emanation, dealing 1d6 spirit damage per level. Each creature in the area must attempt a Will save with the following outcomes.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "spirit",
-                      "aonid": 737,
-                      "game-obj": "Traits",
-                      "name": "spirit",
-                      "type": "link"
-                    },
-                    "name": "spirit",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature takes half damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature takes full damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "enfeebled",
-                    "aonid": 71,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied",
-                    "aonid": 94,
-                    "game-obj": "Conditions",
-                    "name": "stupefied",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "curse",
-                    "aonid": 566,
-                    "game-obj": "Traits",
-                    "name": "curse",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteract",
-                    "aonid": 2250,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature takes full damage and becomes temporarily cursed by the patron deity. The creature becomes enfeebled 1 and stupefied 1 for 1 day; this is a curse effect that uses the Will save DC as the counteract DC.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, except the creature becomes enfeebled 2 and stupefied 2.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Refocus",
-                    "aonid": 2621,
-                    "game-obj": "Actions",
-                    "name": "Refocus",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Domain Spells",
-                "subtype": "ability",
-                "text": "The divine warden selects two of its patron deity's domains. The divine warden can cast the basic domain spell for its chosen domains. The divine warden has a focus pool of 1 Focus Point. It can't Refocus, but its focus pool automatically refills 24 hours after it last used a Focus Point. If the divine warden is at least 10th level, it also gains the advanced domain spells for its chosen domains, and its focus pool increases to 2 Focus Points.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "divine lance",
-                    "aonid": 1498,
-                    "game-obj": "Spells",
-                    "name": "divine lance",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Innate Spells",
-                "subtype": "ability",
-                "text": "A divine warden gains *divine lance* as an innate cantrip.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Sense Motive",
-                    "aonid": 2302,
-                    "game-obj": "Actions",
-                    "name": "Sense Motive",
-                    "type": "link"
-                  }
-                ],
-                "name": "Faith Bound",
-                "subtype": "ability",
-                "text": "A divine warden can't attack a creature that openly wears or displays the religious symbol of the divine warden's patron deity unless that creature uses a hostile action against the divine warden first. If the divine warden is intelligent, it can also attack a creature it believes isn't faithful to its deity or who wears the religious symbol as a ruse (typically after succeeding at a Perception check to Sense Motive).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "striking",
-                    "aonid": 2829,
-                    "game-obj": "Equipment",
-                    "name": "striking",
-                    "type": "link"
-                  }
-                ],
-                "name": "Faithful Weapon",
-                "subtype": "ability",
-                "text": "A divine warden always wields its patron deity's favored weapon. If the weapon is a ranged weapon, the divine warden automatically generates new ammunition with each attack. For a divine warden of 4th level or higher, the deity's favored weapon gains the effects of a *striking* rune while the divine warden wields it; at 12th level, these effects are of a *greater striking* rune, and at 19th level, they're instead of a *major striking* rune.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "heal",
-                    "aonid": 1554,
-                    "game-obj": "Spells",
-                    "name": "heal",
-                    "type": "link"
-                  }
-                ],
-                "name": "Instrument of Faith",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The divine warden is a beacon for its deity's faith. A cleric of the divine warden's patron deity can channel a *heal* spell through a divine warden they can see within 60 feet. The cleric determines any targets or area for the spell as if they were standing in the divine warden's space.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "holy",
-                    "aonid": 517,
-                    "game-obj": "Traits",
-                    "name": "holy",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unholy",
-                    "aonid": 521,
-                    "game-obj": "Traits",
-                    "name": "unholy",
-                    "type": "link"
-                  }
-                ],
-                "name": "Sanctification",
-                "subtype": "ability",
-                "text": "Divine wardens are often sanctified, gaining the holy or unholy traits as preferred by their deity. If the deity doesn't have a preference, the warden isn't sanctified.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating a Divine Warden')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled",
+                "aonid": 71,
+                "game-obj": "Conditions",
+                "name": "enfeebled",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied",
+                "aonid": 94,
+                "game-obj": "Conditions",
+                "name": "stupefied",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 2250,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "Refocus",
+                "aonid": 2621,
+                "game-obj": "Actions",
+                "name": "Refocus",
+                "type": "link"
+              },
+              {
+                "alt": "divine lance",
+                "aonid": 1498,
+                "game-obj": "Spells",
+                "name": "divine lance",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "Sense Motive",
+                "aonid": 2302,
+                "game-obj": "Actions",
+                "name": "Sense Motive",
+                "type": "link"
+              },
+              {
+                "alt": "striking",
+                "aonid": 2829,
+                "game-obj": "Equipment",
+                "name": "striking",
+                "type": "link"
+              },
+              {
+                "alt": "heal",
+                "aonid": 1554,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
+              },
+              {
+                "alt": "holy",
+                "aonid": 517,
+                "game-obj": "Traits",
+                "name": "holy",
+                "type": "link"
+              },
+              {
+                "alt": "unholy",
+                "aonid": 521,
+                "game-obj": "Traits",
+                "name": "unholy",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -414,7 +274,6 @@
         ],
         "name": "Creating a Divine Warden",
         "subtype": "monster_family",
-        "text": "You can build a divine warden from the ground up using the standard rules for monster creation (which is how the divine warden on the following page was built), or you can turn an existing construct into a divine warden by taking the following steps. In either case, the specific divine warden abilities listed below work the same.  \n  \n Select the deity who empowered the divine warden. This deity is the divine warden's patron deity. Increase the creature's level by 1 and change its statistics as follows. \n\n|  |  |\n| --- | --- |\n| **Starting Level** | **HP Increase** |\n| 1 or lower | 10 |\n| 2\u20134  | 15 |\n| 5\u201319  | 20 |\n| 20+  | 30 |\n\n Divine Warden Abilities A divine warden retains any abilities it had previously, and it gains the abilities listed below. You might need to adjust or remove other abilities that conflict with the construct's new theme as a divine warden.",
         "type": "stat_block_section"
       }
     ],
@@ -422,6 +281,388 @@
   },
   "name": "Divine Warden",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "spirit",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Divine Destruction",
+          "subtype": "ability",
+          "text": "When the divine warden is reduced to 0 HP, it erupts with divine energy in a 30-foot emanation, dealing 1d6 spirit damage per level. Each creature in the area must attempt a Will save with the following outcomes.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              "name": "spirit",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature takes half damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature takes full damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "enfeebled",
+              "aonid": 71,
+              "game-obj": "Conditions",
+              "name": "enfeebled",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied",
+              "aonid": 94,
+              "game-obj": "Conditions",
+              "name": "stupefied",
+              "type": "link"
+            },
+            {
+              "alt": "curse",
+              "aonid": 566,
+              "game-obj": "Traits",
+              "name": "curse",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 2250,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            }
+          ],
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature takes full damage and becomes temporarily cursed by the patron deity. The creature becomes enfeebled 1 and stupefied 1 for 1 day; this is a curse effect that uses the Will save DC as the counteract DC.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, except the creature becomes enfeebled 2 and stupefied 2.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Refocus",
+              "aonid": 2621,
+              "game-obj": "Actions",
+              "name": "Refocus",
+              "type": "link"
+            }
+          ],
+          "name": "Divine Domain Spells",
+          "subtype": "ability",
+          "text": "The divine warden selects two of its patron deity's domains. The divine warden can cast the basic domain spell for its chosen domains. The divine warden has a focus pool of 1 Focus Point. It can't Refocus, but its focus pool automatically refills 24 hours after it last used a Focus Point. If the divine warden is at least 10th level, it also gains the advanced domain spells for its chosen domains, and its focus pool increases to 2 Focus Points.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "divine lance",
+              "aonid": 1498,
+              "game-obj": "Spells",
+              "name": "divine lance",
+              "type": "link"
+            }
+          ],
+          "name": "Divine Innate Spells",
+          "subtype": "ability",
+          "text": "A divine warden gains *divine lance* as an innate cantrip.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Sense Motive",
+              "aonid": 2302,
+              "game-obj": "Actions",
+              "name": "Sense Motive",
+              "type": "link"
+            }
+          ],
+          "name": "Faith Bound",
+          "subtype": "ability",
+          "text": "A divine warden can't attack a creature that openly wears or displays the religious symbol of the divine warden's patron deity unless that creature uses a hostile action against the divine warden first. If the divine warden is intelligent, it can also attack a creature it believes isn't faithful to its deity or who wears the religious symbol as a ruse (typically after succeeding at a Perception check to Sense Motive).",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "striking",
+              "aonid": 2829,
+              "game-obj": "Equipment",
+              "name": "striking",
+              "type": "link"
+            }
+          ],
+          "name": "Faithful Weapon",
+          "subtype": "ability",
+          "text": "A divine warden always wields its patron deity's favored weapon. If the weapon is a ranged weapon, the divine warden automatically generates new ammunition with each attack. For a divine warden of 4th level or higher, the deity's favored weapon gains the effects of a *striking* rune while the divine warden wields it; at 12th level, these effects are of a *greater striking* rune, and at 19th level, they're instead of a *major striking* rune.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "heal",
+              "aonid": 1554,
+              "game-obj": "Spells",
+              "name": "heal",
+              "type": "link"
+            }
+          ],
+          "name": "Instrument of Faith",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "within 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The divine warden is a beacon for its deity's faith. A cleric of the divine warden's patron deity can channel a *heal* spell through a divine warden they can see within 60 feet. The cleric determines any targets or area for the spell as if they were standing in the divine warden's space.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "holy",
+              "aonid": 517,
+              "game-obj": "Traits",
+              "name": "holy",
+              "type": "link"
+            },
+            {
+              "alt": "unholy",
+              "aonid": 521,
+              "game-obj": "Traits",
+              "name": "unholy",
+              "type": "link"
+            }
+          ],
+          "name": "Sanctification",
+          "subtype": "ability",
+          "text": "Divine wardens are often sanctified, gaining the holy or unholy traits as preferred by their deity. If the deity doesn't have a preference, the warden isn't sanctified.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "spirit",
+          "aonid": 737,
+          "game-obj": "Traits",
+          "name": "spirit",
+          "type": "link"
+        },
+        {
+          "alt": "enfeebled",
+          "aonid": 71,
+          "game-obj": "Conditions",
+          "name": "enfeebled",
+          "type": "link"
+        },
+        {
+          "alt": "stupefied",
+          "aonid": 94,
+          "game-obj": "Conditions",
+          "name": "stupefied",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 566,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 2250,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        },
+        {
+          "alt": "Refocus",
+          "aonid": 2621,
+          "game-obj": "Actions",
+          "name": "Refocus",
+          "type": "link"
+        },
+        {
+          "alt": "divine lance",
+          "aonid": 1498,
+          "game-obj": "Spells",
+          "name": "divine lance",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "Sense Motive",
+          "aonid": 2302,
+          "game-obj": "Actions",
+          "name": "Sense Motive",
+          "type": "link"
+        },
+        {
+          "alt": "striking",
+          "aonid": 2829,
+          "game-obj": "Equipment",
+          "name": "striking",
+          "type": "link"
+        },
+        {
+          "alt": "heal",
+          "aonid": 1554,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        },
+        {
+          "alt": "holy",
+          "aonid": 517,
+          "game-obj": "Traits",
+          "name": "holy",
+          "type": "link"
+        },
+        {
+          "alt": "unholy",
+          "aonid": 521,
+          "game-obj": "Traits",
+          "name": "unholy",
+          "type": "link"
+        }
+      ],
+      "name": "Creating a Divine Warden",
+      "sections": [
+        {
+          "name": "Heroes of the Faith",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 114",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 114",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 114,
+              "type": "source"
+            }
+          ],
+          "text": "In the rare instances where a deity personally creates a divine warden, the deity tends to animate depictions of great heroes from their faith. The specific image of the hero serves to inspire devotees and act as a leader in combat. Occasionally, the deity will call on the spirit of the hero to actually embody the divine warden, allowing the hero to fight for their faith once again.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 114",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 114",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 114,
+          "type": "source"
+        }
+      ],
+      "text": "You can build a divine warden from the ground up using the standard rules for monster creation (which is how the divine warden on the following page was built), or you can turn an existing construct into a divine warden by taking the following steps. In either case, the specific divine warden abilities listed below work the same.  \n  \n Select the deity who empowered the divine warden. This deity is the divine warden's patron deity. Increase the creature's level by 1 and change its statistics as follows. \n\n|  |  |\n| --- | --- |\n| **Starting Level** | **HP Increase** |\n| 1 or lower | 10 |\n| 2\u20134  | 15 |\n| 5\u201319  | 20 |\n| 20+  | 30 |\n\n Divine Warden Abilities A divine warden retains any abilities it had previously, and it gains the abilities listed below. You might need to adjust or remove other abilities that conflict with the construct's new theme as a divine warden.  \n  \n**Divine Destruction** (divine, spirit) When the divine warden is reduced to 0 HP, it erupts with divine energy in a 30-foot emanation, dealing 1d6 spirit damage per level. Each creature in the area must attempt a Will save with the following outcomes.  \n**Critical Success** The creature takes half damage.  \n**Success** The creature takes full damage.  \n**Failure** The creature takes full damage and becomes temporarily cursed by the patron deity. The creature becomes enfeebled 1 and stupefied 1 for 1 day; this is a curse effect that uses the Will save DC as the counteract DC.  \n**Critical Failure** As failure, except the creature becomes enfeebled 2 and stupefied 2.  \n  \n**Divine Domain Spells** The divine warden selects two of its patron deity's domains. The divine warden can cast the basic domain spell for its chosen domains. The divine warden has a focus pool of 1 Focus Point. It can't Refocus, but its focus pool automatically refills 24 hours after it last used a Focus Point. If the divine warden is at least 10th level, it also gains the advanced domain spells for its chosen domains, and its focus pool increases to 2 Focus Points.  \n  \n**Divine Innate Spells** A divine warden gains *divine lance* as an innate cantrip.  \n  \n**Faith Bound** (divine) A divine warden can't attack a creature that openly wears or displays the religious symbol of the divine warden's patron deity unless that creature uses a hostile action against the divine warden first. If the divine warden is intelligent, it can also attack a creature it believes isn't faithful to its deity or who wears the religious symbol as a ruse (typically after succeeding at a Perception check to Sense Motive).  \n  \n**Faithful Weapon** A divine warden always wields its patron deity's favored weapon. If the weapon is a ranged weapon, the divine warden automatically generates new ammunition with each attack. For a divine warden of 4th level or higher, the deity's favored weapon gains the effects of a *striking* rune while the divine warden wields it; at 12th level, these effects are of a *greater striking* rune, and at 19th level, they're instead of a *major striking* rune.  \n  \n**Instrument of Faith** The divine warden is a beacon for its deity's faith. A cleric of the divine warden's patron deity can channel a *heal* spell through a divine warden they can see within 60 feet. The cleric determines any targets or area for the spell as if they were standing in the divine warden's space.  \n  \n**Sanctification** Divine wardens are often sanctified, gaining the holy or unholy traits as preferred by their deity. If the deity doesn't have a preference, the warden isn't sanctified.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/monster_core_2/dragon_cinder.json
+++ b/monster_families/monster_core_2/dragon_cinder.json
@@ -64,243 +64,105 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 15,
-                    "subtype": "area",
-                    "text": "15-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concealed",
-                    "aonid": 62,
-                    "game-obj": "Conditions",
-                    "name": "concealed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cloud of Ashes",
-                "saving_throw": [
-                  {
-                    "dc": 30,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 30 Fortitude",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The dragon blows a cloud of ashes and smoke out through their scales, surrounding themself in a 15-foot emanation that lasts until the end of their next turn. All creatures within the cloud become concealed to both sight and scent, and all creatures outside the cloud are concealed to creatures within it. Any creature that enters the area or begins its turn in the area must attempt a Fortitude save with a DC equal to the dragon\u2019s Pyre Breath.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "flat check",
-                    "aonid": 333,
-                    "game-obj": "Rules",
-                    "name": "flat check",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "saving_throw": [
-                  {
-                    "dc": 5,
-                    "save_type": "Flat Check",
-                    "subtype": "save_dc",
-                    "text": "DC 5 flat check",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The creature begins coughing and until the start of its next turn it must succeed at a DC 5 flat check if it attempts any action that requires it to speak, or it loses the action.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "aura",
-                    "aonid": 542,
-                    "game-obj": "Traits",
-                    "name": "aura",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fire",
-                    "aonid": 604,
-                    "game-obj": "Traits",
-                    "name": "fire",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "misfortune",
-                    "aonid": 654,
-                    "game-obj": "Traits",
-                    "name": "misfortune",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "primal",
-                    "aonid": 676,
-                    "game-obj": "Traits",
-                    "name": "primal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent fire damage",
-                    "aonid": 86,
-                    "game-obj": "Conditions",
-                    "name": "persistent fire damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, plus it must immediately spend its next action coughing. Inextinguishable Aura (aura, fire, misfortune, primal) 90 feet. Flames burn underwater in this aura and cannot be doused by non-magical water. When a creature within this aura attempts a flat check to end persistent fire damage, it must roll twice and take the worse result.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Inflame Emotions",
-                "range": {
-                  "range": 90,
-                  "subtype": "range",
-                  "text": "90 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The dragon sends out a wave of heat that inflames emotions within 90 feet. Creatures within it must attempt a Will save with a DC equal to the dragon\u2019s Frightful Presence DC. Regardless of the results, they are then immune to Inflame Emotions for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fire",
-                      "aonid": 604,
-                      "game-obj": "Traits",
-                      "name": "fire",
-                      "type": "link"
-                    },
-                    "name": "fire",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature can spend a reaction to make a melee Strike against a target of its choice.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature immediately makes a melee Strike against a target of the dragon\u2019s choice. The creature cannot use reactions until the start of its next turn.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "concealed",
+                "aonid": 62,
+                "game-obj": "Conditions",
+                "name": "concealed",
+                "type": "link"
+              },
+              {
+                "alt": "flat check",
+                "aonid": 333,
+                "game-obj": "Rules",
+                "name": "flat check",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 604,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "misfortune",
+                "aonid": 654,
+                "game-obj": "Traits",
+                "name": "misfortune",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "persistent fire damage",
+                "aonid": 86,
+                "game-obj": "Conditions",
+                "name": "persistent fire damage",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 604,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -310,322 +172,138 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Some cinder dragons burn more or less fiercely, giving them different abilities than most of their kind. You can adjust a cinder dragon of any age by substituting Draconic Frenzy, Frightful Presence, or Stoke the Flames for any one of the following abilities.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "29"
-                ],
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fire shield",
-                            "aonid": 1529,
-                            "game-obj": "Spells",
-                            "name": "fire shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fire shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mountain resilience",
-                            "aonid": 1610,
-                            "game-obj": "Spells",
-                            "name": "mountain resilience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mountain resilience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of fire",
-                            "aonid": 1748,
-                            "game-obj": "Spells",
-                            "name": "wall of fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fireball",
-                            "aonid": 1530,
-                            "game-obj": "Spells",
-                            "name": "fireball",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "floating flame",
-                            "aonid": 1533,
-                            "game-obj": "Spells",
-                            "name": "floating flame",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "floating flame",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cleanse cuisine",
-                            "aonid": 1468,
-                            "game-obj": "Spells",
-                            "name": "cleanse cuisine",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cleanse cuisine",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ventriloquism",
-                            "aonid": 1740,
-                            "game-obj": "Spells",
-                            "name": "ventriloquism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ventriloquism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ignition",
-                            "aonid": 1565,
-                            "game-obj": "Spells",
-                            "name": "ignition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Cinder Dragons')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fire shield",
+                "aonid": 1529,
+                "game-obj": "Spells",
+                "name": "fire shield",
+                "type": "link"
+              },
+              {
+                "alt": "mountain resilience",
+                "aonid": 1610,
+                "game-obj": "Spells",
+                "name": "mountain resilience",
+                "type": "link"
+              },
+              {
+                "alt": "wall of fire",
+                "aonid": 1748,
+                "game-obj": "Spells",
+                "name": "wall of fire",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "fireball",
+                "aonid": 1530,
+                "game-obj": "Spells",
+                "name": "fireball",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "floating flame",
+                "aonid": 1533,
+                "game-obj": "Spells",
+                "name": "floating flame",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "cleanse cuisine",
+                "aonid": 1468,
+                "game-obj": "Spells",
+                "name": "cleanse cuisine",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "ventriloquism",
+                "aonid": 1740,
+                "game-obj": "Spells",
+                "name": "ventriloquism",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "ignition",
+                "aonid": 1565,
+                "game-obj": "Spells",
+                "name": "ignition",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -641,147 +319,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "34",
-                  "As young cinder dragon"
-                ],
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cursed metamorphosis",
-                            "aonid": 1479,
-                            "game-obj": "Spells",
-                            "name": "cursed metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cursed metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truesight",
-                            "aonid": 1727,
-                            "game-obj": "Spells",
-                            "name": "truesight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truesight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "wall of fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blazing bolt",
-                            "aonid": 1450,
-                            "game-obj": "Spells",
-                            "name": "blazing bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blazing bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Cinder Dragons')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cursed metamorphosis",
+                "aonid": 1479,
+                "game-obj": "Spells",
+                "name": "cursed metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "truesight",
+                "aonid": 1727,
+                "game-obj": "Spells",
+                "name": "truesight",
+                "type": "link"
+              },
+              {
+                "alt": "blazing bolt",
+                "aonid": 1450,
+                "game-obj": "Spells",
+                "name": "blazing bolt",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -797,190 +369,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult cinder dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count_text": "asteroids only",
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "volcanic eruption",
-                            "aonid": 1746,
-                            "game-obj": "Spells",
-                            "name": "volcanic eruption",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "volcanic eruption",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "execute",
-                            "aonid": 1519,
-                            "game-obj": "Spells",
-                            "name": "execute",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "execute",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fiery body",
-                            "aonid": 1527,
-                            "game-obj": "Spells",
-                            "name": "fiery body",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fiery body",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "volcanic eruption",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Cinder Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "volcanic eruption",
+                "aonid": 1746,
+                "game-obj": "Spells",
+                "name": "volcanic eruption",
+                "type": "link"
+              },
+              {
+                "alt": "execute",
+                "aonid": 1519,
+                "game-obj": "Spells",
+                "name": "execute",
+                "type": "link"
+              },
+              {
+                "alt": "fiery body",
+                "aonid": 1527,
+                "game-obj": "Spells",
+                "name": "fiery body",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -996,125 +433,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient cinder dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cataclysm",
-                            "aonid": 1460,
-                            "game-obj": "Spells",
-                            "name": "cataclysm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cataclysm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "indestructibility",
-                            "aonid": 1573,
-                            "game-obj": "Spells",
-                            "name": "indestructibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "indestructibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Cinder Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cataclysm",
+                "aonid": 1460,
+                "game-obj": "Spells",
+                "name": "cataclysm",
+                "type": "link"
+              },
+              {
+                "alt": "indestructibility",
+                "aonid": 1573,
+                "game-obj": "Spells",
+                "name": "indestructibility",
+                "type": "link"
+              },
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1129,48 +475,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1181,263 +490,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1447,7 +540,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1456,6 +548,349 @@
   "name": "Dragon, Cinder",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 15,
+              "subtype": "area",
+              "text": "15-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "concealed",
+              "aonid": 62,
+              "game-obj": "Conditions",
+              "name": "concealed",
+              "type": "link"
+            }
+          ],
+          "name": "Cloud of Ashes",
+          "saving_throw": [
+            {
+              "dc": 30,
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "DC 30 Fortitude",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The dragon blows a cloud of ashes and smoke out through their scales, surrounding themself in a 15-foot emanation that lasts until the end of their next turn. All creatures within the cloud become concealed to both sight and scent, and all creatures outside the cloud are concealed to creatures within it. Any creature that enters the area or begins its turn in the area must attempt a Fortitude save with a DC equal to the dragon\u2019s Pyre Breath.",
+          "traits": [
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "flat check",
+              "aonid": 333,
+              "game-obj": "Rules",
+              "name": "flat check",
+              "type": "link"
+            }
+          ],
+          "name": "Failure",
+          "saving_throw": [
+            {
+              "dc": 5,
+              "save_type": "Flat Check",
+              "subtype": "save_dc",
+              "text": "DC 5 flat check",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The creature begins coughing and until the start of its next turn it must succeed at a DC 5 flat check if it attempts any action that requires it to speak, or it loses the action.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "aura",
+              "aonid": 542,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "fire",
+              "aonid": 604,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "misfortune",
+              "aonid": 654,
+              "game-obj": "Traits",
+              "name": "misfortune",
+              "type": "link"
+            },
+            {
+              "alt": "primal",
+              "aonid": 676,
+              "game-obj": "Traits",
+              "name": "primal",
+              "type": "link"
+            },
+            {
+              "alt": "persistent fire damage",
+              "aonid": 86,
+              "game-obj": "Conditions",
+              "name": "persistent fire damage",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, plus it must immediately spend its next action coughing. Inextinguishable Aura (aura, fire, misfortune, primal) 90 feet. Flames burn underwater in this aura and cannot be doused by non-magical water. When a creature within this aura attempts a flat check to end persistent fire damage, it must roll twice and take the worse result.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Inflame Emotions",
+          "range": {
+            "range": 90,
+            "subtype": "range",
+            "text": "90 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The dragon sends out a wave of heat that inflames emotions within 90 feet. Creatures within it must attempt a Will save with a DC equal to the dragon\u2019s Frightful Presence DC. Regardless of the results, they are then immune to Inflame Emotions for 1 minute.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fire",
+                "aonid": 604,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              "name": "fire",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature can spend a reaction to make a melee Strike against a target of its choice.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature immediately makes a melee Strike against a target of the dragon\u2019s choice. The creature cannot use reactions until the start of its next turn.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "concealed",
+          "aonid": 62,
+          "game-obj": "Conditions",
+          "name": "concealed",
+          "type": "link"
+        },
+        {
+          "alt": "flat check",
+          "aonid": 333,
+          "game-obj": "Rules",
+          "name": "flat check",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "fire",
+          "aonid": 604,
+          "game-obj": "Traits",
+          "name": "fire",
+          "type": "link"
+        },
+        {
+          "alt": "misfortune",
+          "aonid": 654,
+          "game-obj": "Traits",
+          "name": "misfortune",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "persistent fire damage",
+          "aonid": 86,
+          "game-obj": "Conditions",
+          "name": "persistent fire damage",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "fire",
+          "aonid": 604,
+          "game-obj": "Traits",
+          "name": "fire",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 118",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 118",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 118,
+          "type": "source"
+        }
+      ],
+      "text": "Some cinder dragons burn more or less fiercely, giving them different abilities than most of their kind. You can adjust a cinder dragon of any age by substituting Draconic Frenzy, Frightful Presence, or Stoke the Flames for any one of the following abilities.   \n  \n**Cloud of Ashes** [#] (primal) The dragon blows a cloud of ashes and smoke out through their scales, surrounding themself in a 15-foot emanation that lasts until the end of their next turn. All creatures within the cloud become concealed to both sight and scent, and all creatures outside the cloud are concealed to creatures within it. Any creature that enters the area or begins its turn in the area must attempt a Fortitude save with a DC equal to the dragon\u2019s Pyre Breath.   \n**Success** The creature is unaffected.   \n**Failure** The creature begins coughing and until the start of its next turn it must succeed at a DC 5 flat check if it attempts any action that requires it to speak, or it loses the action.  \n**Critical Failure** As failure, plus it must immediately spend its next action coughing. Inextinguishable Aura (aura, fire, misfortune, primal) 90 feet. Flames burn underwater in this aura and cannot be doused by non-magical water. When a creature within this aura attempts a flat check to end persistent fire damage, it must roll twice and take the worse result.   \n  \n**Inflame Emotions** [##] (aura, fire, mental, primal) 90 feet. The dragon sends out a wave of heat that inflames emotions within 90 feet. Creatures within it must attempt a Will save with a DC equal to the dragon\u2019s Frightful Presence DC. Regardless of the results, they are then immune to Inflame Emotions for 1 minute.   \n**Critical Success** The creature can spend a reaction to make a melee Strike against a target of its choice.   \n**Success** The creature is unaffected.   \n**Failure** The creature immediately makes a melee Strike against a target of the dragon\u2019s choice. The creature cannot use reactions until the start of its next turn.",
+      "type": "section"
+    },
     {
       "name": "Cinder Dragon Spellcasters",
       "sources": [
@@ -1473,6 +908,1061 @@
         }
       ],
       "text": "Cinder dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fire shield",
+          "aonid": 1529,
+          "game-obj": "Spells",
+          "name": "fire shield",
+          "type": "link"
+        },
+        {
+          "alt": "mountain resilience",
+          "aonid": 1610,
+          "game-obj": "Spells",
+          "name": "mountain resilience",
+          "type": "link"
+        },
+        {
+          "alt": "wall of fire",
+          "aonid": 1748,
+          "game-obj": "Spells",
+          "name": "wall of fire",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "fireball",
+          "aonid": 1530,
+          "game-obj": "Spells",
+          "name": "fireball",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "floating flame",
+          "aonid": 1533,
+          "game-obj": "Spells",
+          "name": "floating flame",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "cleanse cuisine",
+          "aonid": 1468,
+          "game-obj": "Spells",
+          "name": "cleanse cuisine",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "ventriloquism",
+          "aonid": 1740,
+          "game-obj": "Spells",
+          "name": "ventriloquism",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "ignition",
+          "aonid": 1565,
+          "game-obj": "Spells",
+          "name": "ignition",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        }
+      ],
+      "name": "Young Cinder Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 118",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 118",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 118,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "29"
+          ],
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fire shield",
+                      "aonid": 1529,
+                      "game-obj": "Spells",
+                      "name": "fire shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fire shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mountain resilience",
+                      "aonid": 1610,
+                      "game-obj": "Spells",
+                      "name": "mountain resilience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mountain resilience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of fire",
+                      "aonid": 1748,
+                      "game-obj": "Spells",
+                      "name": "wall of fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fireball",
+                      "aonid": 1530,
+                      "game-obj": "Spells",
+                      "name": "fireball",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "floating flame",
+                      "aonid": 1533,
+                      "game-obj": "Spells",
+                      "name": "floating flame",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "floating flame",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cleanse cuisine",
+                      "aonid": 1468,
+                      "game-obj": "Spells",
+                      "name": "cleanse cuisine",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cleanse cuisine",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ventriloquism",
+                      "aonid": 1740,
+                      "game-obj": "Spells",
+                      "name": "ventriloquism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ventriloquism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ignition",
+                      "aonid": 1565,
+                      "game-obj": "Spells",
+                      "name": "ignition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells DC** 29, attack +21; **4th** *fire shield*, *mountain resilience*, *wall of fire*; **3rd** *dispel magic*, *fireball*, *haste*; **2nd** *floating flame*, *mist*, *revealing light*; **1st** *cleanse cuisine*, *fear*, *ventriloquism*; **Cantrips (4th)** *detect magic*, *ignition*, *message*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cursed metamorphosis",
+          "aonid": 1479,
+          "game-obj": "Spells",
+          "name": "cursed metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "truesight",
+          "aonid": 1727,
+          "game-obj": "Spells",
+          "name": "truesight",
+          "type": "link"
+        },
+        {
+          "alt": "blazing bolt",
+          "aonid": 1450,
+          "game-obj": "Spells",
+          "name": "blazing bolt",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Cinder Dragons",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 118",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 118",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 118,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "34",
+            "As young cinder dragon"
+          ],
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cursed metamorphosis",
+                      "aonid": 1479,
+                      "game-obj": "Spells",
+                      "name": "cursed metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cursed metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truesight",
+                      "aonid": 1727,
+                      "game-obj": "Spells",
+                      "name": "truesight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truesight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "wall of fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blazing bolt",
+                      "aonid": 1450,
+                      "game-obj": "Spells",
+                      "name": "blazing bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blazing bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells DC** 34, attack +26; As young cinder dragon, plus **6th** *cursed metamorphosis*, *truesight*, *wall of fire*; **5th** *blazing bolt*, *fireball*, *toxic cloud*; **Cantrips (6th)** *detect magic*, *ignition*, *message*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "volcanic eruption",
+          "aonid": 1746,
+          "game-obj": "Spells",
+          "name": "volcanic eruption",
+          "type": "link"
+        },
+        {
+          "alt": "execute",
+          "aonid": 1519,
+          "game-obj": "Spells",
+          "name": "execute",
+          "type": "link"
+        },
+        {
+          "alt": "fiery body",
+          "aonid": 1527,
+          "game-obj": "Spells",
+          "name": "fiery body",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Cinder Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 118",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 118",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 118,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult cinder dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count_text": "asteroids only",
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "volcanic eruption",
+                      "aonid": 1746,
+                      "game-obj": "Spells",
+                      "name": "volcanic eruption",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "volcanic eruption",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "execute",
+                      "aonid": 1519,
+                      "game-obj": "Spells",
+                      "name": "execute",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "execute",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fiery body",
+                      "aonid": 1527,
+                      "game-obj": "Spells",
+                      "name": "fiery body",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fiery body",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "volcanic eruption",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 41, attack +33; As adult cinder dragon, plus **9th** *detonate magic*, *falling stars* (asteroids only); **8th** *desiccate*, *fireball*, *volcanic eruption*; **7th** *execute*, *fiery body*, *volcanic eruption*; **Cantrips (9th)** *detect magic*, *ignition*, *message*, *read aura*, *sigil*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cataclysm",
+          "aonid": 1460,
+          "game-obj": "Spells",
+          "name": "cataclysm",
+          "type": "link"
+        },
+        {
+          "alt": "indestructibility",
+          "aonid": 1573,
+          "game-obj": "Spells",
+          "name": "indestructibility",
+          "type": "link"
+        },
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        }
+      ],
+      "name": "Cinder Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 118",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 118",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 118,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient cinder dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cataclysm",
+                      "aonid": 1460,
+                      "game-obj": "Spells",
+                      "name": "cataclysm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cataclysm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "indestructibility",
+                      "aonid": 1573,
+                      "game-obj": "Spells",
+                      "name": "indestructibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "indestructibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 45, attack +37; As ancient cinder dragon, plus **10th** *cataclysm*, *indestructibility*; **9th** *massacre*; **Cantrips (10th)** *detect magic*, *ignition*, *message*, *read aura*, *sigil*",
       "type": "section"
     },
     {
@@ -1806,6 +2296,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 118",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 118",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 118,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1953,6 +2499,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 118",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 118",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 118,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/dragon_coral.json
+++ b/monster_families/monster_core_2/dragon_coral.json
@@ -58,245 +58,112 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Athletics",
-                    "aonid": 36,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "grabbed",
-                    "aonid": 77,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Escape",
-                    "aonid": 2296,
-                    "game-obj": "Actions",
-                    "name": "Escape",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drown",
-                    "aonid": 2439,
-                    "game-obj": "Rules",
-                    "name": "drown",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Sustained",
-                    "aonid": 2317,
-                    "game-obj": "Actions",
-                    "name": "Sustained",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grasping Waves",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "saving_throw": [
-                  {
-                    "dc": 30,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 30 Fortitude",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The dragon conjures five watery tentacles from unoccupied water-filled squares of their choice within 30 feet and attempts a single Athletics check against the Fortitude DC of every creature adjacent to a tentacle and no more than 10 feet above the water\u2019s surface. On a success, the creature is grabbed (Escape DC equal to the DC of the dragon\u2019s Hydraulic Breath). On a critical success, or a success against a creature already grabbed, the target is dragged below the surface and begins to drown. All tentacles disappear at the end of the dragon\u2019s next turn unless the effect is Sustained and a new Athletics check is rolled for all existing tentacles.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "water",
-                      "aonid": 732,
-                      "game-obj": "Traits",
-                      "name": "water",
-                      "type": "link"
-                    },
-                    "name": "water",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "poison",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Palytoxin",
-                "subtype": "ability",
-                "text": "Any creature who takes damage from the dragon\u2019s jaws, claws, or tail attack, or who Strikes and does damage to the dragon with an unarmed attack, takes 1d6 poison damage (2d6 for ancient and archdragons) and must attempt a Fortitude saving throw (DC equal to the DC of the dragon\u2019s Hydraulic Breath).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "poison",
-                      "aonid": 669,
-                      "game-obj": "Traits",
-                      "name": "poison",
-                      "type": "link"
-                    },
-                    "name": "poison",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "enfeebled",
-                    "aonid": 71,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature\u2019s enfeebled condition increases by 1 until the end of its next turn, to a maximum of 3. If the creature is already enfeebled 3, it becomes drained 1 instead.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, except the creature\u2019s enfeebled condition increases by 2 instead of 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 50,
-                    "subtype": "area",
-                    "text": "50-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "effect": "The dragon calls tens of thousands of tiny marine creatures from the crevices in their reef, which pour over a 50-foot emanation in a clawing, biting, stinging swarm. Every creature in the area that is fully or partially submerged in water must succeed at a basic Reflex saving throw (DC equal to the DC of the dragon\u2019s Hydraulic Breath) or take piercing damage equal to half that dealt by their Hydraulic Breath and an equivalent amount of poison damage. The dragon can specify any number of creatures within the area to be spared. All summoned creatures disperse at the end of the dragon\u2019s turn.",
-                "frequency": "once per hour",
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  }
-                ],
-                "name": "Primal Tide",
-                "requirement": "The dragon is within the bounds of or no more than 25 feet away from their reef",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 645,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "water",
-                      "aonid": 732,
-                      "game-obj": "Traits",
-                      "name": "water",
-                      "type": "link"
-                    },
-                    "name": "water",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "water",
+                "aonid": 732,
+                "game-obj": "Traits",
+                "name": "water",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 36,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 77,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "Escape",
+                "aonid": 2296,
+                "game-obj": "Actions",
+                "name": "Escape",
+                "type": "link"
+              },
+              {
+                "alt": "drown",
+                "aonid": 2439,
+                "game-obj": "Rules",
+                "name": "drown",
+                "type": "link"
+              },
+              {
+                "alt": "Sustained",
+                "aonid": 2317,
+                "game-obj": "Actions",
+                "name": "Sustained",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled",
+                "aonid": 71,
+                "game-obj": "Conditions",
+                "name": "enfeebled",
+                "type": "link"
+              },
+              {
+                "alt": "drained",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "water",
+                "aonid": 732,
+                "game-obj": "Traits",
+                "name": "water",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -306,302 +173,131 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Some coral dragons can raise massive watery tentacles from the seas around them to pummel or grapple their foes. To make a dragon with this ability, replace Draconic Frenzy with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hydraulic torrent",
-                            "aonid": 1562,
-                            "game-obj": "Spells",
-                            "name": "hydraulic torrent",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vapor form",
-                            "aonid": 1738,
-                            "game-obj": "Spells",
-                            "name": "vapor form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vapor form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "aqueous orb",
-                            "aonid": 1443,
-                            "game-obj": "Spells",
-                            "name": "aqueous orb",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "3rd aqueous orb",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "crashing wave",
-                            "aonid": 1984,
-                            "game-obj": "Spells",
-                            "name": "crashing wave",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "crashing wave",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water breathing",
-                            "aonid": 1755,
-                            "game-obj": "Spells",
-                            "name": "water breathing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water breathing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "water walk",
-                            "aonid": 1756,
-                            "game-obj": "Spells",
-                            "name": "water walk",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "water walk",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "air bubble",
-                            "aonid": 1438,
-                            "game-obj": "Spells",
-                            "name": "air bubble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "air bubble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create water",
-                            "aonid": 1476,
-                            "game-obj": "Spells",
-                            "name": "create water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tailwind",
-                            "aonid": 1711,
-                            "game-obj": "Spells",
-                            "name": "tailwind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tailwind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 2624,
-                            "game-obj": "Actions",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "know the way",
-                            "aonid": 1582,
-                            "game-obj": "Spells",
-                            "name": "know the way",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spout",
-                            "aonid": 2031,
-                            "game-obj": "Spells",
-                            "name": "spout",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 1689,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Coral Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "hydraulic torrent",
+                "aonid": 1562,
+                "game-obj": "Spells",
+                "name": "hydraulic torrent",
+                "type": "link"
+              },
+              {
+                "alt": "vapor form",
+                "aonid": 1738,
+                "game-obj": "Spells",
+                "name": "vapor form",
+                "type": "link"
+              },
+              {
+                "alt": "aqueous orb",
+                "aonid": 1443,
+                "game-obj": "Spells",
+                "name": "aqueous orb",
+                "type": "link"
+              },
+              {
+                "alt": "crashing wave",
+                "aonid": 1984,
+                "game-obj": "Spells",
+                "name": "crashing wave",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "water breathing",
+                "aonid": 1755,
+                "game-obj": "Spells",
+                "name": "water breathing",
+                "type": "link"
+              },
+              {
+                "alt": "water walk",
+                "aonid": 1756,
+                "game-obj": "Spells",
+                "name": "water walk",
+                "type": "link"
+              },
+              {
+                "alt": "air bubble",
+                "aonid": 1438,
+                "game-obj": "Spells",
+                "name": "air bubble",
+                "type": "link"
+              },
+              {
+                "alt": "create water",
+                "aonid": 1476,
+                "game-obj": "Spells",
+                "name": "create water",
+                "type": "link"
+              },
+              {
+                "alt": "tailwind",
+                "aonid": 1711,
+                "game-obj": "Spells",
+                "name": "tailwind",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 2624,
+                "game-obj": "Actions",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "know the way",
+                "aonid": 1582,
+                "game-obj": "Spells",
+                "name": "know the way",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "spout",
+                "aonid": 2031,
+                "game-obj": "Spells",
+                "name": "spout",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 1689,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -617,192 +313,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As young coral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 32,
-                  "subtype": "save_dc",
-                  "text": "DC 32",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chameleon coat",
-                            "aonid": 1973,
-                            "game-obj": "Spells",
-                            "name": "chameleon coat",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chameleon coat",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "petrify",
-                            "aonid": 1628,
-                            "game-obj": "Spells",
-                            "name": "petrify",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "petrify",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "control water",
-                            "aonid": 1473,
-                            "game-obj": "Spells",
-                            "name": "control water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "control water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "crashing wave",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mariner\u2019s curse",
-                            "aonid": 1593,
-                            "game-obj": "Spells",
-                            "name": "mariner\u2019s curse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mariner\u2019s curse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mirage",
-                            "aonid": 1604,
-                            "game-obj": "Spells",
-                            "name": "mirage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mirage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count_text": "nature only",
-                        "links": [
-                          {
-                            "alt": "commune",
-                            "aonid": 114,
-                            "game-obj": "Rituals",
-                            "name": "commune",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "commune",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Coral Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "chameleon coat",
+                "aonid": 1973,
+                "game-obj": "Spells",
+                "name": "chameleon coat",
+                "type": "link"
+              },
+              {
+                "alt": "petrify",
+                "aonid": 1628,
+                "game-obj": "Spells",
+                "name": "petrify",
+                "type": "link"
+              },
+              {
+                "alt": "control water",
+                "aonid": 1473,
+                "game-obj": "Spells",
+                "name": "control water",
+                "type": "link"
+              },
+              {
+                "alt": "mariner\u2019s curse",
+                "aonid": 1593,
+                "game-obj": "Spells",
+                "name": "mariner\u2019s curse",
+                "type": "link"
+              },
+              {
+                "alt": "mirage",
+                "aonid": 1604,
+                "game-obj": "Spells",
+                "name": "mirage",
+                "type": "link"
+              },
+              {
+                "alt": "commune",
+                "aonid": 114,
+                "game-obj": "Rituals",
+                "name": "commune",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -818,195 +377,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As adult coral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "crashing wave",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "desiccate",
-                            "aonid": 1484,
-                            "game-obj": "Spells",
-                            "name": "desiccate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "desiccate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 1607,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "hydraulic torrent",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered pack",
-                            "aonid": 1733,
-                            "game-obj": "Spells",
-                            "name": "unfettered pack",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered pack",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count_text": "nature only",
-                        "name": "commune",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "control weather",
-                            "aonid": 116,
-                            "game-obj": "Rituals",
-                            "name": "control weather",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "control weather",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Coral Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "desiccate",
+                "aonid": 1484,
+                "game-obj": "Spells",
+                "name": "desiccate",
+                "type": "link"
+              },
+              {
+                "alt": "moment of renewal",
+                "aonid": 1607,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered pack",
+                "aonid": 1733,
+                "game-obj": "Spells",
+                "name": "unfettered pack",
+                "type": "link"
+              },
+              {
+                "alt": "control weather",
+                "aonid": 116,
+                "game-obj": "Rituals",
+                "name": "control weather",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1022,145 +434,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Primal Prepared Spells",
-                "notes": [
-                  "As ancient coral dragon"
-                ],
-                "saving_throw": {
-                  "dc": 44,
-                  "subtype": "save_dc",
-                  "text": "DC 44",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 36,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nature incarnate",
-                            "aonid": 1612,
-                            "game-obj": "Spells",
-                            "name": "nature incarnate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nature incarnate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wrathful storm",
-                            "aonid": 1759,
-                            "game-obj": "Spells",
-                            "name": "wrathful storm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wrathful storm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "know the way",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "spout",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 0,
-                    "level_text": "Rituals",
-                    "spells": [
-                      {
-                        "count_text": "Nature only",
-                        "name": "commune",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "control weather",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Primal",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Coral Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "nature incarnate",
+                "aonid": 1612,
+                "game-obj": "Spells",
+                "name": "nature incarnate",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "wrathful storm",
+                "aonid": 1759,
+                "game-obj": "Spells",
+                "name": "wrathful storm",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1175,48 +476,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1227,263 +491,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1493,7 +541,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1502,6 +549,358 @@
   "name": "Dragon, Coral",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "Athletics",
+              "aonid": 36,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "grabbed",
+              "aonid": 77,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "Escape",
+              "aonid": 2296,
+              "game-obj": "Actions",
+              "name": "Escape",
+              "type": "link"
+            },
+            {
+              "alt": "drown",
+              "aonid": 2439,
+              "game-obj": "Rules",
+              "name": "drown",
+              "type": "link"
+            },
+            {
+              "alt": "Sustained",
+              "aonid": 2317,
+              "game-obj": "Actions",
+              "name": "Sustained",
+              "type": "link"
+            }
+          ],
+          "name": "Grasping Waves",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "within 30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "saving_throw": [
+            {
+              "dc": 30,
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "DC 30 Fortitude",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The dragon conjures five watery tentacles from unoccupied water-filled squares of their choice within 30 feet and attempts a single Athletics check against the Fortitude DC of every creature adjacent to a tentacle and no more than 10 feet above the water\u2019s surface. On a success, the creature is grabbed (Escape DC equal to the DC of the dragon\u2019s Hydraulic Breath). On a critical success, or a success against a creature already grabbed, the target is dragged below the surface and begins to drown. All tentacles disappear at the end of the dragon\u2019s next turn unless the effect is Sustained and a new Athletics check is rolled for all existing tentacles.",
+          "traits": [
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "water",
+                "aonid": 732,
+                "game-obj": "Traits",
+                "name": "water",
+                "type": "link"
+              },
+              "name": "water",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "poison",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Palytoxin",
+          "subtype": "ability",
+          "text": "Any creature who takes damage from the dragon\u2019s jaws, claws, or tail attack, or who Strikes and does damage to the dragon with an unarmed attack, takes 1d6 poison damage (2d6 for ancient and archdragons) and must attempt a Fortitude saving throw (DC equal to the DC of the dragon\u2019s Hydraulic Breath).",
+          "traits": [
+            {
+              "link": {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              "name": "poison",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "enfeebled",
+              "aonid": 71,
+              "game-obj": "Conditions",
+              "name": "enfeebled",
+              "type": "link"
+            },
+            {
+              "alt": "drained",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained",
+              "type": "link"
+            }
+          ],
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature\u2019s enfeebled condition increases by 1 until the end of its next turn, to a maximum of 3. If the creature is already enfeebled 3, it becomes drained 1 instead.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, except the creature\u2019s enfeebled condition increases by 2 instead of 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 50,
+              "subtype": "area",
+              "text": "50-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "effect": "The dragon calls tens of thousands of tiny marine creatures from the crevices in their reef, which pour over a 50-foot emanation in a clawing, biting, stinging swarm. Every creature in the area that is fully or partially submerged in water must succeed at a basic Reflex saving throw (DC equal to the DC of the dragon\u2019s Hydraulic Breath) or take piercing damage equal to half that dealt by their Hydraulic Breath and an equivalent amount of poison damage. The dragon can specify any number of creatures within the area to be spared. All summoned creatures disperse at the end of the dragon\u2019s turn.",
+          "frequency": "once per hour",
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            }
+          ],
+          "name": "Primal Tide",
+          "requirement": "The dragon is within the bounds of or no more than 25 feet away from their reef",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              "name": "manipulate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "water",
+                "aonid": 732,
+                "game-obj": "Traits",
+                "name": "water",
+                "type": "link"
+              },
+              "name": "water",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "water",
+          "aonid": 732,
+          "game-obj": "Traits",
+          "name": "water",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 36,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "grabbed",
+          "aonid": 77,
+          "game-obj": "Conditions",
+          "name": "grabbed",
+          "type": "link"
+        },
+        {
+          "alt": "Escape",
+          "aonid": 2296,
+          "game-obj": "Actions",
+          "name": "Escape",
+          "type": "link"
+        },
+        {
+          "alt": "drown",
+          "aonid": 2439,
+          "game-obj": "Rules",
+          "name": "drown",
+          "type": "link"
+        },
+        {
+          "alt": "Sustained",
+          "aonid": 2317,
+          "game-obj": "Actions",
+          "name": "Sustained",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "enfeebled",
+          "aonid": 71,
+          "game-obj": "Conditions",
+          "name": "enfeebled",
+          "type": "link"
+        },
+        {
+          "alt": "drained",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 645,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "water",
+          "aonid": 732,
+          "game-obj": "Traits",
+          "name": "water",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 120",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 120",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 120,
+          "type": "source"
+        }
+      ],
+      "text": "Some coral dragons can raise massive watery tentacles from the seas around them to pummel or grapple their foes. To make a dragon with this ability, replace Draconic Frenzy with the following.   \n  \n**Grasping Waves** [##] (primal, water) The dragon conjures five watery tentacles from unoccupied water-filled squares of their choice within 30 feet and attempts a single Athletics check against the Fortitude DC of every creature adjacent to a tentacle and no more than 10 feet above the water\u2019s surface. On a success, the creature is grabbed (Escape DC equal to the DC of the dragon\u2019s Hydraulic Breath). On a critical success, or a success against a creature already grabbed, the target is dragged below the surface and begins to drown. All tentacles disappear at the end of the dragon\u2019s next turn unless the effect is Sustained and a new Athletics check is rolled for all existing tentacles.   \n  \nThe growths covering a coral dragon\u2019s body can include many different species, some of which produce a potent natural poison. To make a dragon with this ability, replace Biomineralize with the following.   \n  \n**Palytoxin** (poison) Any creature who takes damage from the dragon\u2019s jaws, claws, or tail attack, or who Strikes and does damage to the dragon with an unarmed attack, takes 1d6 poison damage (2d6 for ancient and archdragons) and must attempt a Fortitude saving throw (DC equal to the DC of the dragon\u2019s Hydraulic Breath).   \n**Success** The creature is unaffected.   \n**Failure** The creature\u2019s enfeebled condition increases by 1 until the end of its next turn, to a maximum of 3. If the creature is already enfeebled 3, it becomes drained 1 instead.   \n**Critical Failure** As failure, except the creature\u2019s enfeebled condition increases by 2 instead of 1.   \n  \nThe most powerful coral dragons can call upon the innumerable tiny creatures dwelling within their reefs for aid. To make a dragon with this ability, replace an ancient or archdragon\u2019s Reef Armor with the following.   \n  \n**Primal Tide** [###] (concentrate, manipulate, water) **Requirements** The dragon is within the bounds of or no more than 25 feet away from their reef; **Frequency** once per hour; **Effect** The dragon calls tens of thousands of tiny marine creatures from the crevices in their reef, which pour over a 50-foot emanation in a clawing, biting, stinging swarm. Every creature in the area that is fully or partially submerged in water must succeed at a basic Reflex saving throw (DC equal to the DC of the dragon\u2019s Hydraulic Breath) or take piercing damage equal to half that dealt by their Hydraulic Breath and an equivalent amount of poison damage. The dragon can specify any number of creatures within the area to be spared. All summoned creatures disperse at the end of the dragon\u2019s turn.",
+      "type": "section"
+    },
     {
       "name": "Coral Dragon Spellcasting",
       "sources": [
@@ -1519,6 +918,1111 @@
         }
       ],
       "text": "Coral dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "hydraulic torrent",
+          "aonid": 1562,
+          "game-obj": "Spells",
+          "name": "hydraulic torrent",
+          "type": "link"
+        },
+        {
+          "alt": "vapor form",
+          "aonid": 1738,
+          "game-obj": "Spells",
+          "name": "vapor form",
+          "type": "link"
+        },
+        {
+          "alt": "aqueous orb",
+          "aonid": 1443,
+          "game-obj": "Spells",
+          "name": "aqueous orb",
+          "type": "link"
+        },
+        {
+          "alt": "crashing wave",
+          "aonid": 1984,
+          "game-obj": "Spells",
+          "name": "crashing wave",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "water breathing",
+          "aonid": 1755,
+          "game-obj": "Spells",
+          "name": "water breathing",
+          "type": "link"
+        },
+        {
+          "alt": "water walk",
+          "aonid": 1756,
+          "game-obj": "Spells",
+          "name": "water walk",
+          "type": "link"
+        },
+        {
+          "alt": "air bubble",
+          "aonid": 1438,
+          "game-obj": "Spells",
+          "name": "air bubble",
+          "type": "link"
+        },
+        {
+          "alt": "create water",
+          "aonid": 1476,
+          "game-obj": "Spells",
+          "name": "create water",
+          "type": "link"
+        },
+        {
+          "alt": "tailwind",
+          "aonid": 1711,
+          "game-obj": "Spells",
+          "name": "tailwind",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 2624,
+          "game-obj": "Actions",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "know the way",
+          "aonid": 1582,
+          "game-obj": "Spells",
+          "name": "know the way",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "spout",
+          "aonid": 2031,
+          "game-obj": "Spells",
+          "name": "spout",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 1689,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Young Coral Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 120",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 120",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 120,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hydraulic torrent",
+                      "aonid": 1562,
+                      "game-obj": "Spells",
+                      "name": "hydraulic torrent",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vapor form",
+                      "aonid": 1738,
+                      "game-obj": "Spells",
+                      "name": "vapor form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vapor form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "aqueous orb",
+                      "aonid": 1443,
+                      "game-obj": "Spells",
+                      "name": "aqueous orb",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "3rd aqueous orb",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "crashing wave",
+                      "aonid": 1984,
+                      "game-obj": "Spells",
+                      "name": "crashing wave",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "crashing wave",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water breathing",
+                      "aonid": 1755,
+                      "game-obj": "Spells",
+                      "name": "water breathing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water breathing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "water walk",
+                      "aonid": 1756,
+                      "game-obj": "Spells",
+                      "name": "water walk",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "water walk",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "air bubble",
+                      "aonid": 1438,
+                      "game-obj": "Spells",
+                      "name": "air bubble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "air bubble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create water",
+                      "aonid": 1476,
+                      "game-obj": "Spells",
+                      "name": "create water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tailwind",
+                      "aonid": 1711,
+                      "game-obj": "Spells",
+                      "name": "tailwind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tailwind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 2624,
+                      "game-obj": "Actions",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "know the way",
+                      "aonid": 1582,
+                      "game-obj": "Spells",
+                      "name": "know the way",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spout",
+                      "aonid": 2031,
+                      "game-obj": "Spells",
+                      "name": "spout",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 1689,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 26, attack +18; **4th** *hydraulic torrent*, *vapor form*, **3rd** *aqueous orb*, *crashing wave*, *slow*; **2nd** *mist*, *water breathing*, *water walk*; **1st** *air bubble*, *create water*, *tailwind*; **Cantrips (4th)** detect magic, *know the way*, *prestidigitation*, *spout*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "chameleon coat",
+          "aonid": 1973,
+          "game-obj": "Spells",
+          "name": "chameleon coat",
+          "type": "link"
+        },
+        {
+          "alt": "petrify",
+          "aonid": 1628,
+          "game-obj": "Spells",
+          "name": "petrify",
+          "type": "link"
+        },
+        {
+          "alt": "control water",
+          "aonid": 1473,
+          "game-obj": "Spells",
+          "name": "control water",
+          "type": "link"
+        },
+        {
+          "alt": "mariner\u2019s curse",
+          "aonid": 1593,
+          "game-obj": "Spells",
+          "name": "mariner\u2019s curse",
+          "type": "link"
+        },
+        {
+          "alt": "mirage",
+          "aonid": 1604,
+          "game-obj": "Spells",
+          "name": "mirage",
+          "type": "link"
+        },
+        {
+          "alt": "commune",
+          "aonid": 114,
+          "game-obj": "Rituals",
+          "name": "commune",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Coral Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 120",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 120",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 120,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As young coral dragon"
+          ],
+          "saving_throw": {
+            "dc": 32,
+            "subtype": "save_dc",
+            "text": "DC 32",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chameleon coat",
+                      "aonid": 1973,
+                      "game-obj": "Spells",
+                      "name": "chameleon coat",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chameleon coat",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "petrify",
+                      "aonid": 1628,
+                      "game-obj": "Spells",
+                      "name": "petrify",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "petrify",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "control water",
+                      "aonid": 1473,
+                      "game-obj": "Spells",
+                      "name": "control water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "control water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "crashing wave",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mariner\u2019s curse",
+                      "aonid": 1593,
+                      "game-obj": "Spells",
+                      "name": "mariner\u2019s curse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mariner\u2019s curse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mirage",
+                      "aonid": 1604,
+                      "game-obj": "Spells",
+                      "name": "mirage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mirage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count_text": "nature only",
+                  "links": [
+                    {
+                      "alt": "commune",
+                      "aonid": 114,
+                      "game-obj": "Rituals",
+                      "name": "commune",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "commune",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 32, attack +24; As young coral dragon, plus **6th** *chameleon coat*, *petrify*; **5th** *control water*, *crashing wave*, *mariner\u2019s curse*; **4th** *mirage*; **Cantrips (6th)** *detect magic*, *know the way*, *prestidigitation*, *spout*, *stabilize*; **Rituals** DC 32; *commune* (nature only)",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "desiccate",
+          "aonid": 1484,
+          "game-obj": "Spells",
+          "name": "desiccate",
+          "type": "link"
+        },
+        {
+          "alt": "moment of renewal",
+          "aonid": 1607,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered pack",
+          "aonid": 1733,
+          "game-obj": "Spells",
+          "name": "unfettered pack",
+          "type": "link"
+        },
+        {
+          "alt": "control weather",
+          "aonid": 116,
+          "game-obj": "Rituals",
+          "name": "control weather",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Coral Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 120",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 120",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 120,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As adult coral dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "crashing wave",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "desiccate",
+                      "aonid": 1484,
+                      "game-obj": "Spells",
+                      "name": "desiccate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "desiccate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 1607,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "hydraulic torrent",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered pack",
+                      "aonid": 1733,
+                      "game-obj": "Spells",
+                      "name": "unfettered pack",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered pack",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count_text": "nature only",
+                  "name": "commune",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "control weather",
+                      "aonid": 116,
+                      "game-obj": "Rituals",
+                      "name": "control weather",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "control weather",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 38, attack +30; As adult coral dragon, plus **8th** *crashing wave*, *desiccate*, *moment of renewal*; **7th** *hydraulic torrent*, *regenerate*, *unfettered pack*; **6th** *slow*; **Cantrips (8th)** *detect magic*, *know the way*, *prestidigitation*, *spout*, *stabilize*; **Rituals** DC 38; *commune* (nature only), control weather",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "nature incarnate",
+          "aonid": 1612,
+          "game-obj": "Spells",
+          "name": "nature incarnate",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "wrathful storm",
+          "aonid": 1759,
+          "game-obj": "Spells",
+          "name": "wrathful storm",
+          "type": "link"
+        }
+      ],
+      "name": "Coral Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 120",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 120",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 120,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Primal Prepared Spells",
+          "notes": [
+            "As ancient coral dragon"
+          ],
+          "saving_throw": {
+            "dc": 44,
+            "subtype": "save_dc",
+            "text": "DC 44",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 36,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nature incarnate",
+                      "aonid": 1612,
+                      "game-obj": "Spells",
+                      "name": "nature incarnate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nature incarnate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wrathful storm",
+                      "aonid": 1759,
+                      "game-obj": "Spells",
+                      "name": "wrathful storm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wrathful storm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "know the way",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "spout",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 0,
+              "level_text": "Rituals",
+              "spells": [
+                {
+                  "count_text": "Nature only",
+                  "name": "commune",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "control weather",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Primal",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Primal Prepared Spells** DC 44, attack +36; As ancient coral dragon plus **10th** *nature incarnate*; **9th** *implosion*, *wrathful storm*; **Cantrips (10th)** *detect magic*, *know the way*, *prestidigitation*, *spout*, *stabilize*; **Rituals** DC 44; *commune (Nature only)*, *control weather*",
       "type": "section"
     },
     {
@@ -1852,6 +2356,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 120",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 120",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 120,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1999,6 +2559,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 120",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 120",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 120,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/dragon_despair.json
+++ b/monster_families/monster_core_2/dragon_despair.json
@@ -58,259 +58,133 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "frightened",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Manifest Fear",
-                "subtype": "ability",
-                "text": "The despair dragon creates an illusory image of a creature referenced in local superstition. This functions as illusory creature, heightened to a rank equal to half the dragon\u2019s level. The damage die of the illusory creature\u2019s Strikes increases to d6s against creatures with the frightened condition. Some despair dragons can implant false memories in the minds of others. To make a dragon with this ability, replace Draconic Momentum with the following.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 541,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 629,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 645,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "olfactory",
-                      "aonid": 664,
-                      "game-obj": "Traits",
-                      "name": "olfactory",
-                      "type": "link"
-                    },
-                    "name": "olfactory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Cursed Memories",
-                "range": {
-                  "range": 90,
-                  "subtype": "range",
-                  "text": "90 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "Creatures near a despair dragon can't trust their own minds. When any creature in the aura attempts a skill check to Recall Knowledge, they must roll twice and take the lower result.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "misfortune",
-                      "aonid": 654,
-                      "game-obj": "Traits",
-                      "name": "misfortune",
-                      "type": "link"
-                    },
-                    "name": "misfortune",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "torch",
-                    "aonid": 2760,
-                    "game-obj": "Equipment",
-                    "name": "torch",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "lantern",
-                    "aonid": 2730,
-                    "game-obj": "Equipment",
-                    "name": "lantern",
-                    "type": "link"
-                  }
-                ],
-                "name": "Lights Out",
-                "subtype": "ability",
-                "text": "The despair dragon belches an impenetrable darkness that encompasses a 30-foot emanation. Light does not enter the area and any non-magical light sources, such as a torch or lantern, do not emanate any light while inside the area, even if their light radius would extend beyond the darkness. This also suppresses magical light of a spell rank equal to half the dragon's level or lower. Light can't pass through, so all creatures in the area except for the dragon can't see outside.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "darkness",
-                      "aonid": 569,
-                      "game-obj": "Traits",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    "name": "darkness",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "olfactory",
+                "aonid": 664,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "frightened",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "misfortune",
+                "aonid": 654,
+                "game-obj": "Traits",
+                "name": "misfortune",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 569,
+                "game-obj": "Traits",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "torch",
+                "aonid": 2760,
+                "game-obj": "Equipment",
+                "name": "torch",
+                "type": "link"
+              },
+              {
+                "alt": "lantern",
+                "aonid": 2730,
+                "game-obj": "Equipment",
+                "name": "lantern",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -320,334 +194,138 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Despair dragons can develop different ways of using fear to their advantage. You can apply the following adjustments to a despair dragon of any age.  \n  \nDespair dragons who specialize in whipping a populace into hysteria using urban legends and regional fears can shape this terror into a semi-physical form. To make a dragon with this ability, replace Unbidden Thoughts with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "darkness",
-                            "aonid": 1480,
-                            "game-obj": "Spells",
-                            "name": "darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nightmare",
-                            "aonid": 1615,
-                            "game-obj": "Spells",
-                            "name": "nightmare",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nightmare",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mind reading",
-                            "aonid": 1602,
-                            "game-obj": "Spells",
-                            "name": "mind reading",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mind reading",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "noise blast",
-                            "aonid": 1616,
-                            "game-obj": "Spells",
-                            "name": "noise blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "noise blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "paranoia",
-                            "aonid": 1623,
-                            "game-obj": "Spells",
-                            "name": "paranoia",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "paranoia",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stupefy",
-                            "aonid": 1691,
-                            "game-obj": "Spells",
-                            "name": "stupefy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stupefy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ventriloquism",
-                            "aonid": 1740,
-                            "game-obj": "Spells",
-                            "name": "ventriloquism",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ventriloquism",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ill omen",
-                            "aonid": 1566,
-                            "game-obj": "Spells",
-                            "name": "ill omen",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ill omen",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sleep",
-                            "aonid": 1675,
-                            "game-obj": "Spells",
-                            "name": "sleep",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sleep",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect scrying",
-                            "aonid": 1487,
-                            "game-obj": "Spells",
-                            "name": "detect scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haunting hymn",
-                            "aonid": 1999,
-                            "game-obj": "Spells",
-                            "name": "haunting hymn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 1718,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Despair Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "nightmare",
+                "aonid": 1615,
+                "game-obj": "Spells",
+                "name": "nightmare",
+                "type": "link"
+              },
+              {
+                "alt": "mind reading",
+                "aonid": 1602,
+                "game-obj": "Spells",
+                "name": "mind reading",
+                "type": "link"
+              },
+              {
+                "alt": "noise blast",
+                "aonid": 1616,
+                "game-obj": "Spells",
+                "name": "noise blast",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "paranoia",
+                "aonid": 1623,
+                "game-obj": "Spells",
+                "name": "paranoia",
+                "type": "link"
+              },
+              {
+                "alt": "stupefy",
+                "aonid": 1691,
+                "game-obj": "Spells",
+                "name": "stupefy",
+                "type": "link"
+              },
+              {
+                "alt": "ventriloquism",
+                "aonid": 1740,
+                "game-obj": "Spells",
+                "name": "ventriloquism",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "ill omen",
+                "aonid": 1566,
+                "game-obj": "Spells",
+                "name": "ill omen",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 1675,
+                "game-obj": "Spells",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "detect scrying",
+                "aonid": 1487,
+                "game-obj": "Spells",
+                "name": "detect scrying",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "haunting hymn",
+                "aonid": 1999,
+                "game-obj": "Spells",
+                "name": "haunting hymn",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 1718,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -663,169 +341,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young despair dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mislead",
-                            "aonid": 1605,
-                            "game-obj": "Spells",
-                            "name": "mislead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mislead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal calamity",
-                            "aonid": 1630,
-                            "game-obj": "Spells",
-                            "name": "phantasmal calamity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal calamity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "strange geometry",
-                            "aonid": 2032,
-                            "game-obj": "Spells",
-                            "name": "strange geometry",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "strange geometry",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "synaptic pulse",
-                            "aonid": 1710,
-                            "game-obj": "Spells",
-                            "name": "synaptic pulse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "synaptic pulse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wave of despair",
-                            "aonid": 1757,
-                            "game-obj": "Spells",
-                            "name": "wave of despair",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wave of despair",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Despair Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mislead",
+                "aonid": 1605,
+                "game-obj": "Spells",
+                "name": "mislead",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal calamity",
+                "aonid": 1630,
+                "game-obj": "Spells",
+                "name": "phantasmal calamity",
+                "type": "link"
+              },
+              {
+                "alt": "strange geometry",
+                "aonid": 2032,
+                "game-obj": "Spells",
+                "name": "strange geometry",
+                "type": "link"
+              },
+              {
+                "alt": "synaptic pulse",
+                "aonid": 1710,
+                "game-obj": "Spells",
+                "name": "synaptic pulse",
+                "type": "link"
+              },
+              {
+                "alt": "wave of despair",
+                "aonid": 1757,
+                "game-obj": "Spells",
+                "name": "wave of despair",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -841,184 +398,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult despair dragon"
-                ],
-                "saving_throw": {
-                  "dc": 40,
-                  "subtype": "save_dc",
-                  "text": "DC 40",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "canticle of everlasting grief",
-                            "aonid": 1459,
-                            "game-obj": "Spells",
-                            "name": "canticle of everlasting grief",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "canticle of everlasting grief",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mask of terror",
-                            "aonid": 1595,
-                            "game-obj": "Spells",
-                            "name": "mask of terror",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mask of terror",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "visions of danger",
-                            "aonid": 2040,
-                            "game-obj": "Spells",
-                            "name": "visions of danger",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "visions of danger",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "wave of despair",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scrying",
-                            "aonid": 1662,
-                            "game-obj": "Spells",
-                            "name": "scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectileo",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Despair Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "canticle of everlasting grief",
+                "aonid": 1459,
+                "game-obj": "Spells",
+                "name": "canticle of everlasting grief",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
+              },
+              {
+                "alt": "mask of terror",
+                "aonid": 1595,
+                "game-obj": "Spells",
+                "name": "mask of terror",
+                "type": "link"
+              },
+              {
+                "alt": "visions of danger",
+                "aonid": 2040,
+                "game-obj": "Spells",
+                "name": "visions of danger",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 1662,
+                "game-obj": "Spells",
+                "name": "scrying",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1034,140 +462,41 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient despair dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fabricated truth",
-                            "aonid": 1520,
-                            "game-obj": "Spells",
-                            "name": "fabricated truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fabricated truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmagoria",
-                            "aonid": 1629,
-                            "game-obj": "Spells",
-                            "name": "phantasmagoria",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmagoria",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wails of the damned",
-                            "aonid": 1747,
-                            "game-obj": "Spells",
-                            "name": "wails of the damned",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wails of the damned",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Despair Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fabricated truth",
+                "aonid": 1520,
+                "game-obj": "Spells",
+                "name": "fabricated truth",
+                "type": "link"
+              },
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmagoria",
+                "aonid": 1629,
+                "game-obj": "Spells",
+                "name": "phantasmagoria",
+                "type": "link"
+              },
+              {
+                "alt": "wails of the damned",
+                "aonid": 1747,
+                "game-obj": "Spells",
+                "name": "wails of the damned",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1182,48 +511,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1234,263 +526,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1500,7 +576,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1509,6 +584,393 @@
   "name": "Dragon, Despair",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "frightened",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened",
+              "type": "link"
+            }
+          ],
+          "name": "Manifest Fear",
+          "subtype": "ability",
+          "text": "The despair dragon creates an illusory image of a creature referenced in local superstition. This functions as illusory creature, heightened to a rank equal to half the dragon\u2019s level. The damage die of the illusory creature\u2019s Strikes increases to d6s against creatures with the frightened condition. Some despair dragons can implant false memories in the minds of others. To make a dragon with this ability, replace Draconic Momentum with the following.",
+          "traits": [
+            {
+              "link": {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              "name": "auditory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              "name": "illusion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              "name": "manipulate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "olfactory",
+                "aonid": 664,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              "name": "olfactory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Cursed Memories",
+          "range": {
+            "range": 90,
+            "subtype": "range",
+            "text": "90 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "Creatures near a despair dragon can't trust their own minds. When any creature in the aura attempts a skill check to Recall Knowledge, they must roll twice and take the lower result.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "misfortune",
+                "aonid": 654,
+                "game-obj": "Traits",
+                "name": "misfortune",
+                "type": "link"
+              },
+              "name": "misfortune",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "torch",
+              "aonid": 2760,
+              "game-obj": "Equipment",
+              "name": "torch",
+              "type": "link"
+            },
+            {
+              "alt": "lantern",
+              "aonid": 2730,
+              "game-obj": "Equipment",
+              "name": "lantern",
+              "type": "link"
+            }
+          ],
+          "name": "Lights Out",
+          "subtype": "ability",
+          "text": "The despair dragon belches an impenetrable darkness that encompasses a 30-foot emanation. Light does not enter the area and any non-magical light sources, such as a torch or lantern, do not emanate any light while inside the area, even if their light radius would extend beyond the darkness. This also suppresses magical light of a spell rank equal to half the dragon's level or lower. Light can't pass through, so all creatures in the area except for the dragon can't see outside.",
+          "traits": [
+            {
+              "link": {
+                "alt": "darkness",
+                "aonid": 569,
+                "game-obj": "Traits",
+                "name": "darkness",
+                "type": "link"
+              },
+              "name": "darkness",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "auditory",
+          "aonid": 541,
+          "game-obj": "Traits",
+          "name": "auditory",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "illusion",
+          "aonid": 629,
+          "game-obj": "Traits",
+          "name": "illusion",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 645,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "olfactory",
+          "aonid": 664,
+          "game-obj": "Traits",
+          "name": "olfactory",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "frightened",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "misfortune",
+          "aonid": 654,
+          "game-obj": "Traits",
+          "name": "misfortune",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "darkness",
+          "aonid": 569,
+          "game-obj": "Traits",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "torch",
+          "aonid": 2760,
+          "game-obj": "Equipment",
+          "name": "torch",
+          "type": "link"
+        },
+        {
+          "alt": "lantern",
+          "aonid": 2730,
+          "game-obj": "Equipment",
+          "name": "lantern",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 122",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 122",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 122,
+          "type": "source"
+        }
+      ],
+      "text": "Despair dragons can develop different ways of using fear to their advantage. You can apply the following adjustments to a despair dragon of any age.  \n  \nDespair dragons who specialize in whipping a populace into hysteria using urban legends and regional fears can shape this terror into a semi-physical form. To make a dragon with this ability, replace Unbidden Thoughts with the following.  \n  \n**Manifest Fear** [##] (auditory, concentrate, illusion, manipulate, mental, olfactory, visual) The despair dragon creates an illusory image of a creature referenced in local superstition. This functions as illusory creature, heightened to a rank equal to half the dragon\u2019s level. The damage die of the illusory creature\u2019s Strikes increases to d6s against creatures with the frightened condition. Some despair dragons can implant false memories in the minds of others. To make a dragon with this ability, replace Draconic Momentum with the following.   \n  \n**Cursed Memories** (aura, mental, misfortune, occult) 90 feet. Creatures near a despair dragon can't trust their own minds. When any creature in the aura attempts a skill check to Recall Knowledge, they must roll twice and take the lower result.  \n  \nThe best place to sow fear is from the shadows. To make a dragon with this ability, replace Draconic Frenzy with the following.  \n  \n**Lights Out** [##] (darkness, occult) The despair dragon belches an impenetrable darkness that encompasses a 30-foot emanation. Light does not enter the area and any non-magical light sources, such as a torch or lantern, do not emanate any light while inside the area, even if their light radius would extend beyond the darkness. This also suppresses magical light of a spell rank equal to half the dragon's level or lower. Light can't pass through, so all creatures in the area except for the dragon can't see outside.",
+      "type": "section"
+    },
     {
       "name": "Despair Dragon Spellcasting",
       "sources": [
@@ -1526,6 +988,1118 @@
         }
       ],
       "text": "Despair dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "darkness",
+          "aonid": 1480,
+          "game-obj": "Spells",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "nightmare",
+          "aonid": 1615,
+          "game-obj": "Spells",
+          "name": "nightmare",
+          "type": "link"
+        },
+        {
+          "alt": "mind reading",
+          "aonid": 1602,
+          "game-obj": "Spells",
+          "name": "mind reading",
+          "type": "link"
+        },
+        {
+          "alt": "noise blast",
+          "aonid": 1616,
+          "game-obj": "Spells",
+          "name": "noise blast",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "paranoia",
+          "aonid": 1623,
+          "game-obj": "Spells",
+          "name": "paranoia",
+          "type": "link"
+        },
+        {
+          "alt": "stupefy",
+          "aonid": 1691,
+          "game-obj": "Spells",
+          "name": "stupefy",
+          "type": "link"
+        },
+        {
+          "alt": "ventriloquism",
+          "aonid": 1740,
+          "game-obj": "Spells",
+          "name": "ventriloquism",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "ill omen",
+          "aonid": 1566,
+          "game-obj": "Spells",
+          "name": "ill omen",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 1675,
+          "game-obj": "Spells",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "detect scrying",
+          "aonid": 1487,
+          "game-obj": "Spells",
+          "name": "detect scrying",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "haunting hymn",
+          "aonid": 1999,
+          "game-obj": "Spells",
+          "name": "haunting hymn",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 1718,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Young Despair Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 122",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 122",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 122,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "darkness",
+                      "aonid": 1480,
+                      "game-obj": "Spells",
+                      "name": "darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nightmare",
+                      "aonid": 1615,
+                      "game-obj": "Spells",
+                      "name": "nightmare",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nightmare",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mind reading",
+                      "aonid": 1602,
+                      "game-obj": "Spells",
+                      "name": "mind reading",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mind reading",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "noise blast",
+                      "aonid": 1616,
+                      "game-obj": "Spells",
+                      "name": "noise blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "noise blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "paranoia",
+                      "aonid": 1623,
+                      "game-obj": "Spells",
+                      "name": "paranoia",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "paranoia",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stupefy",
+                      "aonid": 1691,
+                      "game-obj": "Spells",
+                      "name": "stupefy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stupefy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ventriloquism",
+                      "aonid": 1740,
+                      "game-obj": "Spells",
+                      "name": "ventriloquism",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ventriloquism",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ill omen",
+                      "aonid": 1566,
+                      "game-obj": "Spells",
+                      "name": "ill omen",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ill omen",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sleep",
+                      "aonid": 1675,
+                      "game-obj": "Spells",
+                      "name": "sleep",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sleep",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect scrying",
+                      "aonid": 1487,
+                      "game-obj": "Spells",
+                      "name": "detect scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haunting hymn",
+                      "aonid": 1999,
+                      "game-obj": "Spells",
+                      "name": "haunting hymn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 1718,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 28, attack +20; **4th** *darkness*, *nightmare*; **3rd** *mind reading*, *noise blast*, *slow*; **2nd** *paranoia*, *stupefy*, *ventriloquism*; **1st** *command*, *ill omen*, *sleep*; **Cantrips (4th)** *detect scrying*; **Cantrips (6th)** *detect magic*, *figment*, *haunting hymn*, *message*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "mislead",
+          "aonid": 1605,
+          "game-obj": "Spells",
+          "name": "mislead",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal calamity",
+          "aonid": 1630,
+          "game-obj": "Spells",
+          "name": "phantasmal calamity",
+          "type": "link"
+        },
+        {
+          "alt": "strange geometry",
+          "aonid": 2032,
+          "game-obj": "Spells",
+          "name": "strange geometry",
+          "type": "link"
+        },
+        {
+          "alt": "synaptic pulse",
+          "aonid": 1710,
+          "game-obj": "Spells",
+          "name": "synaptic pulse",
+          "type": "link"
+        },
+        {
+          "alt": "wave of despair",
+          "aonid": 1757,
+          "game-obj": "Spells",
+          "name": "wave of despair",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Despair Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 122",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 122",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 122,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young despair dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mislead",
+                      "aonid": 1605,
+                      "game-obj": "Spells",
+                      "name": "mislead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mislead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal calamity",
+                      "aonid": 1630,
+                      "game-obj": "Spells",
+                      "name": "phantasmal calamity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal calamity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "strange geometry",
+                      "aonid": 2032,
+                      "game-obj": "Spells",
+                      "name": "strange geometry",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "strange geometry",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "synaptic pulse",
+                      "aonid": 1710,
+                      "game-obj": "Spells",
+                      "name": "synaptic pulse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "synaptic pulse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wave of despair",
+                      "aonid": 1757,
+                      "game-obj": "Spells",
+                      "name": "wave of despair",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wave of despair",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 33, attack +25; As young despair dragon, plus **6th** *mislead*, *phantasmal calamity*; **5th** *strange geometry*, *synaptic pulse*, *wave of despair*; **4th** *detect scrying*; **Cantrips (6th)** *detect magic*, *figment*, *haunting hymn*, *message*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "canticle of everlasting grief",
+          "aonid": 1459,
+          "game-obj": "Spells",
+          "name": "canticle of everlasting grief",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        },
+        {
+          "alt": "mask of terror",
+          "aonid": 1595,
+          "game-obj": "Spells",
+          "name": "mask of terror",
+          "type": "link"
+        },
+        {
+          "alt": "visions of danger",
+          "aonid": 2040,
+          "game-obj": "Spells",
+          "name": "visions of danger",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 1662,
+          "game-obj": "Spells",
+          "name": "scrying",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Despair Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 122",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 122",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 122,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult despair dragon"
+          ],
+          "saving_throw": {
+            "dc": 40,
+            "subtype": "save_dc",
+            "text": "DC 40",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "canticle of everlasting grief",
+                      "aonid": 1459,
+                      "game-obj": "Spells",
+                      "name": "canticle of everlasting grief",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "canticle of everlasting grief",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mask of terror",
+                      "aonid": 1595,
+                      "game-obj": "Spells",
+                      "name": "mask of terror",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mask of terror",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "visions of danger",
+                      "aonid": 2040,
+                      "game-obj": "Spells",
+                      "name": "visions of danger",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "visions of danger",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "wave of despair",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scrying",
+                      "aonid": 1662,
+                      "game-obj": "Spells",
+                      "name": "scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectileo",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 40, attack +32; As adult despair dragon, plus **8th** *canticle of everlasting grief*, *hidden mind*, *pinpoint*; **7th** *mask of terror*, *visions of danger*, wave of despair; **6th** *scrying*; **Cantrips (8th)** *detect magic*, *figment*, *haunting hymn*, *message*, *telekinetic projectile*o",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fabricated truth",
+          "aonid": 1520,
+          "game-obj": "Spells",
+          "name": "fabricated truth",
+          "type": "link"
+        },
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmagoria",
+          "aonid": 1629,
+          "game-obj": "Spells",
+          "name": "phantasmagoria",
+          "type": "link"
+        },
+        {
+          "alt": "wails of the damned",
+          "aonid": 1747,
+          "game-obj": "Spells",
+          "name": "wails of the damned",
+          "type": "link"
+        }
+      ],
+      "name": "Despair Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 122",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 122",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 122,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient despair dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fabricated truth",
+                      "aonid": 1520,
+                      "game-obj": "Spells",
+                      "name": "fabricated truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fabricated truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmagoria",
+                      "aonid": 1629,
+                      "game-obj": "Spells",
+                      "name": "phantasmagoria",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmagoria",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wails of the damned",
+                      "aonid": 1747,
+                      "game-obj": "Spells",
+                      "name": "wails of the damned",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wails of the damned",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 45, attack +37; As ancient despair dragon plus **10th** *fabricated truth*; **9th** *overwhelming presence*, *phantasmagoria*, *wails of the damned*; **Cantrips (10th)** *detect magic*, *figment*, *haunting hymn*, *message*, *telekinetic projectile*",
       "type": "section"
     },
     {
@@ -1859,6 +2433,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 122",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 122",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 122,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -2006,6 +2636,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 122",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 122",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 122,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/dragon_phase.json
+++ b/monster_families/monster_core_2/dragon_phase.json
@@ -58,112 +58,147 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The phase dragon becomes incorporeal, gaining the incorporeal trait, resistance to all damage (except force, *ghost touch*, and spirit) equal to half their level (double the resistance against non-magical damage), and immunity to precision damage. If the dragon attempts a Strike against a creature with any circumstance bonuses to AC (such as from a shield or cover), reduce that bonus by 2. This effect lasts for 1 minute or until the phase dragon Dismisses it.",
-                "frequency": "once per hour",
-                "links": [
-                  {
-                    "alt": "flat check",
-                    "aonid": 333,
-                    "game-obj": "Rules",
-                    "name": "flat check",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "incorporeal",
-                    "aonid": 632,
-                    "game-obj": "Traits",
-                    "name": "incorporeal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "force",
-                    "aonid": 610,
-                    "game-obj": "Traits",
-                    "name": "force",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "ghost touch",
-                    "aonid": 2840,
-                    "game-obj": "Equipment",
-                    "name": "ghost touch",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "spirit",
-                    "aonid": 737,
-                    "game-obj": "Traits",
-                    "name": "spirit",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "shield",
-                    "aonid": 12,
-                    "game-obj": "WeaponGroups",
-                    "name": "shield",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "cover",
-                    "aonid": 2372,
-                    "game-obj": "Rules",
-                    "name": "cover",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Dismisses",
-                    "aonid": 2311,
-                    "game-obj": "Actions",
-                    "name": "Dismisses",
-                    "type": "link"
-                  }
-                ],
-                "name": "Afterimage Jumps",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 629,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "flat check",
+                "aonid": 333,
+                "game-obj": "Rules",
+                "name": "flat check",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "spellshape",
+                "aonid": 513,
+                "game-obj": "Traits",
+                "name": "spellshape",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "teleportation",
+                "aonid": 710,
+                "game-obj": "Traits",
+                "name": "teleportation",
+                "type": "link"
+              },
+              {
+                "alt": "invisible",
+                "aonid": 83,
+                "game-obj": "Conditions",
+                "name": "invisible",
+                "type": "link"
+              },
+              {
+                "alt": "hostile action",
+                "aonid": 2251,
+                "game-obj": "Rules",
+                "name": "hostile action",
+                "type": "link"
+              },
+              {
+                "alt": "interacts",
+                "aonid": 2297,
+                "game-obj": "Actions",
+                "name": "interacts",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "incorporeal",
+                "aonid": 632,
+                "game-obj": "Traits",
+                "name": "incorporeal",
+                "type": "link"
+              },
+              {
+                "alt": "force",
+                "aonid": 610,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              {
+                "alt": "ghost touch",
+                "aonid": 2840,
+                "game-obj": "Equipment",
+                "name": "ghost touch",
+                "type": "link"
+              },
+              {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 12,
+                "game-obj": "WeaponGroups",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "cover",
+                "aonid": 2372,
+                "game-obj": "Rules",
+                "name": "cover",
+                "type": "link"
+              },
+              {
+                "alt": "Dismisses",
+                "aonid": 2311,
+                "game-obj": "Actions",
+                "name": "Dismisses",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -173,310 +208,131 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Some phase dragons\u2019 mastery of teleportation manifests in different ways. You can apply the following adjustments to a phase dragon of any age.   \n  \nSome phase dragons can appear to be in two places at once. To make a dragon with such an ability, remove flicker from their innate spells and replace Shoo! with either of the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 28,
-                  "subtype": "save_dc",
-                  "text": "DC 28",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 20,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "liminal doorway",
-                            "aonid": 1587,
-                            "game-obj": "Spells",
-                            "name": "liminal doorway",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "liminal doorway",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairaudience",
-                            "aonid": 1465,
-                            "game-obj": "Spells",
-                            "name": "clairaudience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairaudience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "safe passage",
-                            "aonid": 1659,
-                            "game-obj": "Spells",
-                            "name": "safe passage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "safe passage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blur",
-                            "aonid": 1455,
-                            "game-obj": "Spells",
-                            "name": "blur",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blur",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 1560,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ant haul",
-                            "aonid": 1442,
-                            "game-obj": "Spells",
-                            "name": "ant haul",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ant haul",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "force barrage",
-                            "aonid": 1536,
-                            "game-obj": "Spells",
-                            "name": "force barrage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tailwind",
-                            "aonid": 1711,
-                            "game-obj": "Spells",
-                            "name": "tailwind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tailwind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 1718,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Phase Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "liminal doorway",
+                "aonid": 1587,
+                "game-obj": "Spells",
+                "name": "liminal doorway",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "clairaudience",
+                "aonid": 1465,
+                "game-obj": "Spells",
+                "name": "clairaudience",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "safe passage",
+                "aonid": 1659,
+                "game-obj": "Spells",
+                "name": "safe passage",
+                "type": "link"
+              },
+              {
+                "alt": "blur",
+                "aonid": 1455,
+                "game-obj": "Spells",
+                "name": "blur",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 1560,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "ant haul",
+                "aonid": 1442,
+                "game-obj": "Spells",
+                "name": "ant haul",
+                "type": "link"
+              },
+              {
+                "alt": "force barrage",
+                "aonid": 1536,
+                "game-obj": "Spells",
+                "name": "force barrage",
+                "type": "link"
+              },
+              {
+                "alt": "tailwind",
+                "aonid": 1711,
+                "game-obj": "Spells",
+                "name": "tailwind",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 1718,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -492,169 +348,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young phase dragon"
-                ],
-                "saving_throw": {
-                  "dc": 33,
-                  "subtype": "save_dc",
-                  "text": "DC 33",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 25,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scrying",
-                            "aonid": 1662,
-                            "game-obj": "Spells",
-                            "name": "scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of force",
-                            "aonid": 1749,
-                            "game-obj": "Spells",
-                            "name": "wall of force",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of force",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mirage",
-                            "aonid": 1604,
-                            "game-obj": "Spells",
-                            "name": "mirage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mirage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Phase Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "scrying",
+                "aonid": 1662,
+                "game-obj": "Spells",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "wall of force",
+                "aonid": 1749,
+                "game-obj": "Spells",
+                "name": "wall of force",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
+              },
+              {
+                "alt": "mirage",
+                "aonid": 1604,
+                "game-obj": "Spells",
+                "name": "mirage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -670,184 +405,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult phase dragon"
-                ],
-                "saving_throw": {
-                  "dc": 40,
-                  "subtype": "save_dc",
-                  "text": "DC 40",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 32,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pinpoint",
-                            "aonid": 1633,
-                            "game-obj": "Spells",
-                            "name": "pinpoint",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pinpoint",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "teleport",
-                            "aonid": 1720,
-                            "game-obj": "Spells",
-                            "name": "teleport",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "teleport",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "contingency",
-                            "aonid": 1472,
-                            "game-obj": "Spells",
-                            "name": "contingency",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "contingency",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "energy aegis",
-                            "aonid": 1512,
-                            "game-obj": "Spells",
-                            "name": "energy aegis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "energy aegis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "retrocognition",
-                            "aonid": 1652,
-                            "game-obj": "Spells",
-                            "name": "retrocognition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "retrocognition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disintegrate",
-                            "aonid": 1492,
-                            "game-obj": "Spells",
-                            "name": "disintegrate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disintegrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectileo",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Phase Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "pinpoint",
+                "aonid": 1633,
+                "game-obj": "Spells",
+                "name": "pinpoint",
+                "type": "link"
+              },
+              {
+                "alt": "teleport",
+                "aonid": 1720,
+                "game-obj": "Spells",
+                "name": "teleport",
+                "type": "link"
+              },
+              {
+                "alt": "contingency",
+                "aonid": 1472,
+                "game-obj": "Spells",
+                "name": "contingency",
+                "type": "link"
+              },
+              {
+                "alt": "energy aegis",
+                "aonid": 1512,
+                "game-obj": "Spells",
+                "name": "energy aegis",
+                "type": "link"
+              },
+              {
+                "alt": "retrocognition",
+                "aonid": 1652,
+                "game-obj": "Spells",
+                "name": "retrocognition",
+                "type": "link"
+              },
+              {
+                "alt": "disintegrate",
+                "aonid": 1492,
+                "game-obj": "Spells",
+                "name": "disintegrate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -863,155 +469,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As ancient phase dragon"
-                ],
-                "saving_throw": {
-                  "dc": 45,
-                  "subtype": "save_dc",
-                  "text": "DC 45",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 37,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "freeze time",
-                            "aonid": 1538,
-                            "game-obj": "Spells",
-                            "name": "freeze time",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "freeze time",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gate",
-                            "aonid": 1540,
-                            "game-obj": "Spells",
-                            "name": "gate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "metamorphosis",
-                            "aonid": 1599,
-                            "game-obj": "Spells",
-                            "name": "metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Phase Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "freeze time",
+                "aonid": 1538,
+                "game-obj": "Spells",
+                "name": "freeze time",
+                "type": "link"
+              },
+              {
+                "alt": "gate",
+                "aonid": 1540,
+                "game-obj": "Spells",
+                "name": "gate",
+                "type": "link"
+              },
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
+              },
+              {
+                "alt": "metamorphosis",
+                "aonid": 1599,
+                "game-obj": "Spells",
+                "name": "metamorphosis",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1026,48 +525,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1078,263 +540,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1344,7 +590,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1353,6 +598,260 @@
   "name": "Dragon, Phase",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The phase dragon becomes incorporeal, gaining the incorporeal trait, resistance to all damage (except force, *ghost touch*, and spirit) equal to half their level (double the resistance against non-magical damage), and immunity to precision damage. If the dragon attempts a Strike against a creature with any circumstance bonuses to AC (such as from a shield or cover), reduce that bonus by 2. This effect lasts for 1 minute or until the phase dragon Dismisses it.",
+          "frequency": "once per hour",
+          "links": [
+            {
+              "alt": "flat check",
+              "aonid": 333,
+              "game-obj": "Rules",
+              "name": "flat check",
+              "type": "link"
+            },
+            {
+              "alt": "incorporeal",
+              "aonid": 632,
+              "game-obj": "Traits",
+              "name": "incorporeal",
+              "type": "link"
+            },
+            {
+              "alt": "force",
+              "aonid": 610,
+              "game-obj": "Traits",
+              "name": "force",
+              "type": "link"
+            },
+            {
+              "alt": "ghost touch",
+              "aonid": 2840,
+              "game-obj": "Equipment",
+              "name": "ghost touch",
+              "type": "link"
+            },
+            {
+              "alt": "spirit",
+              "aonid": 737,
+              "game-obj": "Traits",
+              "name": "spirit",
+              "type": "link"
+            },
+            {
+              "alt": "shield",
+              "aonid": 12,
+              "game-obj": "WeaponGroups",
+              "name": "shield",
+              "type": "link"
+            },
+            {
+              "alt": "cover",
+              "aonid": 2372,
+              "game-obj": "Rules",
+              "name": "cover",
+              "type": "link"
+            },
+            {
+              "alt": "Dismisses",
+              "aonid": 2311,
+              "game-obj": "Actions",
+              "name": "Dismisses",
+              "type": "link"
+            }
+          ],
+          "name": "Afterimage Jumps",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              "name": "illusion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "illusion",
+          "aonid": 629,
+          "game-obj": "Traits",
+          "name": "illusion",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "flat check",
+          "aonid": 333,
+          "game-obj": "Rules",
+          "name": "flat check",
+          "type": "link"
+        },
+        {
+          "alt": "illusion",
+          "aonid": 629,
+          "game-obj": "Traits",
+          "name": "illusion",
+          "type": "link"
+        },
+        {
+          "alt": "spellshape",
+          "aonid": 513,
+          "game-obj": "Traits",
+          "name": "spellshape",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "teleportation",
+          "aonid": 710,
+          "game-obj": "Traits",
+          "name": "teleportation",
+          "type": "link"
+        },
+        {
+          "alt": "invisible",
+          "aonid": 83,
+          "game-obj": "Conditions",
+          "name": "invisible",
+          "type": "link"
+        },
+        {
+          "alt": "hostile action",
+          "aonid": 2251,
+          "game-obj": "Rules",
+          "name": "hostile action",
+          "type": "link"
+        },
+        {
+          "alt": "interacts",
+          "aonid": 2297,
+          "game-obj": "Actions",
+          "name": "interacts",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "incorporeal",
+          "aonid": 632,
+          "game-obj": "Traits",
+          "name": "incorporeal",
+          "type": "link"
+        },
+        {
+          "alt": "force",
+          "aonid": 610,
+          "game-obj": "Traits",
+          "name": "force",
+          "type": "link"
+        },
+        {
+          "alt": "ghost touch",
+          "aonid": 2840,
+          "game-obj": "Equipment",
+          "name": "ghost touch",
+          "type": "link"
+        },
+        {
+          "alt": "spirit",
+          "aonid": 737,
+          "game-obj": "Traits",
+          "name": "spirit",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 12,
+          "game-obj": "WeaponGroups",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "cover",
+          "aonid": 2372,
+          "game-obj": "Rules",
+          "name": "cover",
+          "type": "link"
+        },
+        {
+          "alt": "Dismisses",
+          "aonid": 2311,
+          "game-obj": "Actions",
+          "name": "Dismisses",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 124",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 124",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 124,
+          "type": "source"
+        }
+      ],
+      "text": "Some phase dragons\u2019 mastery of teleportation manifests in different ways. You can apply the following adjustments to a phase dragon of any age.   \n  \nSome phase dragons can appear to be in two places at once. To make a dragon with such an ability, remove flicker from their innate spells and replace Shoo! with either of the following.   \n  \n**Afterimage Jumps** [#] (illusion, visual) **Frequency** once per 10 minutes; **Effect** The phase dragon teleports in a quick series of jumps around their own location, creating three illusory images of themself that are hard to distinguish from the real thing. Any foe targeting the phase dragon with an attack must first succeed at a DC 15 flat check. On a failure, the phase dragon isn\u2019t affected and one of the illusory duplicates is shattered; the DC of the next flat check for Afterimage Jumps is reduced by 5. Any remaining images disappear at the start of the dragon\u2019s next turn.   \n  \nSecond Glance [#] (illusion, spellshape, visual) If the phase dragon\u2019s next action is to use an ability or spell with the teleportation trait, they become invisible when they arrive at their destination and leave an illusory duplicate at their initial location. The invisibility ends and the illusory duplicate disappears if the dragon takes a hostile action; if a creature interacts with the false image, including attempting to Strike it; or at the start of the dragon\u2019s next turn, whichever comes first.   \n  \nRarely, a phase dragon can tune their forms to be slightly out of phase with reality. To make a dragon with such an ability, remove flicker from their innate spells and replace Portal Strike with the following.   \n  \nDematerialize [#] (concentrate, polymorph) **Frequency** once per hour; **Effect** The phase dragon becomes incorporeal, gaining the incorporeal trait, resistance to all damage (except force, *ghost touch*, and spirit) equal to half their level (double the resistance against non-magical damage), and immunity to precision damage. If the dragon attempts a Strike against a creature with any circumstance bonuses to AC (such as from a shield or cover), reduce that bonus by 2. This effect lasts for 1 minute or until the phase dragon Dismisses it.",
+      "type": "section"
+    },
     {
       "name": "Phase Dragon Spellcasters",
       "sources": [
@@ -1370,6 +869,1109 @@
         }
       ],
       "text": "Phase dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "liminal doorway",
+          "aonid": 1587,
+          "game-obj": "Spells",
+          "name": "liminal doorway",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "clairaudience",
+          "aonid": 1465,
+          "game-obj": "Spells",
+          "name": "clairaudience",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "safe passage",
+          "aonid": 1659,
+          "game-obj": "Spells",
+          "name": "safe passage",
+          "type": "link"
+        },
+        {
+          "alt": "blur",
+          "aonid": 1455,
+          "game-obj": "Spells",
+          "name": "blur",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 1560,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "ant haul",
+          "aonid": 1442,
+          "game-obj": "Spells",
+          "name": "ant haul",
+          "type": "link"
+        },
+        {
+          "alt": "force barrage",
+          "aonid": 1536,
+          "game-obj": "Spells",
+          "name": "force barrage",
+          "type": "link"
+        },
+        {
+          "alt": "tailwind",
+          "aonid": 1711,
+          "game-obj": "Spells",
+          "name": "tailwind",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 1718,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Young Phase Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 124",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 124",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 124,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 28,
+            "subtype": "save_dc",
+            "text": "DC 28",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 20,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "liminal doorway",
+                      "aonid": 1587,
+                      "game-obj": "Spells",
+                      "name": "liminal doorway",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "liminal doorway",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairaudience",
+                      "aonid": 1465,
+                      "game-obj": "Spells",
+                      "name": "clairaudience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairaudience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "safe passage",
+                      "aonid": 1659,
+                      "game-obj": "Spells",
+                      "name": "safe passage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "safe passage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blur",
+                      "aonid": 1455,
+                      "game-obj": "Spells",
+                      "name": "blur",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blur",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 1560,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ant haul",
+                      "aonid": 1442,
+                      "game-obj": "Spells",
+                      "name": "ant haul",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ant haul",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "force barrage",
+                      "aonid": 1536,
+                      "game-obj": "Spells",
+                      "name": "force barrage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tailwind",
+                      "aonid": 1711,
+                      "game-obj": "Spells",
+                      "name": "tailwind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tailwind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 1718,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 28, attack +20; **4th** *liminal doorway*, *unfettered movement*; **3rd** *clairaudience*, *haste*, *safe passage*; **2nd** *blur*, *dispel magic*, *humanoid form*; **1st** *ant haul*, *force barrage*, *tailwind*; **Cantrips (4th)** *detect magic*, *figment*, *message*, *read aura*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "scrying",
+          "aonid": 1662,
+          "game-obj": "Spells",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "wall of force",
+          "aonid": 1749,
+          "game-obj": "Spells",
+          "name": "wall of force",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        },
+        {
+          "alt": "mirage",
+          "aonid": 1604,
+          "game-obj": "Spells",
+          "name": "mirage",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Phase Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 124",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 124",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 124,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young phase dragon"
+          ],
+          "saving_throw": {
+            "dc": 33,
+            "subtype": "save_dc",
+            "text": "DC 33",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 25,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scrying",
+                      "aonid": 1662,
+                      "game-obj": "Spells",
+                      "name": "scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of force",
+                      "aonid": 1749,
+                      "game-obj": "Spells",
+                      "name": "wall of force",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of force",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mirage",
+                      "aonid": 1604,
+                      "game-obj": "Spells",
+                      "name": "mirage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mirage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 33, attack +25; As young phase dragon, plus **6th** *scrying*, *wall of force*; **5th** *banishment*, *dispel magic*, *sending*; **4th** *mirage*; **Cantrips (6th)** *detect magic*, *figment*, *message*, *read aura*, *telekinetic projectile*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "pinpoint",
+          "aonid": 1633,
+          "game-obj": "Spells",
+          "name": "pinpoint",
+          "type": "link"
+        },
+        {
+          "alt": "teleport",
+          "aonid": 1720,
+          "game-obj": "Spells",
+          "name": "teleport",
+          "type": "link"
+        },
+        {
+          "alt": "contingency",
+          "aonid": 1472,
+          "game-obj": "Spells",
+          "name": "contingency",
+          "type": "link"
+        },
+        {
+          "alt": "energy aegis",
+          "aonid": 1512,
+          "game-obj": "Spells",
+          "name": "energy aegis",
+          "type": "link"
+        },
+        {
+          "alt": "retrocognition",
+          "aonid": 1652,
+          "game-obj": "Spells",
+          "name": "retrocognition",
+          "type": "link"
+        },
+        {
+          "alt": "disintegrate",
+          "aonid": 1492,
+          "game-obj": "Spells",
+          "name": "disintegrate",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Phase Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 124",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 124",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 124,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult phase dragon"
+          ],
+          "saving_throw": {
+            "dc": 40,
+            "subtype": "save_dc",
+            "text": "DC 40",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 32,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pinpoint",
+                      "aonid": 1633,
+                      "game-obj": "Spells",
+                      "name": "pinpoint",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pinpoint",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "teleport",
+                      "aonid": 1720,
+                      "game-obj": "Spells",
+                      "name": "teleport",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "teleport",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "contingency",
+                      "aonid": 1472,
+                      "game-obj": "Spells",
+                      "name": "contingency",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "contingency",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "energy aegis",
+                      "aonid": 1512,
+                      "game-obj": "Spells",
+                      "name": "energy aegis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "energy aegis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "retrocognition",
+                      "aonid": 1652,
+                      "game-obj": "Spells",
+                      "name": "retrocognition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "retrocognition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disintegrate",
+                      "aonid": 1492,
+                      "game-obj": "Spells",
+                      "name": "disintegrate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disintegrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectileo",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 40, attack +32; As adult phase dragon, plus **8th** *dispel magic*, *pinpoint*, *teleport*; **7th** *contingency*, *energy aegis*, *retrocognition*; **6th** *disintegrate*; **Cantrips (8th)** *detect magic*, *figment*, *message*, *read aura*, *telekinetic projectile*o",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "freeze time",
+          "aonid": 1538,
+          "game-obj": "Spells",
+          "name": "freeze time",
+          "type": "link"
+        },
+        {
+          "alt": "gate",
+          "aonid": 1540,
+          "game-obj": "Spells",
+          "name": "gate",
+          "type": "link"
+        },
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        },
+        {
+          "alt": "metamorphosis",
+          "aonid": 1599,
+          "game-obj": "Spells",
+          "name": "metamorphosis",
+          "type": "link"
+        }
+      ],
+      "name": "Phase Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 124",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 124",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 124,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As ancient phase dragon"
+          ],
+          "saving_throw": {
+            "dc": 45,
+            "subtype": "save_dc",
+            "text": "DC 45",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 37,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "freeze time",
+                      "aonid": 1538,
+                      "game-obj": "Spells",
+                      "name": "freeze time",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "freeze time",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gate",
+                      "aonid": 1540,
+                      "game-obj": "Spells",
+                      "name": "gate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "metamorphosis",
+                      "aonid": 1599,
+                      "game-obj": "Spells",
+                      "name": "metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 45, attack +37; As ancient phase dragon plus **10th** *freeze time*, *gate*; **9th** *detonate magic*, *implosion*, *metamorphosis*; **Cantrips (10th)** *detect magic*, *figment*, *message*, *read aura*, *telekinetic projectile*",
       "type": "section"
     },
     {
@@ -1703,6 +2305,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 124",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 124",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 124,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1850,6 +2508,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 124",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 124",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 124,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/dragon_requiem.json
+++ b/monster_families/monster_core_2/dragon_requiem.json
@@ -81,267 +81,112 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The dragon tethers their soul to the soul of a living creature within 60 feet, pulling it along into death. The target must attempt a Fortitude save.",
-                "name": "Die Together",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 631,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    },
-                    "name": "void",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "The dragon dies",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The target is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The target takes void damage equal to half the damage dealt by the dragon\u2019s Dooming Breath.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The target takes void damage equal to the damage dealt by the dragon\u2019s Dooming Breath.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "dying",
-                    "aonid": 69,
-                    "game-obj": "Conditions",
-                    "name": "dying",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "The target drops to 0 Hit Points and becomes dying 1, or increases its dying condition by 1 if it\u2019s already dying. While the target is dying, the dragon remains at 1 Hit Point and dies instantly if the target loses the dying condition.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 120,
-                    "subtype": "area",
-                    "text": "120-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "effect": "The dragon lets out a mighty roar that rouses their allies and rattles the souls of their enemies. Each ally in a 120-foot emanation gains temporary Hit Points equal to the dragon\u2019s level that last for 1 minute, while each enemy within that area must attempt a Will save.",
-                "frequency": "once per round",
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "temporary Hit Points",
-                    "aonid": 2321,
-                    "game-obj": "Rules",
-                    "name": "temporary Hit Points",
-                    "type": "link"
-                  }
-                ],
-                "name": "Soul Roar",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 541,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "spirit",
-                      "aonid": 737,
-                      "game-obj": "Traits",
-                      "name": "spirit",
-                      "type": "link"
-                    },
-                    "name": "spirit",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected and is immune to Soul Roar for 1 minute.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightened",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is frightened 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "doomed",
-                    "aonid": 67,
-                    "game-obj": "Conditions",
-                    "name": "doomed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature is frightened 2 and doomed 1. If the target is already doomed, the doomed value increases by 1 (to a maximum of doomed 4).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fleeing",
-                    "aonid": 74,
-                    "game-obj": "Conditions",
-                    "name": "fleeing",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "The creature gains the fleeing condition for 1 round, is frightened 4, and is doomed 1. If the target is already doomed, the doomed value increases by 1 (to a maximum of doomed 4).",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "dying",
+                "aonid": 69,
+                "game-obj": "Conditions",
+                "name": "dying",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "temporary Hit Points",
+                "aonid": 2321,
+                "game-obj": "Rules",
+                "name": "temporary Hit Points",
+                "type": "link"
+              },
+              {
+                "alt": "frightened",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened",
+                "type": "link"
+              },
+              {
+                "alt": "doomed",
+                "aonid": 67,
+                "game-obj": "Conditions",
+                "name": "doomed",
+                "type": "link"
+              },
+              {
+                "alt": "fleeing",
+                "aonid": 74,
+                "game-obj": "Conditions",
+                "name": "fleeing",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -351,316 +196,131 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "A requiem dragon\u2019s control over souls manifests in various ways. You can apply the following adjustments to a requiem dragon of any age.  \n  \nSome requiem dragons are spiteful enough to try to bring a living creature along with them when they die. To create a dragon with this ability, replace Withhold Death with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ghostly tragedy",
-                            "aonid": 1995,
-                            "game-obj": "Spells",
-                            "name": "ghostly tragedy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ghostly tragedy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "talking corpse",
-                            "aonid": 1712,
-                            "game-obj": "Spells",
-                            "name": "talking corpse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "talking corpse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vital beacon",
-                            "aonid": 1743,
-                            "game-obj": "Spells",
-                            "name": "vital beacon",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vital beacon",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "protection",
-                            "aonid": 1641,
-                            "game-obj": "Spells",
-                            "name": "protection",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "protection",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ring of truth",
-                            "aonid": 1656,
-                            "game-obj": "Spells",
-                            "name": "ring of truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ring of truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "safe passage",
-                            "aonid": 1659,
-                            "game-obj": "Spells",
-                            "name": "safe passage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "safe passage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "see the unseen",
-                            "aonid": 1663,
-                            "game-obj": "Spells",
-                            "name": "see the unseen",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "see the unseen",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "share life",
-                            "aonid": 1669,
-                            "game-obj": "Spells",
-                            "name": "share life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "share life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "thoughtful gift",
-                            "aonid": 2037,
-                            "game-obj": "Spells",
-                            "name": "thoughtful gift",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "thoughtful gift",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "protection",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sanctuary",
-                            "aonid": 1660,
-                            "game-obj": "Spells",
-                            "name": "sanctuary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sanctuary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit link",
-                            "aonid": 1686,
-                            "game-obj": "Spells",
-                            "name": "spirit link",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit link",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haunting hymn",
-                            "aonid": 1999,
-                            "game-obj": "Spells",
-                            "name": "haunting hymn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 1381,
-                            "game-obj": "Rules",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Requiem Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "ghostly tragedy",
+                "aonid": 1995,
+                "game-obj": "Spells",
+                "name": "ghostly tragedy",
+                "type": "link"
+              },
+              {
+                "alt": "talking corpse",
+                "aonid": 1712,
+                "game-obj": "Spells",
+                "name": "talking corpse",
+                "type": "link"
+              },
+              {
+                "alt": "vital beacon",
+                "aonid": 1743,
+                "game-obj": "Spells",
+                "name": "vital beacon",
+                "type": "link"
+              },
+              {
+                "alt": "protection",
+                "aonid": 1641,
+                "game-obj": "Spells",
+                "name": "protection",
+                "type": "link"
+              },
+              {
+                "alt": "ring of truth",
+                "aonid": 1656,
+                "game-obj": "Spells",
+                "name": "ring of truth",
+                "type": "link"
+              },
+              {
+                "alt": "safe passage",
+                "aonid": 1659,
+                "game-obj": "Spells",
+                "name": "safe passage",
+                "type": "link"
+              },
+              {
+                "alt": "see the unseen",
+                "aonid": 1663,
+                "game-obj": "Spells",
+                "name": "see the unseen",
+                "type": "link"
+              },
+              {
+                "alt": "share life",
+                "aonid": 1669,
+                "game-obj": "Spells",
+                "name": "share life",
+                "type": "link"
+              },
+              {
+                "alt": "thoughtful gift",
+                "aonid": 2037,
+                "game-obj": "Spells",
+                "name": "thoughtful gift",
+                "type": "link"
+              },
+              {
+                "alt": "sanctuary",
+                "aonid": 1660,
+                "game-obj": "Spells",
+                "name": "sanctuary",
+                "type": "link"
+              },
+              {
+                "alt": "spirit link",
+                "aonid": 1686,
+                "game-obj": "Spells",
+                "name": "spirit link",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "haunting hymn",
+                "aonid": 1999,
+                "game-obj": "Spells",
+                "name": "haunting hymn",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 1381,
+                "game-obj": "Rules",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -676,161 +336,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As young requiem dragon"
-                ],
-                "saving_throw": {
-                  "dc": 36,
-                  "subtype": "save_dc",
-                  "text": "DC 36",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 28,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "field of life",
-                            "aonid": 1526,
-                            "game-obj": "Spells",
-                            "name": "field of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "field of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "raise dead",
-                            "aonid": 1645,
-                            "game-obj": "Spells",
-                            "name": "raise dead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "raise dead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "vital beacon",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "breath of life",
-                            "aonid": 1456,
-                            "game-obj": "Spells",
-                            "name": "breath of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "breath of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "invoke spirits",
-                            "aonid": 1578,
-                            "game-obj": "Spells",
-                            "name": "invoke spirits",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "invoke spirits",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Requiem Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "field of life",
+                "aonid": 1526,
+                "game-obj": "Spells",
+                "name": "field of life",
+                "type": "link"
+              },
+              {
+                "alt": "raise dead",
+                "aonid": 1645,
+                "game-obj": "Spells",
+                "name": "raise dead",
+                "type": "link"
+              },
+              {
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
+              },
+              {
+                "alt": "breath of life",
+                "aonid": 1456,
+                "game-obj": "Spells",
+                "name": "breath of life",
+                "type": "link"
+              },
+              {
+                "alt": "invoke spirits",
+                "aonid": 1578,
+                "game-obj": "Spells",
+                "name": "invoke spirits",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -845,90 +392,56 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "foresight",
-                    "aonid": 1537,
-                    "game-obj": "Spells",
-                    "name": "foresight",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "seize soul",
-                    "aonid": 1664,
-                    "game-obj": "Spells",
-                    "name": "seize soul",
-                    "type": "link"
-                  }
-                ],
-                "name": "9th",
-                "subtype": "ability",
-                "text": "*foresight*, *raise dead*, *seize soul*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "spirit song",
-                    "aonid": 2029,
-                    "game-obj": "Spells",
-                    "name": "spirit song",
-                    "type": "link"
-                  }
-                ],
-                "name": "8th",
-                "subtype": "ability",
-                "text": "*field of life*, *safe passage*, *spirit song*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "interplanar teleport",
-                    "aonid": 1576,
-                    "game-obj": "Spells",
-                    "name": "interplanar teleport",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "planar seal",
-                    "aonid": 1635,
-                    "game-obj": "Spells",
-                    "name": "planar seal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "regenerate",
-                    "aonid": 1648,
-                    "game-obj": "Spells",
-                    "name": "regenerate",
-                    "type": "link"
-                  }
-                ],
-                "name": "7th",
-                "subtype": "ability",
-                "text": "*interplanar teleport*, *planar seal*, *regenerate*;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Cantrips (9th)",
-                "subtype": "ability",
-                "text": "*guidance*, *haunting hymn* , *message*, *sigil*, *stabilize*o",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Ancient Requiem Dragon')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "seize soul",
+                "aonid": 1664,
+                "game-obj": "Spells",
+                "name": "seize soul",
+                "type": "link"
+              },
+              {
+                "alt": "spirit song",
+                "aonid": 2029,
+                "game-obj": "Spells",
+                "name": "spirit song",
+                "type": "link"
+              },
+              {
+                "alt": "interplanar teleport",
+                "aonid": 1576,
+                "game-obj": "Spells",
+                "name": "interplanar teleport",
+                "type": "link"
+              },
+              {
+                "alt": "planar seal",
+                "aonid": 1635,
+                "game-obj": "Spells",
+                "name": "planar seal",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -938,132 +451,40 @@
         ],
         "name": "Ancient Requiem Dragon",
         "subtype": "monster_family",
-        "text": "Divine Prepared Spells DC 42, attack +34; As adult requiem dragon, plus",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As ancient requiem dragon"
-                ],
-                "saving_throw": {
-                  "dc": 48,
-                  "subtype": "save_dc",
-                  "text": "DC 48",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 40,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "raise dead",
-                            "aonid": 1645,
-                            "game-obj": "Spells",
-                            "name": "raise dead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "raise dead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revival",
-                            "aonid": 1654,
-                            "game-obj": "Spells",
-                            "name": "revival",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revival",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "breath of life",
-                            "aonid": 1456,
-                            "game-obj": "Spells",
-                            "name": "breath of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "breath of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Requiem Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "raise dead",
+                "aonid": 1645,
+                "game-obj": "Spells",
+                "name": "raise dead",
+                "type": "link"
+              },
+              {
+                "alt": "revival",
+                "aonid": 1654,
+                "game-obj": "Spells",
+                "name": "revival",
+                "type": "link"
+              },
+              {
+                "alt": "breath of life",
+                "aonid": 1456,
+                "game-obj": "Spells",
+                "name": "breath of life",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1078,48 +499,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1130,263 +514,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1396,7 +564,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1405,6 +572,380 @@
   "name": "Dragon, Requiem",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The dragon tethers their soul to the soul of a living creature within 60 feet, pulling it along into death. The target must attempt a Fortitude save.",
+          "name": "Die Together",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "within 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              "name": "incapacitation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              "name": "void",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "trigger": "The dragon dies",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The target is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The target takes void damage equal to half the damage dealt by the dragon\u2019s Dooming Breath.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The target takes void damage equal to the damage dealt by the dragon\u2019s Dooming Breath.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "dying",
+              "aonid": 69,
+              "game-obj": "Conditions",
+              "name": "dying",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "The target drops to 0 Hit Points and becomes dying 1, or increases its dying condition by 1 if it\u2019s already dying. While the target is dying, the dragon remains at 1 Hit Point and dies instantly if the target loses the dying condition.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 120,
+              "subtype": "area",
+              "text": "120-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "effect": "The dragon lets out a mighty roar that rouses their allies and rattles the souls of their enemies. Each ally in a 120-foot emanation gains temporary Hit Points equal to the dragon\u2019s level that last for 1 minute, while each enemy within that area must attempt a Will save.",
+          "frequency": "once per round",
+          "links": [
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "temporary Hit Points",
+              "aonid": 2321,
+              "game-obj": "Rules",
+              "name": "temporary Hit Points",
+              "type": "link"
+            }
+          ],
+          "name": "Soul Roar",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              "name": "auditory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              "name": "spirit",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected and is immune to Soul Roar for 1 minute.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "frightened",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is frightened 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "doomed",
+              "aonid": 67,
+              "game-obj": "Conditions",
+              "name": "doomed",
+              "type": "link"
+            }
+          ],
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature is frightened 2 and doomed 1. If the target is already doomed, the doomed value increases by 1 (to a maximum of doomed 4).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "fleeing",
+              "aonid": 74,
+              "game-obj": "Conditions",
+              "name": "fleeing",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "The creature gains the fleeing condition for 1 round, is frightened 4, and is doomed 1. If the target is already doomed, the doomed value increases by 1 (to a maximum of doomed 4).",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "incapacitation",
+          "aonid": 631,
+          "game-obj": "Traits",
+          "name": "incapacitation",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        },
+        {
+          "alt": "dying",
+          "aonid": 69,
+          "game-obj": "Conditions",
+          "name": "dying",
+          "type": "link"
+        },
+        {
+          "alt": "auditory",
+          "aonid": 541,
+          "game-obj": "Traits",
+          "name": "auditory",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "spirit",
+          "aonid": 737,
+          "game-obj": "Traits",
+          "name": "spirit",
+          "type": "link"
+        },
+        {
+          "alt": "emanation",
+          "aonid": 2387,
+          "game-obj": "Rules",
+          "name": "emanation",
+          "type": "link"
+        },
+        {
+          "alt": "temporary Hit Points",
+          "aonid": 2321,
+          "game-obj": "Rules",
+          "name": "temporary Hit Points",
+          "type": "link"
+        },
+        {
+          "alt": "frightened",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened",
+          "type": "link"
+        },
+        {
+          "alt": "doomed",
+          "aonid": 67,
+          "game-obj": "Conditions",
+          "name": "doomed",
+          "type": "link"
+        },
+        {
+          "alt": "fleeing",
+          "aonid": 74,
+          "game-obj": "Conditions",
+          "name": "fleeing",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 126",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 126",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 126,
+          "type": "source"
+        }
+      ],
+      "text": "A requiem dragon\u2019s control over souls manifests in various ways. You can apply the following adjustments to a requiem dragon of any age.  \n  \nSome requiem dragons are spiteful enough to try to bring a living creature along with them when they die. To create a dragon with this ability, replace Withhold Death with the following.  \n  \n**Die Together** [@] (divine, incapacitation, void) **Trigger** The dragon dies; **Effect** The dragon tethers their soul to the soul of a living creature within 60 feet, pulling it along into death. The target must attempt a Fortitude save.   \n**Critical Success** The target is unaffected.   \n**Success** The target takes void damage equal to half the damage dealt by the dragon\u2019s Dooming Breath.   \n**Failure** The target takes void damage equal to the damage dealt by the dragon\u2019s Dooming Breath.  \n**Critical Failure** The target drops to 0 Hit Points and becomes dying 1, or increases its dying condition by 1 if it\u2019s already dying. While the target is dying, the dragon remains at 1 Hit Point and dies instantly if the target loses the dying condition.  \n  \nRequiem dragons who specialize in fighting against and alongside armies can let out a mighty roar that frightens their enemies and bolsters their allies. To create a dragon with this ability, replace Draconic Frenzy with the following.   \n  \n**Soul Roar** [#] (auditory, emotion, fear, mental, spirit) **Frequency** once per round; **Effect** The dragon lets out a mighty roar that rouses their allies and rattles the souls of their enemies. Each ally in a 120-foot emanation gains temporary Hit Points equal to the dragon\u2019s level that last for 1 minute, while each enemy within that area must attempt a Will save.  \n**Critical Success** The creature is unaffected and is immune to Soul Roar for 1 minute.  \n**Success** The creature is frightened 1.   \n**Failure** The creature is frightened 2 and doomed 1. If the target is already doomed, the doomed value increases by 1 (to a maximum of doomed 4).  \n**Critical Failure** The creature gains the fleeing condition for 1 round, is frightened 4, and is doomed 1. If the target is already doomed, the doomed value increases by 1 (to a maximum of doomed 4).",
+      "type": "section"
+    },
     {
       "name": "Requiem Dragon Spellcasters",
       "sources": [
@@ -1422,6 +963,961 @@
         }
       ],
       "text": "Requiem dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "ghostly tragedy",
+          "aonid": 1995,
+          "game-obj": "Spells",
+          "name": "ghostly tragedy",
+          "type": "link"
+        },
+        {
+          "alt": "talking corpse",
+          "aonid": 1712,
+          "game-obj": "Spells",
+          "name": "talking corpse",
+          "type": "link"
+        },
+        {
+          "alt": "vital beacon",
+          "aonid": 1743,
+          "game-obj": "Spells",
+          "name": "vital beacon",
+          "type": "link"
+        },
+        {
+          "alt": "protection",
+          "aonid": 1641,
+          "game-obj": "Spells",
+          "name": "protection",
+          "type": "link"
+        },
+        {
+          "alt": "ring of truth",
+          "aonid": 1656,
+          "game-obj": "Spells",
+          "name": "ring of truth",
+          "type": "link"
+        },
+        {
+          "alt": "safe passage",
+          "aonid": 1659,
+          "game-obj": "Spells",
+          "name": "safe passage",
+          "type": "link"
+        },
+        {
+          "alt": "see the unseen",
+          "aonid": 1663,
+          "game-obj": "Spells",
+          "name": "see the unseen",
+          "type": "link"
+        },
+        {
+          "alt": "share life",
+          "aonid": 1669,
+          "game-obj": "Spells",
+          "name": "share life",
+          "type": "link"
+        },
+        {
+          "alt": "thoughtful gift",
+          "aonid": 2037,
+          "game-obj": "Spells",
+          "name": "thoughtful gift",
+          "type": "link"
+        },
+        {
+          "alt": "sanctuary",
+          "aonid": 1660,
+          "game-obj": "Spells",
+          "name": "sanctuary",
+          "type": "link"
+        },
+        {
+          "alt": "spirit link",
+          "aonid": 1686,
+          "game-obj": "Spells",
+          "name": "spirit link",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "haunting hymn",
+          "aonid": 1999,
+          "game-obj": "Spells",
+          "name": "haunting hymn",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 1381,
+          "game-obj": "Rules",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Young Requiem Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 126",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 126",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 126,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ghostly tragedy",
+                      "aonid": 1995,
+                      "game-obj": "Spells",
+                      "name": "ghostly tragedy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ghostly tragedy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "talking corpse",
+                      "aonid": 1712,
+                      "game-obj": "Spells",
+                      "name": "talking corpse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "talking corpse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vital beacon",
+                      "aonid": 1743,
+                      "game-obj": "Spells",
+                      "name": "vital beacon",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vital beacon",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "protection",
+                      "aonid": 1641,
+                      "game-obj": "Spells",
+                      "name": "protection",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "protection",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ring of truth",
+                      "aonid": 1656,
+                      "game-obj": "Spells",
+                      "name": "ring of truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ring of truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "safe passage",
+                      "aonid": 1659,
+                      "game-obj": "Spells",
+                      "name": "safe passage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "safe passage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "see the unseen",
+                      "aonid": 1663,
+                      "game-obj": "Spells",
+                      "name": "see the unseen",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "see the unseen",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "share life",
+                      "aonid": 1669,
+                      "game-obj": "Spells",
+                      "name": "share life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "share life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "thoughtful gift",
+                      "aonid": 2037,
+                      "game-obj": "Spells",
+                      "name": "thoughtful gift",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "thoughtful gift",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "protection",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sanctuary",
+                      "aonid": 1660,
+                      "game-obj": "Spells",
+                      "name": "sanctuary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sanctuary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit link",
+                      "aonid": 1686,
+                      "game-obj": "Spells",
+                      "name": "spirit link",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit link",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haunting hymn",
+                      "aonid": 1999,
+                      "game-obj": "Spells",
+                      "name": "haunting hymn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 1381,
+                      "game-obj": "Rules",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 30, attack +22; **4th** *ghostly tragedy*, *talking corpse*, *vital beacon*; **3rd** *protection*, *ring of truth*, *safe passage*; **2nd** *see the unseen*, *share life*, *thoughtful gift*; **1st** *protection*, *sanctuary*, *spirit link*; **Cantrips (4th)** *guidance*, *haunting hymn*, *message*, *sigil*, stabilize",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "field of life",
+          "aonid": 1526,
+          "game-obj": "Spells",
+          "name": "field of life",
+          "type": "link"
+        },
+        {
+          "alt": "raise dead",
+          "aonid": 1645,
+          "game-obj": "Spells",
+          "name": "raise dead",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "breath of life",
+          "aonid": 1456,
+          "game-obj": "Spells",
+          "name": "breath of life",
+          "type": "link"
+        },
+        {
+          "alt": "invoke spirits",
+          "aonid": 1578,
+          "game-obj": "Spells",
+          "name": "invoke spirits",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Requiem Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 126",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 126",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 126,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As young requiem dragon"
+          ],
+          "saving_throw": {
+            "dc": 36,
+            "subtype": "save_dc",
+            "text": "DC 36",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 28,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "field of life",
+                      "aonid": 1526,
+                      "game-obj": "Spells",
+                      "name": "field of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "field of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "raise dead",
+                      "aonid": 1645,
+                      "game-obj": "Spells",
+                      "name": "raise dead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "raise dead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "vital beacon",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "breath of life",
+                      "aonid": 1456,
+                      "game-obj": "Spells",
+                      "name": "breath of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "breath of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "invoke spirits",
+                      "aonid": 1578,
+                      "game-obj": "Spells",
+                      "name": "invoke spirits",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "invoke spirits",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 36, attack +28; As young requiem dragon, plus **6th** *field of life*, *raise dead*, *vital beacon*; **5th** *banishment*, *breath of life*, *invoke spirits*; **Cantrips (6th)** *guidance*, *haunting hymn*, *message*, *sigil*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "foresight",
+              "aonid": 1537,
+              "game-obj": "Spells",
+              "name": "foresight",
+              "type": "link"
+            },
+            {
+              "alt": "seize soul",
+              "aonid": 1664,
+              "game-obj": "Spells",
+              "name": "seize soul",
+              "type": "link"
+            }
+          ],
+          "name": "9th",
+          "subtype": "ability",
+          "text": "*foresight*, *raise dead*, *seize soul*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "spirit song",
+              "aonid": 2029,
+              "game-obj": "Spells",
+              "name": "spirit song",
+              "type": "link"
+            }
+          ],
+          "name": "8th",
+          "subtype": "ability",
+          "text": "*field of life*, *safe passage*, *spirit song*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "interplanar teleport",
+              "aonid": 1576,
+              "game-obj": "Spells",
+              "name": "interplanar teleport",
+              "type": "link"
+            },
+            {
+              "alt": "planar seal",
+              "aonid": 1635,
+              "game-obj": "Spells",
+              "name": "planar seal",
+              "type": "link"
+            },
+            {
+              "alt": "regenerate",
+              "aonid": 1648,
+              "game-obj": "Spells",
+              "name": "regenerate",
+              "type": "link"
+            }
+          ],
+          "name": "7th",
+          "subtype": "ability",
+          "text": "*interplanar teleport*, *planar seal*, *regenerate*;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Cantrips (9th)",
+          "subtype": "ability",
+          "text": "*guidance*, *haunting hymn* , *message*, *sigil*, *stabilize*o",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "seize soul",
+          "aonid": 1664,
+          "game-obj": "Spells",
+          "name": "seize soul",
+          "type": "link"
+        },
+        {
+          "alt": "spirit song",
+          "aonid": 2029,
+          "game-obj": "Spells",
+          "name": "spirit song",
+          "type": "link"
+        },
+        {
+          "alt": "interplanar teleport",
+          "aonid": 1576,
+          "game-obj": "Spells",
+          "name": "interplanar teleport",
+          "type": "link"
+        },
+        {
+          "alt": "planar seal",
+          "aonid": 1635,
+          "game-obj": "Spells",
+          "name": "planar seal",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Requiem Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 126",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 126",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 126,
+          "type": "source"
+        }
+      ],
+      "text": "Divine Prepared Spells DC 42, attack +34; As adult requiem dragon, plus **9th** *foresight*, *raise dead*, *seize soul*; **8th** *field of life*, *safe passage*, *spirit song*; **7th** *interplanar teleport*, *planar seal*, *regenerate*; **Cantrips (9th)** *guidance*, *haunting hymn* , *message*, *sigil*, *stabilize*o",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "raise dead",
+          "aonid": 1645,
+          "game-obj": "Spells",
+          "name": "raise dead",
+          "type": "link"
+        },
+        {
+          "alt": "revival",
+          "aonid": 1654,
+          "game-obj": "Spells",
+          "name": "revival",
+          "type": "link"
+        },
+        {
+          "alt": "breath of life",
+          "aonid": 1456,
+          "game-obj": "Spells",
+          "name": "breath of life",
+          "type": "link"
+        }
+      ],
+      "name": "Requiem Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 126",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 126",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 126,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As ancient requiem dragon"
+          ],
+          "saving_throw": {
+            "dc": 48,
+            "subtype": "save_dc",
+            "text": "DC 48",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 40,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "raise dead",
+                      "aonid": 1645,
+                      "game-obj": "Spells",
+                      "name": "raise dead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "raise dead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revival",
+                      "aonid": 1654,
+                      "game-obj": "Spells",
+                      "name": "revival",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revival",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "breath of life",
+                      "aonid": 1456,
+                      "game-obj": "Spells",
+                      "name": "breath of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "breath of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 48, attack +40; As ancient requiem dragon plus **10th** *raise dead*, *revival*; **9th** *breath of life*; **Cantrips (10th)** *guidance*, *haunting hymn*, *message*, *sigil*, *stabilize*",
       "type": "section"
     },
     {
@@ -1764,6 +2260,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 126",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 126",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 126,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1911,6 +2463,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 126",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 126",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 126,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/dragon_resurrection.json
+++ b/monster_families/monster_core_2/dragon_resurrection.json
@@ -58,89 +58,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 60,
-                    "subtype": "area",
-                    "text": "60-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "effect": "Excess void energy spills out from the dragon in a 60-foot emanation. Each living creature in the area must succeed at a Fortitude save with a DC equal to the dragon\u2019s Soul Siphoning Breath or gain weakness to void equal to the dragon\u2019s resistance to spirit for 1 round (or 1 minute on a critical failure).",
-                "links": [
-                  {
-                    "alt": "emanation",
-                    "aonid": 2387,
-                    "game-obj": "Rules",
-                    "name": "emanation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "weakness",
-                    "aonid": 2317,
-                    "game-obj": "Rules",
-                    "name": "weakness",
-                    "type": "link"
-                  }
-                ],
-                "name": "Shred Souls",
-                "requirement": "The dragon\u2019s Soul Siphoning Breath recharged this turn",
-                "saving_throw": [
-                  {
-                    "dc": 20,
-                    "subtype": "save_dc",
-                    "text": "DC 20",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    },
-                    "name": "void",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "The resurrection dragon ends their turn",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].sections[?(@.name=='Healing')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "emanation",
+                "aonid": 2387,
+                "game-obj": "Rules",
+                "name": "emanation",
+                "type": "link"
+              },
+              {
+                "alt": "weakness",
+                "aonid": 2317,
+                "game-obj": "Rules",
+                "name": "weakness",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -150,99 +103,46 @@
         ],
         "name": "Healing",
         "subtype": "monster_family",
-        "text": "As a resurrection dragon heals themself, they can simultaneously weaken the living around them. To create a dragon with this ability, replace Draconic Momentum with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "divine",
-                    "href": "SpellLists.aspx?Tradition=2",
-                    "name": "divine",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "harm",
-                    "aonid": 1552,
-                    "game-obj": "Spells",
-                    "name": "harm",
-                    "type": "link"
-                  }
-                ],
-                "name": "Harmful Claw",
-                "subtype": "ability",
-                "text": "The resurrection dragon channels a divine spell into their claw. They Cast a 1-action version of *harm*, but the effects of the spell don\u2019t occur immediately. The dragon then makes a claw Strike. This counts as two attacks for the dragon\u2019s multiple attack penalty. The attack is imbued with the spell\u2019s effects according to the results of the Strike.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The Strike deals double damage as normal, and the target must attempt a basic Fortitude save against the spell\u2019s damage, but treats its result as one degree of success worse.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The Strike deals damage as normal, and the target attempts a basic Fortitude save against the spell\u2019s damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The Strike deals no damage, but the target must attempt a basic Fortitude save against the spell\u2019s damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "The Strike deals no damage, and the target is unaffected by the spell.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].sections[?(@.name=='Slaying')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "href": "SpellLists.aspx?Tradition=2",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "harm",
+                "aonid": 1552,
+                "game-obj": "Spells",
+                "name": "harm",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -252,69 +152,16 @@
         ],
         "name": "Slaying",
         "subtype": "monster_family",
-        "text": "Resurrection dragons who focus their power into slaying as much of the living as possible can wreath their claws in void energy. To create a dragon with this ability, replace Draconic Frenzy with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "create undead",
-                    "aonid": 117,
-                    "game-obj": "Rituals",
-                    "name": "create undead",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "mindless",
-                    "aonid": 652,
-                    "game-obj": "Traits",
-                    "name": "mindless",
-                    "type": "link"
-                  }
-                ],
-                "name": "Deathless Servant",
-                "subtype": "ability",
-                "text": "When a resurrection dragon performs the *create undead* ritual, they can create any common undead and don\u2019t require secondary casters. If the dragon creates a mindless undead creature whose level is at least 2 lower than themself, it automatically becomes the dragon\u2019s minion\u2014a deathless servant. This minion can\u2019t be destroyed unless the dragon is slain; if reduced to 0 Hit Points, such a minion returns to full Hit Points 1d6 days later. A resurrection dragon can have only one deathless servant at a time.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "unholy",
-                      "aonid": 521,
-                      "game-obj": "Traits",
-                      "name": "unholy",
-                      "type": "link"
-                    },
-                    "name": "unholy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].sections[?(@.name=='Necromancy')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -332,6 +179,34 @@
                 "game-obj": "Rituals",
                 "name": "create undead",
                 "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "unholy",
+                "aonid": 521,
+                "game-obj": "Traits",
+                "name": "unholy",
+                "type": "link"
+              },
+              {
+                "alt": "create undead",
+                "aonid": 117,
+                "game-obj": "Rituals",
+                "name": "create undead",
+                "type": "link"
+              },
+              {
+                "alt": "mindless",
+                "aonid": 652,
+                "game-obj": "Traits",
+                "name": "mindless",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -341,272 +216,117 @@
         ],
         "name": "Necromancy",
         "subtype": "monster_family",
-        "text": "More necromancy-focused resurrection dragons enjoy creating permanent undead minions. To create a dragon with this ability, give the dragon the *create undead* ritual and replace Risen Commander with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Innate Spells",
-                "saving_throw": {
-                  "dc": 26,
-                  "subtype": "save_dc",
-                  "text": "DC 26",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 18,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "final sacrifice",
-                            "aonid": 1992,
-                            "game-obj": "Spells",
-                            "name": "final sacrifice",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "final sacrifice",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sudden blight",
-                            "aonid": 2033,
-                            "game-obj": "Spells",
-                            "name": "sudden blight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sudden blight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vampiric feast",
-                            "aonid": 1736,
-                            "game-obj": "Spells",
-                            "name": "vampiric feast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vampiric feast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "heal",
-                            "aonid": 1554,
-                            "game-obj": "Spells",
-                            "name": "heal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "share life",
-                            "aonid": 1669,
-                            "game-obj": "Spells",
-                            "name": "share life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "share life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spirit sense",
-                            "aonid": 2028,
-                            "game-obj": "Spells",
-                            "name": "spirit sense",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spirit sense",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "infuse vitality",
-                            "aonid": 1574,
-                            "game-obj": "Spells",
-                            "name": "infuse vitality",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "infuse vitality",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grim tendrils",
-                            "aonid": 1548,
-                            "game-obj": "Spells",
-                            "name": "grim tendrils",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grim tendrils",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "guidance",
-                            "aonid": 1549,
-                            "game-obj": "Spells",
-                            "name": "guidance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haunting hymn",
-                            "aonid": 1999,
-                            "game-obj": "Spells",
-                            "name": "haunting hymn",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stabilize",
-                            "aonid": 1689,
-                            "game-obj": "Spells",
-                            "name": "stabilize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Innate Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Resurrection Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "final sacrifice",
+                "aonid": 1992,
+                "game-obj": "Spells",
+                "name": "final sacrifice",
+                "type": "link"
+              },
+              {
+                "alt": "sudden blight",
+                "aonid": 2033,
+                "game-obj": "Spells",
+                "name": "sudden blight",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric feast",
+                "aonid": 1736,
+                "game-obj": "Spells",
+                "name": "vampiric feast",
+                "type": "link"
+              },
+              {
+                "alt": "heal",
+                "aonid": 1554,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
+              },
+              {
+                "alt": "share life",
+                "aonid": 1669,
+                "game-obj": "Spells",
+                "name": "share life",
+                "type": "link"
+              },
+              {
+                "alt": "spirit sense",
+                "aonid": 2028,
+                "game-obj": "Spells",
+                "name": "spirit sense",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "infuse vitality",
+                "aonid": 1574,
+                "game-obj": "Spells",
+                "name": "infuse vitality",
+                "type": "link"
+              },
+              {
+                "alt": "grim tendrils",
+                "aonid": 1548,
+                "game-obj": "Spells",
+                "name": "grim tendrils",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "guidance",
+                "aonid": 1549,
+                "game-obj": "Spells",
+                "name": "guidance",
+                "type": "link"
+              },
+              {
+                "alt": "haunting hymn",
+                "aonid": 1999,
+                "game-obj": "Spells",
+                "name": "haunting hymn",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "stabilize",
+                "aonid": 1689,
+                "game-obj": "Spells",
+                "name": "stabilize",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -622,161 +342,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Innate Spells",
-                "notes": [
-                  "As young resurrection dragon"
-                ],
-                "saving_throw": {
-                  "dc": 32,
-                  "subtype": "save_dc",
-                  "text": "DC 32",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 24,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "heal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "invoke spirits",
-                            "aonid": 1578,
-                            "game-obj": "Spells",
-                            "name": "invoke spirits",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "invoke spirits",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "harm",
-                            "aonid": 1552,
-                            "game-obj": "Spells",
-                            "name": "harm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "harm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "summon undead",
-                            "aonid": 1706,
-                            "game-obj": "Spells",
-                            "name": "summon undead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "summon undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "talking corpse",
-                            "aonid": 1712,
-                            "game-obj": "Spells",
-                            "name": "talking corpse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "talking corpse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Innate Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Resurrection Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "invoke spirits",
+                "aonid": 1578,
+                "game-obj": "Spells",
+                "name": "invoke spirits",
+                "type": "link"
+              },
+              {
+                "alt": "harm",
+                "aonid": 1552,
+                "game-obj": "Spells",
+                "name": "harm",
+                "type": "link"
+              },
+              {
+                "alt": "summon undead",
+                "aonid": 1706,
+                "game-obj": "Spells",
+                "name": "summon undead",
+                "type": "link"
+              },
+              {
+                "alt": "talking corpse",
+                "aonid": 1712,
+                "game-obj": "Spells",
+                "name": "talking corpse",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -792,187 +399,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Innate Spells",
-                "notes": [
-                  "As adult resurrection dragon"
-                ],
-                "saving_throw": {
-                  "dc": 38,
-                  "subtype": "save_dc",
-                  "text": "DC 38",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 30,
-                "spell_list": [
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "moment of renewal",
-                            "aonid": 1607,
-                            "game-obj": "Spells",
-                            "name": "moment of renewal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "moment of renewal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "raise dead",
-                            "aonid": 1645,
-                            "game-obj": "Spells",
-                            "name": "raise dead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "raise dead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "execute",
-                            "aonid": 1519,
-                            "game-obj": "Spells",
-                            "name": "execute",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "execute",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "harm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "regenerate",
-                            "aonid": 1648,
-                            "game-obj": "Spells",
-                            "name": "regenerate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "regenerate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "field of life",
-                            "aonid": 1526,
-                            "game-obj": "Spells",
-                            "name": "field of life",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "field of life",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "raise dead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "summon undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 8,
-                    "level_text": "(8th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Innate Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Resurrection Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "moment of renewal",
+                "aonid": 1607,
+                "game-obj": "Spells",
+                "name": "moment of renewal",
+                "type": "link"
+              },
+              {
+                "alt": "raise dead",
+                "aonid": 1645,
+                "game-obj": "Spells",
+                "name": "raise dead",
+                "type": "link"
+              },
+              {
+                "alt": "execute",
+                "aonid": 1519,
+                "game-obj": "Spells",
+                "name": "execute",
+                "type": "link"
+              },
+              {
+                "alt": "regenerate",
+                "aonid": 1648,
+                "game-obj": "Spells",
+                "name": "regenerate",
+                "type": "link"
+              },
+              {
+                "alt": "field of life",
+                "aonid": 1526,
+                "game-obj": "Spells",
+                "name": "field of life",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -988,125 +456,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Divine Prepared Spells",
-                "notes": [
-                  "As ancient resurrection dragon"
-                ],
-                "saving_throw": {
-                  "dc": 46,
-                  "subtype": "save_dc",
-                  "text": "DC 46",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revival",
-                            "aonid": 1654,
-                            "game-obj": "Spells",
-                            "name": "revival",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revival",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "massacre",
-                            "aonid": 1596,
-                            "game-obj": "Spells",
-                            "name": "massacre",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "massacre",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wails of the damned",
-                            "aonid": 1747,
-                            "game-obj": "Spells",
-                            "name": "wails of the damned",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wails of the damned",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "guidance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "haunting hymn",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "stabilize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Divine",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Resurrection Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "revival",
+                "aonid": 1654,
+                "game-obj": "Spells",
+                "name": "revival",
+                "type": "link"
+              },
+              {
+                "alt": "massacre",
+                "aonid": 1596,
+                "game-obj": "Spells",
+                "name": "massacre",
+                "type": "link"
+              },
+              {
+                "alt": "wails of the damned",
+                "aonid": 1747,
+                "game-obj": "Spells",
+                "name": "wails of the damned",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1121,48 +498,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1173,263 +513,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1439,7 +563,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1450,6 +573,378 @@
   "sections": [
     {
       "name": "Alternate Abilities",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Free Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "emanation",
+                  "size": 60,
+                  "subtype": "area",
+                  "text": "60-foot emanation",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "effect": "Excess void energy spills out from the dragon in a 60-foot emanation. Each living creature in the area must succeed at a Fortitude save with a DC equal to the dragon\u2019s Soul Siphoning Breath or gain weakness to void equal to the dragon\u2019s resistance to spirit for 1 round (or 1 minute on a critical failure).",
+              "links": [
+                {
+                  "alt": "emanation",
+                  "aonid": 2387,
+                  "game-obj": "Rules",
+                  "name": "emanation",
+                  "type": "link"
+                },
+                {
+                  "alt": "weakness",
+                  "aonid": 2317,
+                  "game-obj": "Rules",
+                  "name": "weakness",
+                  "type": "link"
+                }
+              ],
+              "name": "Shred Souls",
+              "requirement": "The dragon\u2019s Soul Siphoning Breath recharged this turn",
+              "saving_throw": [
+                {
+                  "dc": 20,
+                  "subtype": "save_dc",
+                  "text": "DC 20",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 579,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "void",
+                    "aonid": 510,
+                    "game-obj": "Traits",
+                    "name": "void",
+                    "type": "link"
+                  },
+                  "name": "void",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "trigger": "The resurrection dragon ends their turn",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 579,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "void",
+              "aonid": 510,
+              "game-obj": "Traits",
+              "name": "void",
+              "type": "link"
+            },
+            {
+              "alt": "emanation",
+              "aonid": 2387,
+              "game-obj": "Rules",
+              "name": "emanation",
+              "type": "link"
+            },
+            {
+              "alt": "weakness",
+              "aonid": 2317,
+              "game-obj": "Rules",
+              "name": "weakness",
+              "type": "link"
+            }
+          ],
+          "name": "Healing",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 128",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 128",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 128,
+              "type": "source"
+            }
+          ],
+          "text": "As a resurrection dragon heals themself, they can simultaneously weaken the living around them. To create a dragon with this ability, replace Draconic Momentum with the following.  \n  \n**Shred Souls** (divine, void) [-] **Trigger** The resurrection dragon ends their turn; **Requirements** The dragon\u2019s Soul Siphoning Breath recharged this turn; **Effect** Excess void energy spills out from the dragon in a 60-foot emanation. Each living creature in the area must succeed at a Fortitude save with a DC equal to the dragon\u2019s Soul Siphoning Breath or gain weakness to void equal to the dragon\u2019s resistance to spirit for 1 round (or 1 minute on a critical failure).",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "divine",
+                  "href": "SpellLists.aspx?Tradition=2",
+                  "name": "divine",
+                  "type": "link"
+                },
+                {
+                  "alt": "harm",
+                  "aonid": 1552,
+                  "game-obj": "Spells",
+                  "name": "harm",
+                  "type": "link"
+                }
+              ],
+              "name": "Harmful Claw",
+              "subtype": "ability",
+              "text": "The resurrection dragon channels a divine spell into their claw. They Cast a 1-action version of *harm*, but the effects of the spell don\u2019t occur immediately. The dragon then makes a claw Strike. This counts as two attacks for the dragon\u2019s multiple attack penalty. The attack is imbued with the spell\u2019s effects according to the results of the Strike.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 579,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Critical Success",
+              "subtype": "ability",
+              "text": "The Strike deals double damage as normal, and the target must attempt a basic Fortitude save against the spell\u2019s damage, but treats its result as one degree of success worse.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 2297,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Success",
+              "subtype": "ability",
+              "text": "The Strike deals damage as normal, and the target attempts a basic Fortitude save against the spell\u2019s damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Failure",
+              "subtype": "ability",
+              "text": "The Strike deals no damage, but the target must attempt a basic Fortitude save against the spell\u2019s damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Critical Failure",
+              "subtype": "ability",
+              "text": "The Strike deals no damage, and the target is unaffected by the spell.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "divine",
+              "aonid": 579,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "href": "SpellLists.aspx?Tradition=2",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "harm",
+              "aonid": 1552,
+              "game-obj": "Spells",
+              "name": "harm",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Slaying",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 128",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 128",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 128,
+              "type": "source"
+            }
+          ],
+          "text": "Resurrection dragons who focus their power into slaying as much of the living as possible can wreath their claws in void energy. To create a dragon with this ability, replace Draconic Frenzy with the following.   \n  \n**Harmful Claw** [##] (divine) The resurrection dragon channels a divine spell into their claw. They Cast a 1-action version of *harm*, but the effects of the spell don\u2019t occur immediately. The dragon then makes a claw Strike. This counts as two attacks for the dragon\u2019s multiple attack penalty. The attack is imbued with the spell\u2019s effects according to the results of the Strike.   \n**Critical Success** The Strike deals double damage as normal, and the target must attempt a basic Fortitude save against the spell\u2019s damage, but treats its result as one degree of success worse.  \n**Success** The Strike deals damage as normal, and the target attempts a basic Fortitude save against the spell\u2019s damage.  \n**Failure** The Strike deals no damage, but the target must attempt a basic Fortitude save against the spell\u2019s damage.  \n**Critical Failure** The Strike deals no damage, and the target is unaffected by the spell.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "create undead",
+                  "aonid": 117,
+                  "game-obj": "Rituals",
+                  "name": "create undead",
+                  "type": "link"
+                },
+                {
+                  "alt": "mindless",
+                  "aonid": 652,
+                  "game-obj": "Traits",
+                  "name": "mindless",
+                  "type": "link"
+                }
+              ],
+              "name": "Deathless Servant",
+              "subtype": "ability",
+              "text": "When a resurrection dragon performs the *create undead* ritual, they can create any common undead and don\u2019t require secondary casters. If the dragon creates a mindless undead creature whose level is at least 2 lower than themself, it automatically becomes the dragon\u2019s minion\u2014a deathless servant. This minion can\u2019t be destroyed unless the dragon is slain; if reduced to 0 Hit Points, such a minion returns to full Hit Points 1d6 days later. A resurrection dragon can have only one deathless servant at a time.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 579,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "unholy",
+                    "aonid": 521,
+                    "game-obj": "Traits",
+                    "name": "unholy",
+                    "type": "link"
+                  },
+                  "name": "unholy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 722,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "create undead",
+              "aonid": 117,
+              "game-obj": "Rituals",
+              "name": "create undead",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 579,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "unholy",
+              "aonid": 521,
+              "game-obj": "Traits",
+              "name": "unholy",
+              "type": "link"
+            },
+            {
+              "alt": "create undead",
+              "aonid": 117,
+              "game-obj": "Rituals",
+              "name": "create undead",
+              "type": "link"
+            },
+            {
+              "alt": "mindless",
+              "aonid": 652,
+              "game-obj": "Traits",
+              "name": "mindless",
+              "type": "link"
+            }
+          ],
+          "name": "Necromancy",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 128",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 128",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 128,
+              "type": "source"
+            }
+          ],
+          "text": "More necromancy-focused resurrection dragons enjoy creating permanent undead minions. To create a dragon with this ability, give the dragon the *create undead* ritual and replace Risen Commander with the following.  \n  \n**Deathless Servant** (divine, unholy) When a resurrection dragon performs the *create undead* ritual, they can create any common undead and don\u2019t require secondary casters. If the dragon creates a mindless undead creature whose level is at least 2 lower than themself, it automatically becomes the dragon\u2019s minion\u2014a deathless servant. This minion can\u2019t be destroyed unless the dragon is slain; if reduced to 0 Hit Points, such a minion returns to full Hit Points 1d6 days later. A resurrection dragon can have only one deathless servant at a time.",
+          "type": "section"
+        }
+      ],
       "sources": [
         {
           "link": {
@@ -1484,6 +979,1001 @@
         }
       ],
       "text": "Resurrection dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "final sacrifice",
+          "aonid": 1992,
+          "game-obj": "Spells",
+          "name": "final sacrifice",
+          "type": "link"
+        },
+        {
+          "alt": "sudden blight",
+          "aonid": 2033,
+          "game-obj": "Spells",
+          "name": "sudden blight",
+          "type": "link"
+        },
+        {
+          "alt": "vampiric feast",
+          "aonid": 1736,
+          "game-obj": "Spells",
+          "name": "vampiric feast",
+          "type": "link"
+        },
+        {
+          "alt": "heal",
+          "aonid": 1554,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        },
+        {
+          "alt": "share life",
+          "aonid": 1669,
+          "game-obj": "Spells",
+          "name": "share life",
+          "type": "link"
+        },
+        {
+          "alt": "spirit sense",
+          "aonid": 2028,
+          "game-obj": "Spells",
+          "name": "spirit sense",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "infuse vitality",
+          "aonid": 1574,
+          "game-obj": "Spells",
+          "name": "infuse vitality",
+          "type": "link"
+        },
+        {
+          "alt": "grim tendrils",
+          "aonid": 1548,
+          "game-obj": "Spells",
+          "name": "grim tendrils",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "guidance",
+          "aonid": 1549,
+          "game-obj": "Spells",
+          "name": "guidance",
+          "type": "link"
+        },
+        {
+          "alt": "haunting hymn",
+          "aonid": 1999,
+          "game-obj": "Spells",
+          "name": "haunting hymn",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "stabilize",
+          "aonid": 1689,
+          "game-obj": "Spells",
+          "name": "stabilize",
+          "type": "link"
+        }
+      ],
+      "name": "Young Resurrection Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 128",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 128",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 128,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Innate Spells",
+          "saving_throw": {
+            "dc": 26,
+            "subtype": "save_dc",
+            "text": "DC 26",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 18,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "final sacrifice",
+                      "aonid": 1992,
+                      "game-obj": "Spells",
+                      "name": "final sacrifice",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "final sacrifice",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sudden blight",
+                      "aonid": 2033,
+                      "game-obj": "Spells",
+                      "name": "sudden blight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sudden blight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vampiric feast",
+                      "aonid": 1736,
+                      "game-obj": "Spells",
+                      "name": "vampiric feast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vampiric feast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "heal",
+                      "aonid": 1554,
+                      "game-obj": "Spells",
+                      "name": "heal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "share life",
+                      "aonid": 1669,
+                      "game-obj": "Spells",
+                      "name": "share life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "share life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spirit sense",
+                      "aonid": 2028,
+                      "game-obj": "Spells",
+                      "name": "spirit sense",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spirit sense",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "infuse vitality",
+                      "aonid": 1574,
+                      "game-obj": "Spells",
+                      "name": "infuse vitality",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "infuse vitality",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grim tendrils",
+                      "aonid": 1548,
+                      "game-obj": "Spells",
+                      "name": "grim tendrils",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grim tendrils",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "guidance",
+                      "aonid": 1549,
+                      "game-obj": "Spells",
+                      "name": "guidance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haunting hymn",
+                      "aonid": 1999,
+                      "game-obj": "Spells",
+                      "name": "haunting hymn",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stabilize",
+                      "aonid": 1689,
+                      "game-obj": "Spells",
+                      "name": "stabilize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Innate Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Innate Spells** DC 26, attack +18; **3rd** *final sacrifice*, *sudden blight*, *vampiric feast*; **2nd** *heal*, *share life*, *spirit sense*; **1st** *command*, *infuse vitality*, *grim tendrils*; **Cantrips (3rd)** *detect magic*, *guidance*, *haunting hymn*, *read aura*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "invoke spirits",
+          "aonid": 1578,
+          "game-obj": "Spells",
+          "name": "invoke spirits",
+          "type": "link"
+        },
+        {
+          "alt": "harm",
+          "aonid": 1552,
+          "game-obj": "Spells",
+          "name": "harm",
+          "type": "link"
+        },
+        {
+          "alt": "summon undead",
+          "aonid": 1706,
+          "game-obj": "Spells",
+          "name": "summon undead",
+          "type": "link"
+        },
+        {
+          "alt": "talking corpse",
+          "aonid": 1712,
+          "game-obj": "Spells",
+          "name": "talking corpse",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Resurrection Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 128",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 128",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 128,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Innate Spells",
+          "notes": [
+            "As young resurrection dragon"
+          ],
+          "saving_throw": {
+            "dc": 32,
+            "subtype": "save_dc",
+            "text": "DC 32",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 24,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "heal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "invoke spirits",
+                      "aonid": 1578,
+                      "game-obj": "Spells",
+                      "name": "invoke spirits",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "invoke spirits",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "harm",
+                      "aonid": 1552,
+                      "game-obj": "Spells",
+                      "name": "harm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "harm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "summon undead",
+                      "aonid": 1706,
+                      "game-obj": "Spells",
+                      "name": "summon undead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "summon undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "talking corpse",
+                      "aonid": 1712,
+                      "game-obj": "Spells",
+                      "name": "talking corpse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "talking corpse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Innate Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Innate Spells** DC 32, attack +24; As young resurrection dragon, plus **5th** *dispel magic*, *heal*, *invoke spirits*; **4th** *harm*, *summon undead*, *talking corpse*; **Cantrips (5th)** *detect magic*, *guidance*, *haunting hymn*, *read aura*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "moment of renewal",
+          "aonid": 1607,
+          "game-obj": "Spells",
+          "name": "moment of renewal",
+          "type": "link"
+        },
+        {
+          "alt": "raise dead",
+          "aonid": 1645,
+          "game-obj": "Spells",
+          "name": "raise dead",
+          "type": "link"
+        },
+        {
+          "alt": "execute",
+          "aonid": 1519,
+          "game-obj": "Spells",
+          "name": "execute",
+          "type": "link"
+        },
+        {
+          "alt": "regenerate",
+          "aonid": 1648,
+          "game-obj": "Spells",
+          "name": "regenerate",
+          "type": "link"
+        },
+        {
+          "alt": "field of life",
+          "aonid": 1526,
+          "game-obj": "Spells",
+          "name": "field of life",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Resurrection Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 128",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 128",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 128,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Innate Spells",
+          "notes": [
+            "As adult resurrection dragon"
+          ],
+          "saving_throw": {
+            "dc": 38,
+            "subtype": "save_dc",
+            "text": "DC 38",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 30,
+          "spell_list": [
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "moment of renewal",
+                      "aonid": 1607,
+                      "game-obj": "Spells",
+                      "name": "moment of renewal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "moment of renewal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "raise dead",
+                      "aonid": 1645,
+                      "game-obj": "Spells",
+                      "name": "raise dead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "raise dead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "execute",
+                      "aonid": 1519,
+                      "game-obj": "Spells",
+                      "name": "execute",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "execute",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "harm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "regenerate",
+                      "aonid": 1648,
+                      "game-obj": "Spells",
+                      "name": "regenerate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "regenerate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "field of life",
+                      "aonid": 1526,
+                      "game-obj": "Spells",
+                      "name": "field of life",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "field of life",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "raise dead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "summon undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 8,
+              "level_text": "(8th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Innate Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Innate Spells** DC 38, attack +30; As adult resurrection dragon, plus **8th** *moment of renewal*, *raise dead*, *summon undead*; **7th** *execute*, *harm*, *regenerate*; **6th** *field of life*, *raise dead*, *summon undead*; **Cantrips (8th)** *detect magic*, *guidance*, *haunting hymn*, *read aura*, *stabilize*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "revival",
+          "aonid": 1654,
+          "game-obj": "Spells",
+          "name": "revival",
+          "type": "link"
+        },
+        {
+          "alt": "massacre",
+          "aonid": 1596,
+          "game-obj": "Spells",
+          "name": "massacre",
+          "type": "link"
+        },
+        {
+          "alt": "wails of the damned",
+          "aonid": 1747,
+          "game-obj": "Spells",
+          "name": "wails of the damned",
+          "type": "link"
+        }
+      ],
+      "name": "Resurrection Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 128",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 128",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 128,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Divine Prepared Spells",
+          "notes": [
+            "As ancient resurrection dragon"
+          ],
+          "saving_throw": {
+            "dc": 46,
+            "subtype": "save_dc",
+            "text": "DC 46",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revival",
+                      "aonid": 1654,
+                      "game-obj": "Spells",
+                      "name": "revival",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revival",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "massacre",
+                      "aonid": 1596,
+                      "game-obj": "Spells",
+                      "name": "massacre",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "massacre",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wails of the damned",
+                      "aonid": 1747,
+                      "game-obj": "Spells",
+                      "name": "wails of the damned",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wails of the damned",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "guidance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "haunting hymn",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "stabilize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Divine",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Divine Prepared Spells** DC 46, attack +38; As ancient resurrection dragon plus **10th** *revival*; **9th** *massacre*, *wails of the damned*; **Cantrips (10th)** *detect magic*, *guidance*, *haunting hymn*, *read aura*, *stabilize*",
       "type": "section"
     },
     {
@@ -1826,6 +2316,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 128",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 128",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 128,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -1973,6 +2519,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 128",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 128",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 128,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/dragon_rune.json
+++ b/monster_families/monster_core_2/dragon_rune.json
@@ -58,156 +58,84 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 10,
-                    "subtype": "area",
-                    "text": "10-foot burst",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "burst",
-                    "aonid": 2385,
-                    "game-obj": "Rules",
-                    "name": "burst",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "difficult terrain",
-                    "aonid": 2366,
-                    "game-obj": "Rules",
-                    "name": "difficult terrain",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "concealed",
-                    "aonid": 62,
-                    "game-obj": "Conditions",
-                    "name": "concealed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "move",
-                    "aonid": 658,
-                    "game-obj": "Traits",
-                    "name": "move",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Interact",
-                    "aonid": 2297,
-                    "game-obj": "Actions",
-                    "name": "Interact",
-                    "type": "link"
-                  }
-                ],
-                "name": "Runic Jail",
-                "subtype": "ability",
-                "text": "The rune dragon conjures a prison that promises pain to those within and those who try to escape. The dragon creates a runic jail in a 10-foot burst up to 60 feet away. The area is difficult terrain and creatures outside the jail become concealed to creatures within it. If a creature uses a move action to leave the runic jail, they gain a detonating rune. The runic jail lasts for 1 round, but a creature adjacent to the jail, but not within it, can use an Interact action to remove the rune early.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot burst",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "burst",
-                    "aonid": 2385,
-                    "game-obj": "Rules",
-                    "name": "burst",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 2297,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Interact",
-                    "aonid": 2297,
-                    "game-obj": "Actions",
-                    "name": "Interact",
-                    "type": "link"
-                  }
-                ],
-                "name": "Catalyzing Rune",
-                "saving_throw": [
-                  {
-                    "dc": 34,
-                    "subtype": "save_dc",
-                    "text": "DC 34",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The dragon creates a highly reactive rune in a 30-foot burst up to 60 feet away. Whenever a creature takes damage from a detonating rune while within the area, all other creatures in the area take the damage of the detonating rune (basic Reflex save DC 34). The Catalyzing Rune lasts for 1 minute but can be removed if creatures adjacent to the rune spend two Interact actions.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Adult Rune Dragon:')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "burst",
+                "aonid": 2385,
+                "game-obj": "Rules",
+                "name": "burst",
+                "type": "link"
+              },
+              {
+                "alt": "difficult terrain",
+                "aonid": 2366,
+                "game-obj": "Rules",
+                "name": "difficult terrain",
+                "type": "link"
+              },
+              {
+                "alt": "concealed",
+                "aonid": 62,
+                "game-obj": "Conditions",
+                "name": "concealed",
+                "type": "link"
+              },
+              {
+                "alt": "move",
+                "aonid": 658,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
+              },
+              {
+                "alt": "Interact",
+                "aonid": 2297,
+                "game-obj": "Actions",
+                "name": "Interact",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "burst",
+                "aonid": 2385,
+                "game-obj": "Rules",
+                "name": "burst",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 2297,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "Interact",
+                "aonid": 2297,
+                "game-obj": "Actions",
+                "name": "Interact",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -222,114 +150,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 20,
-                    "subtype": "area",
-                    "text": "20-foot burst",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "burst",
-                    "aonid": 2385,
-                    "game-obj": "Rules",
-                    "name": "burst",
-                    "type": "link"
-                  }
-                ],
-                "name": "Runic Jail",
-                "subtype": "ability",
-                "text": "As adult rune dragon, but the area is a 20-foot burst.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 40,
-                    "subtype": "area",
-                    "text": "40-foot burst",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "burst",
-                    "aonid": 2385,
-                    "game-obj": "Rules",
-                    "name": "burst",
-                    "type": "link"
-                  }
-                ],
-                "name": "Catalyzing Rune",
-                "saving_throw": [
-                  {
-                    "dc": 41,
-                    "subtype": "save_dc",
-                    "text": "DC 41",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "As adult rune dragon, but the area is a 40-foot burst and the DC is 41.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Ancient Rune Dragon:')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "burst",
+                "aonid": 2385,
+                "game-obj": "Rules",
+                "name": "burst",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "burst",
+                "aonid": 2385,
+                "game-obj": "Rules",
+                "name": "burst",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -344,114 +200,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot burst",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "burst",
-                    "aonid": 2385,
-                    "game-obj": "Rules",
-                    "name": "burst",
-                    "type": "link"
-                  }
-                ],
-                "name": "Runic Jail",
-                "subtype": "ability",
-                "text": "As adult rune dragon, but the area is a 30-foot burst.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 60,
-                    "subtype": "area",
-                    "text": "60-foot burst",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "burst",
-                    "aonid": 2385,
-                    "game-obj": "Rules",
-                    "name": "burst",
-                    "type": "link"
-                  }
-                ],
-                "name": "Catalyzing Rune",
-                "saving_throw": [
-                  {
-                    "dc": 46,
-                    "subtype": "save_dc",
-                    "text": "DC 46",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "As adult rune dragon, but the area is a 60-foot burst and the DC is 46.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 534,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Rune Archdragon:')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "burst",
+                "aonid": 2385,
+                "game-obj": "Rules",
+                "name": "burst",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "burst",
+                "aonid": 2385,
+                "game-obj": "Rules",
+                "name": "burst",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -467,309 +251,125 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "saving_throw": {
-                  "dc": 29,
-                  "subtype": "save_dc",
-                  "text": "DC 29",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 21,
-                "spell_list": [
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translate",
-                            "aonid": 1723,
-                            "game-obj": "Spells",
-                            "name": "translate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of fire",
-                            "aonid": 1748,
-                            "game-obj": "Spells",
-                            "name": "wall of fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fireball",
-                            "aonid": 1530,
-                            "game-obj": "Spells",
-                            "name": "fireball",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gravity well",
-                            "aonid": 1997,
-                            "game-obj": "Spells",
-                            "name": "gravity well",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gravity well",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "veil of privacy",
-                            "aonid": 1739,
-                            "game-obj": "Spells",
-                            "name": "veil of privacy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "veil of privacy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blur",
-                            "aonid": 1455,
-                            "game-obj": "Spells",
-                            "name": "blur",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blur",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "embed message",
-                            "aonid": 1511,
-                            "game-obj": "Spells",
-                            "name": "embed message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "embed message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "translate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "alarm",
-                            "aonid": 1439,
-                            "game-obj": "Spells",
-                            "name": "alarm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "alarm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gust of wind",
-                            "aonid": 1550,
-                            "game-obj": "Spells",
-                            "name": "gust of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gust of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 4,
-                    "level_text": "(4th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ignition",
-                            "aonid": 1565,
-                            "game-obj": "Spells",
-                            "name": "ignition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Rune Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "translate",
+                "aonid": 1723,
+                "game-obj": "Spells",
+                "name": "translate",
+                "type": "link"
+              },
+              {
+                "alt": "wall of fire",
+                "aonid": 1748,
+                "game-obj": "Spells",
+                "name": "wall of fire",
+                "type": "link"
+              },
+              {
+                "alt": "fireball",
+                "aonid": 1530,
+                "game-obj": "Spells",
+                "name": "fireball",
+                "type": "link"
+              },
+              {
+                "alt": "gravity well",
+                "aonid": 1997,
+                "game-obj": "Spells",
+                "name": "gravity well",
+                "type": "link"
+              },
+              {
+                "alt": "veil of privacy",
+                "aonid": 1739,
+                "game-obj": "Spells",
+                "name": "veil of privacy",
+                "type": "link"
+              },
+              {
+                "alt": "blur",
+                "aonid": 1455,
+                "game-obj": "Spells",
+                "name": "blur",
+                "type": "link"
+              },
+              {
+                "alt": "embed message",
+                "aonid": 1511,
+                "game-obj": "Spells",
+                "name": "embed message",
+                "type": "link"
+              },
+              {
+                "alt": "alarm",
+                "aonid": 1439,
+                "game-obj": "Spells",
+                "name": "alarm",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "gust of wind",
+                "aonid": 1550,
+                "game-obj": "Spells",
+                "name": "gust of wind",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "ignition",
+                "aonid": 1565,
+                "game-obj": "Spells",
+                "name": "ignition",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -785,170 +385,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As young rune dragon"
-                ],
-                "saving_throw": {
-                  "dc": 34,
-                  "subtype": "save_dc",
-                  "text": "DC 34",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 26,
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chain lightning",
-                            "aonid": 1462,
-                            "game-obj": "Spells",
-                            "name": "chain lightning",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "chain lightning",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scrying",
-                            "aonid": 1662,
-                            "game-obj": "Spells",
-                            "name": "scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of force",
-                            "aonid": 1749,
-                            "game-obj": "Spells",
-                            "name": "wall of force",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of force",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "howling blizzard",
-                            "aonid": 1559,
-                            "game-obj": "Spells",
-                            "name": "howling blizzard",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "howling blizzard",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "imaginary lockbox",
-                            "aonid": 2002,
-                            "game-obj": "Spells",
-                            "name": "imaginary lockbox",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "imaginary lockbox",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "truespeech",
-                            "aonid": 1728,
-                            "game-obj": "Spells",
-                            "name": "truespeech",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "truespeech",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Rune Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "chain lightning",
+                "aonid": 1462,
+                "game-obj": "Spells",
+                "name": "chain lightning",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 1662,
+                "game-obj": "Spells",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "wall of force",
+                "aonid": 1749,
+                "game-obj": "Spells",
+                "name": "wall of force",
+                "type": "link"
+              },
+              {
+                "alt": "howling blizzard",
+                "aonid": 1559,
+                "game-obj": "Spells",
+                "name": "howling blizzard",
+                "type": "link"
+              },
+              {
+                "alt": "imaginary lockbox",
+                "aonid": 2002,
+                "game-obj": "Spells",
+                "name": "imaginary lockbox",
+                "type": "link"
+              },
+              {
+                "alt": "truespeech",
+                "aonid": 1728,
+                "game-obj": "Spells",
+                "name": "truespeech",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -964,214 +449,69 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As adult rune dragon"
-                ],
-                "saving_throw": {
-                  "dc": 41,
-                  "subtype": "save_dc",
-                  "text": "DC 41",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 33,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detonate magic",
-                            "aonid": 1488,
-                            "game-obj": "Spells",
-                            "name": "detonate magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detonate magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "falling stars",
-                            "aonid": 1521,
-                            "game-obj": "Spells",
-                            "name": "falling stars",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "falling stars",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "foresight",
-                            "aonid": 1537,
-                            "game-obj": "Spells",
-                            "name": "foresight",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "foresight",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "quandary",
-                            "aonid": 1644,
-                            "game-obj": "Spells",
-                            "name": "quandary",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "quandary",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unrelenting observation",
-                            "aonid": 1734,
-                            "game-obj": "Spells",
-                            "name": "unrelenting observation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unrelenting observation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar seal",
-                            "aonid": 1635,
-                            "game-obj": "Spells",
-                            "name": "planar seal",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar seal",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "spell riposte",
-                            "aonid": 2027,
-                            "game-obj": "Spells",
-                            "name": "spell riposte",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "spell riposte",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hando",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Rune Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "detonate magic",
+                "aonid": 1488,
+                "game-obj": "Spells",
+                "name": "detonate magic",
+                "type": "link"
+              },
+              {
+                "alt": "falling stars",
+                "aonid": 1521,
+                "game-obj": "Spells",
+                "name": "falling stars",
+                "type": "link"
+              },
+              {
+                "alt": "foresight",
+                "aonid": 1537,
+                "game-obj": "Spells",
+                "name": "foresight",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "quandary",
+                "aonid": 1644,
+                "game-obj": "Spells",
+                "name": "quandary",
+                "type": "link"
+              },
+              {
+                "alt": "unrelenting observation",
+                "aonid": 1734,
+                "game-obj": "Spells",
+                "name": "unrelenting observation",
+                "type": "link"
+              },
+              {
+                "alt": "planar seal",
+                "aonid": 1635,
+                "game-obj": "Spells",
+                "name": "planar seal",
+                "type": "link"
+              },
+              {
+                "alt": "spell riposte",
+                "aonid": 2027,
+                "game-obj": "Spells",
+                "name": "spell riposte",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1187,125 +527,34 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Arcane Prepared Spells",
-                "notes": [
-                  "As ancient rune dragon"
-                ],
-                "saving_throw": {
-                  "dc": 46,
-                  "subtype": "save_dc",
-                  "text": "DC 46",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 38,
-                "spell_list": [
-                  {
-                    "level": 10,
-                    "level_text": "10th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cataclysm",
-                            "aonid": 1460,
-                            "game-obj": "Spells",
-                            "name": "cataclysm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cataclysm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "implosion",
-                            "aonid": 1572,
-                            "game-obj": "Spells",
-                            "name": "implosion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "implosion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 10,
-                    "level_text": "(10th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Arcane",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Rune Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "cataclysm",
+                "aonid": 1460,
+                "game-obj": "Spells",
+                "name": "cataclysm",
+                "type": "link"
+              },
+              {
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
+              },
+              {
+                "alt": "implosion",
+                "aonid": 1572,
+                "game-obj": "Spells",
+                "name": "implosion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1320,48 +569,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1372,263 +584,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1638,7 +634,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1667,6 +662,543 @@
       "type": "section"
     },
     {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 10,
+              "subtype": "area",
+              "text": "10-foot burst",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "burst",
+              "aonid": 2385,
+              "game-obj": "Rules",
+              "name": "burst",
+              "type": "link"
+            },
+            {
+              "alt": "difficult terrain",
+              "aonid": 2366,
+              "game-obj": "Rules",
+              "name": "difficult terrain",
+              "type": "link"
+            },
+            {
+              "alt": "concealed",
+              "aonid": 62,
+              "game-obj": "Conditions",
+              "name": "concealed",
+              "type": "link"
+            },
+            {
+              "alt": "move",
+              "aonid": 658,
+              "game-obj": "Traits",
+              "name": "move",
+              "type": "link"
+            },
+            {
+              "alt": "Interact",
+              "aonid": 2297,
+              "game-obj": "Actions",
+              "name": "Interact",
+              "type": "link"
+            }
+          ],
+          "name": "Runic Jail",
+          "subtype": "ability",
+          "text": "The rune dragon conjures a prison that promises pain to those within and those who try to escape. The dragon creates a runic jail in a 10-foot burst up to 60 feet away. The area is difficult terrain and creatures outside the jail become concealed to creatures within it. If a creature uses a move action to leave the runic jail, they gain a detonating rune. The runic jail lasts for 1 round, but a creature adjacent to the jail, but not within it, can use an Interact action to remove the rune early.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot burst",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "burst",
+              "aonid": 2385,
+              "game-obj": "Rules",
+              "name": "burst",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 2297,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "Interact",
+              "aonid": 2297,
+              "game-obj": "Actions",
+              "name": "Interact",
+              "type": "link"
+            }
+          ],
+          "name": "Catalyzing Rune",
+          "saving_throw": [
+            {
+              "dc": 34,
+              "subtype": "save_dc",
+              "text": "DC 34",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The dragon creates a highly reactive rune in a 30-foot burst up to 60 feet away. Whenever a creature takes damage from a detonating rune while within the area, all other creatures in the area take the damage of the detonating rune (basic Reflex save DC 34). The Catalyzing Rune lasts for 1 minute but can be removed if creatures adjacent to the rune spend two Interact actions.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "burst",
+          "aonid": 2385,
+          "game-obj": "Rules",
+          "name": "burst",
+          "type": "link"
+        },
+        {
+          "alt": "difficult terrain",
+          "aonid": 2366,
+          "game-obj": "Rules",
+          "name": "difficult terrain",
+          "type": "link"
+        },
+        {
+          "alt": "concealed",
+          "aonid": 62,
+          "game-obj": "Conditions",
+          "name": "concealed",
+          "type": "link"
+        },
+        {
+          "alt": "move",
+          "aonid": 658,
+          "game-obj": "Traits",
+          "name": "move",
+          "type": "link"
+        },
+        {
+          "alt": "Interact",
+          "aonid": 2297,
+          "game-obj": "Actions",
+          "name": "Interact",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "burst",
+          "aonid": 2385,
+          "game-obj": "Rules",
+          "name": "burst",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 2297,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "Interact",
+          "aonid": 2297,
+          "game-obj": "Actions",
+          "name": "Interact",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Rune Dragon:",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 131",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 131",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "text": "**Runic Jail** [#] (arcane) The rune dragon conjures a prison that promises pain to those within and those who try to escape. The dragon creates a runic jail in a 10-foot burst up to 60 feet away. The area is difficult terrain and creatures outside the jail become concealed to creatures within it. If a creature uses a move action to leave the runic jail, they gain a detonating rune. The runic jail lasts for 1 round, but a creature adjacent to the jail, but not within it, can use an Interact action to remove the rune early.  \n  \n**Catalyzing Rune** [#] (arcane) The dragon creates a highly reactive rune in a 30-foot burst up to 60 feet away. Whenever a creature takes damage from a detonating rune while within the area, all other creatures in the area take the damage of the detonating rune (basic Reflex save DC 34). The Catalyzing Rune lasts for 1 minute but can be removed if creatures adjacent to the rune spend two Interact actions.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 20,
+              "subtype": "area",
+              "text": "20-foot burst",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "burst",
+              "aonid": 2385,
+              "game-obj": "Rules",
+              "name": "burst",
+              "type": "link"
+            }
+          ],
+          "name": "Runic Jail",
+          "subtype": "ability",
+          "text": "As adult rune dragon, but the area is a 20-foot burst.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 40,
+              "subtype": "area",
+              "text": "40-foot burst",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "burst",
+              "aonid": 2385,
+              "game-obj": "Rules",
+              "name": "burst",
+              "type": "link"
+            }
+          ],
+          "name": "Catalyzing Rune",
+          "saving_throw": [
+            {
+              "dc": 41,
+              "subtype": "save_dc",
+              "text": "DC 41",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "As adult rune dragon, but the area is a 40-foot burst and the DC is 41.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "burst",
+          "aonid": 2385,
+          "game-obj": "Rules",
+          "name": "burst",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "burst",
+          "aonid": 2385,
+          "game-obj": "Rules",
+          "name": "burst",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Rune Dragon:",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 131",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 131",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "text": "**Runic Jail** [#] (arcane) As adult rune dragon, but the area is a 20-foot burst.  \n  \n**Catalyzing Rune** [#] (arcane) As adult rune dragon, but the area is a 40-foot burst and the DC is 41.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot burst",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "burst",
+              "aonid": 2385,
+              "game-obj": "Rules",
+              "name": "burst",
+              "type": "link"
+            }
+          ],
+          "name": "Runic Jail",
+          "subtype": "ability",
+          "text": "As adult rune dragon, but the area is a 30-foot burst.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 60,
+              "subtype": "area",
+              "text": "60-foot burst",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "burst",
+              "aonid": 2385,
+              "game-obj": "Rules",
+              "name": "burst",
+              "type": "link"
+            }
+          ],
+          "name": "Catalyzing Rune",
+          "saving_throw": [
+            {
+              "dc": 46,
+              "subtype": "save_dc",
+              "text": "DC 46",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "As adult rune dragon, but the area is a 60-foot burst and the DC is 46.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 534,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "burst",
+          "aonid": 2385,
+          "game-obj": "Rules",
+          "name": "burst",
+          "type": "link"
+        },
+        {
+          "alt": "arcane",
+          "aonid": 534,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "burst",
+          "aonid": 2385,
+          "game-obj": "Rules",
+          "name": "burst",
+          "type": "link"
+        }
+      ],
+      "name": "Rune Archdragon:",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 131",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 131",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "text": "**Runic Jail** [#] (arcane) As adult rune dragon, but the area is a 30-foot burst.  \n  \n**Catalyzing Rune** [#] (arcane) As adult rune dragon, but the area is a 60-foot burst and the DC is 46.",
+      "type": "section"
+    },
+    {
       "links": [
         {
           "alt": "rune trap",
@@ -1692,6 +1224,1123 @@
         }
       ],
       "text": "If a spell the rune dragon casts would deal energy damage, it instead deals the damage type associated with its Shifting Runes. Additionally, rune dragon spellcasters know the rune trap ritual and can fulfill the role of the secondary caster themselves. Rune dragon spellcasters tend to focus on specific types of magic such as ice magic or summoning. The following represents a rune dragon with a broader array of spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "translate",
+          "aonid": 1723,
+          "game-obj": "Spells",
+          "name": "translate",
+          "type": "link"
+        },
+        {
+          "alt": "wall of fire",
+          "aonid": 1748,
+          "game-obj": "Spells",
+          "name": "wall of fire",
+          "type": "link"
+        },
+        {
+          "alt": "fireball",
+          "aonid": 1530,
+          "game-obj": "Spells",
+          "name": "fireball",
+          "type": "link"
+        },
+        {
+          "alt": "gravity well",
+          "aonid": 1997,
+          "game-obj": "Spells",
+          "name": "gravity well",
+          "type": "link"
+        },
+        {
+          "alt": "veil of privacy",
+          "aonid": 1739,
+          "game-obj": "Spells",
+          "name": "veil of privacy",
+          "type": "link"
+        },
+        {
+          "alt": "blur",
+          "aonid": 1455,
+          "game-obj": "Spells",
+          "name": "blur",
+          "type": "link"
+        },
+        {
+          "alt": "embed message",
+          "aonid": 1511,
+          "game-obj": "Spells",
+          "name": "embed message",
+          "type": "link"
+        },
+        {
+          "alt": "alarm",
+          "aonid": 1439,
+          "game-obj": "Spells",
+          "name": "alarm",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "gust of wind",
+          "aonid": 1550,
+          "game-obj": "Spells",
+          "name": "gust of wind",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "ignition",
+          "aonid": 1565,
+          "game-obj": "Spells",
+          "name": "ignition",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Young Rune Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 131",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 131",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "saving_throw": {
+            "dc": 29,
+            "subtype": "save_dc",
+            "text": "DC 29",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 21,
+          "spell_list": [
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translate",
+                      "aonid": 1723,
+                      "game-obj": "Spells",
+                      "name": "translate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of fire",
+                      "aonid": 1748,
+                      "game-obj": "Spells",
+                      "name": "wall of fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fireball",
+                      "aonid": 1530,
+                      "game-obj": "Spells",
+                      "name": "fireball",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gravity well",
+                      "aonid": 1997,
+                      "game-obj": "Spells",
+                      "name": "gravity well",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gravity well",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "veil of privacy",
+                      "aonid": 1739,
+                      "game-obj": "Spells",
+                      "name": "veil of privacy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "veil of privacy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blur",
+                      "aonid": 1455,
+                      "game-obj": "Spells",
+                      "name": "blur",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blur",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "embed message",
+                      "aonid": 1511,
+                      "game-obj": "Spells",
+                      "name": "embed message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "embed message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "translate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "alarm",
+                      "aonid": 1439,
+                      "game-obj": "Spells",
+                      "name": "alarm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "alarm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gust of wind",
+                      "aonid": 1550,
+                      "game-obj": "Spells",
+                      "name": "gust of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gust of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 4,
+              "level_text": "(4th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ignition",
+                      "aonid": 1565,
+                      "game-obj": "Spells",
+                      "name": "ignition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 29, attack +21; **4th** *dispel magic*, *translate*, *wall of fire*; **3rd** *fireball*, *gravity well*, *veil of privacy*; **2nd** *blur*, *embed message*, *translate*; **1st** *alarm*, *fear*, *gust of wind*; **Cantrips (4th)** *detect magic*, *ignition*, *message*, *sigil*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "chain lightning",
+          "aonid": 1462,
+          "game-obj": "Spells",
+          "name": "chain lightning",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 1662,
+          "game-obj": "Spells",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "wall of force",
+          "aonid": 1749,
+          "game-obj": "Spells",
+          "name": "wall of force",
+          "type": "link"
+        },
+        {
+          "alt": "howling blizzard",
+          "aonid": 1559,
+          "game-obj": "Spells",
+          "name": "howling blizzard",
+          "type": "link"
+        },
+        {
+          "alt": "imaginary lockbox",
+          "aonid": 2002,
+          "game-obj": "Spells",
+          "name": "imaginary lockbox",
+          "type": "link"
+        },
+        {
+          "alt": "truespeech",
+          "aonid": 1728,
+          "game-obj": "Spells",
+          "name": "truespeech",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Rune Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 131",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 131",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As young rune dragon"
+          ],
+          "saving_throw": {
+            "dc": 34,
+            "subtype": "save_dc",
+            "text": "DC 34",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 26,
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chain lightning",
+                      "aonid": 1462,
+                      "game-obj": "Spells",
+                      "name": "chain lightning",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "chain lightning",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scrying",
+                      "aonid": 1662,
+                      "game-obj": "Spells",
+                      "name": "scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of force",
+                      "aonid": 1749,
+                      "game-obj": "Spells",
+                      "name": "wall of force",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of force",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "howling blizzard",
+                      "aonid": 1559,
+                      "game-obj": "Spells",
+                      "name": "howling blizzard",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "howling blizzard",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "imaginary lockbox",
+                      "aonid": 2002,
+                      "game-obj": "Spells",
+                      "name": "imaginary lockbox",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "imaginary lockbox",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "truespeech",
+                      "aonid": 1728,
+                      "game-obj": "Spells",
+                      "name": "truespeech",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "truespeech",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 34, attack +26; As young rune dragon, plus **6th** *chain lightning*, *scrying*, *wall of force*; **5th** *howling blizzard*, *imaginary lockbox*, *truespeech*; **Cantrips (6th)** *detect magic*, *ignition*, *message*, *sigil*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "detonate magic",
+          "aonid": 1488,
+          "game-obj": "Spells",
+          "name": "detonate magic",
+          "type": "link"
+        },
+        {
+          "alt": "falling stars",
+          "aonid": 1521,
+          "game-obj": "Spells",
+          "name": "falling stars",
+          "type": "link"
+        },
+        {
+          "alt": "foresight",
+          "aonid": 1537,
+          "game-obj": "Spells",
+          "name": "foresight",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "quandary",
+          "aonid": 1644,
+          "game-obj": "Spells",
+          "name": "quandary",
+          "type": "link"
+        },
+        {
+          "alt": "unrelenting observation",
+          "aonid": 1734,
+          "game-obj": "Spells",
+          "name": "unrelenting observation",
+          "type": "link"
+        },
+        {
+          "alt": "planar seal",
+          "aonid": 1635,
+          "game-obj": "Spells",
+          "name": "planar seal",
+          "type": "link"
+        },
+        {
+          "alt": "spell riposte",
+          "aonid": 2027,
+          "game-obj": "Spells",
+          "name": "spell riposte",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Rune Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 131",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 131",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As adult rune dragon"
+          ],
+          "saving_throw": {
+            "dc": 41,
+            "subtype": "save_dc",
+            "text": "DC 41",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 33,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detonate magic",
+                      "aonid": 1488,
+                      "game-obj": "Spells",
+                      "name": "detonate magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detonate magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "falling stars",
+                      "aonid": 1521,
+                      "game-obj": "Spells",
+                      "name": "falling stars",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "falling stars",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "foresight",
+                      "aonid": 1537,
+                      "game-obj": "Spells",
+                      "name": "foresight",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "foresight",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "quandary",
+                      "aonid": 1644,
+                      "game-obj": "Spells",
+                      "name": "quandary",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "quandary",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unrelenting observation",
+                      "aonid": 1734,
+                      "game-obj": "Spells",
+                      "name": "unrelenting observation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unrelenting observation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar seal",
+                      "aonid": 1635,
+                      "game-obj": "Spells",
+                      "name": "planar seal",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar seal",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "spell riposte",
+                      "aonid": 2027,
+                      "game-obj": "Spells",
+                      "name": "spell riposte",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "spell riposte",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hando",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 41, attack +33; As adult rune dragon, plus **9th** *detonate magic*, *falling stars*, *foresight*; **8th** *hidden mind*, *quandary*, *unrelenting observation*; **7th** *fireball*, *planar seal*, *spell riposte*; **Cantrips (9th)** *detect magic*, *ignition*, *message*, *sigil*, *telekinetic hand*o",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "cataclysm",
+          "aonid": 1460,
+          "game-obj": "Spells",
+          "name": "cataclysm",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "implosion",
+          "aonid": 1572,
+          "game-obj": "Spells",
+          "name": "implosion",
+          "type": "link"
+        }
+      ],
+      "name": "Rune Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 131",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 131",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 131,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Arcane Prepared Spells",
+          "notes": [
+            "As ancient rune dragon"
+          ],
+          "saving_throw": {
+            "dc": 46,
+            "subtype": "save_dc",
+            "text": "DC 46",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 38,
+          "spell_list": [
+            {
+              "level": 10,
+              "level_text": "10th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cataclysm",
+                      "aonid": 1460,
+                      "game-obj": "Spells",
+                      "name": "cataclysm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cataclysm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "implosion",
+                      "aonid": 1572,
+                      "game-obj": "Spells",
+                      "name": "implosion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "implosion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 10,
+              "level_text": "(10th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Arcane",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Arcane Prepared Spells** DC 46, attack +38; As ancient rune dragon plus **10th** *cataclysm*; **9th** *dispel magic*, *implosion*; **Cantrips (10th)** *detect magic*, *ignition*, *message*, *sigil*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -2025,6 +2674,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 131",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 131",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 131,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -2172,6 +2877,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 131",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 131",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 131,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/dragon_whisper.json
+++ b/monster_families/monster_core_2/dragon_whisper.json
@@ -64,375 +64,91 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "wish",
-                    "aonid": 125,
-                    "game-obj": "Rituals",
-                    "name": "wish",
-                    "type": "link"
-                  }
-                ],
-                "name": "Draft Contract",
-                "subtype": "ability",
-                "text": "The dragon produces a contract for a single living mortal. This contract can grant a single boon or ability, the extent of which is dependent on the power of the dragon, in exchange for one piece of knowledge the mortal possesses. The mortal must willingly sign their true name to the contract, as well as the knowledge they wish to surrender. Upon signing, the mortal forgets the bartered information, which cannot be restored by any means short of a *wish* ritual; if they restore this knowledge, they lose the boon granted by the contract.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 645,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Sustain",
-                    "aonid": 2317,
-                    "game-obj": "Actions",
-                    "name": "Sustain",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Dismiss",
-                    "aonid": 2311,
-                    "game-obj": "Actions",
-                    "name": "Dismiss",
-                    "type": "link"
-                  }
-                ],
-                "name": "Share Sight",
-                "range": {
-                  "range": 100,
-                  "subtype": "range",
-                  "text": "within 100 miles",
-                  "type": "stat_block_section",
-                  "unit": "miles"
-                },
-                "subtype": "ability",
-                "text": "The dragon states the name of an allied informant within 100 miles, giving them a mental alert. The informant can choose whether to accept the contact. If they consent, the dragon projects their senses into the informant\u2019s, allowing them to perceive through their informant. When they do, they lose all sensory information from their own body. The dragon can Sustain this effect for up to 1 hour and Dismiss it as a free action. A whisper dragon might take on a humanoid guise to gather information without attracting notice. To make a dragon with this ability, give them the following ability.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "scrying",
-                      "aonid": 689,
-                      "game-obj": "Traits",
-                      "name": "scrying",
-                      "type": "link"
-                    },
-                    "name": "scrying",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of a Small or Medium humanoid. Their humanoid shape has a specific, persistent appearance. In humanoid shape, the dragon loses their jaws, claws, and tail Strikes, but retains their attack bonuses with any weapons they wield. Their Speed is reduced to 25 feet.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "wish",
+                "aonid": 125,
+                "game-obj": "Rituals",
+                "name": "wish",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 689,
+                "game-obj": "Traits",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "Sustain",
+                "aonid": 2317,
+                "game-obj": "Actions",
+                "name": "Sustain",
+                "type": "link"
+              },
+              {
+                "alt": "Dismiss",
+                "aonid": 2311,
+                "game-obj": "Actions",
+                "name": "Dismiss",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -442,257 +158,110 @@
         ],
         "name": "Alternate Abilities",
         "subtype": "monster_family",
-        "text": "Whisper dragons can develop different skills and abilities than are typical. You can apply the following adjustments to whisper dragons of any age.  \n  \nSome whisper dragons bind an informant\u2019s secrets into contracts, obtaining their information in exchange for granting them a boon. To make a dragon with this ability, replace Steal Knowledge with the following.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "saving_throw": {
-                  "dc": 25,
-                  "subtype": "save_dc",
-                  "text": "DC 25",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 17,
-                "spell_list": [
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hypercognition",
-                            "aonid": 1563,
-                            "game-obj": "Spells",
-                            "name": "hypercognition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hypercognition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ring of truth",
-                            "aonid": 1656,
-                            "game-obj": "Spells",
-                            "name": "ring of truth",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ring of truth",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clear mind",
-                            "aonid": 1469,
-                            "game-obj": "Spells",
-                            "name": "clear mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clear mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 1560,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "see the unseen",
-                            "aonid": 1663,
-                            "game-obj": "Spells",
-                            "name": "see the unseen",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "see the unseen",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disguise magic",
-                            "aonid": 1491,
-                            "game-obj": "Spells",
-                            "name": "disguise magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disguise magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mindlink",
-                            "aonid": 1603,
-                            "game-obj": "Spells",
-                            "name": "mindlink",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mindlink",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 3,
-                    "level_text": "(3rd)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "forbidding ward",
-                            "aonid": 1535,
-                            "game-obj": "Spells",
-                            "name": "forbidding ward",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Young Whisper Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "hypercognition",
+                "aonid": 1563,
+                "game-obj": "Spells",
+                "name": "hypercognition",
+                "type": "link"
+              },
+              {
+                "alt": "ring of truth",
+                "aonid": 1656,
+                "game-obj": "Spells",
+                "name": "ring of truth",
+                "type": "link"
+              },
+              {
+                "alt": "clear mind",
+                "aonid": 1469,
+                "game-obj": "Spells",
+                "name": "clear mind",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 1560,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "see the unseen",
+                "aonid": 1663,
+                "game-obj": "Spells",
+                "name": "see the unseen",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "disguise magic",
+                "aonid": 1491,
+                "game-obj": "Spells",
+                "name": "disguise magic",
+                "type": "link"
+              },
+              {
+                "alt": "mindlink",
+                "aonid": 1603,
+                "game-obj": "Spells",
+                "name": "mindlink",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "forbidding ward",
+                "aonid": 1535,
+                "game-obj": "Spells",
+                "name": "forbidding ward",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -708,178 +277,55 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As young whisper dragon"
-                ],
-                "saving_throw": {
-                  "dc": 30,
-                  "subtype": "save_dc",
-                  "text": "DC 30",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 22,
-                "spell_list": [
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sending",
-                            "aonid": 1665,
-                            "game-obj": "Spells",
-                            "name": "sending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "synaptic pulse",
-                            "aonid": 1710,
-                            "game-obj": "Spells",
-                            "name": "synaptic pulse",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "synaptic pulse",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect scrying",
-                            "aonid": 1487,
-                            "game-obj": "Spells",
-                            "name": "detect scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "rewrite memory",
-                            "aonid": 1655,
-                            "game-obj": "Spells",
-                            "name": "rewrite memory",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "rewrite memory",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dream message",
-                            "aonid": 1503,
-                            "game-obj": "Spells",
-                            "name": "dream message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dream message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 5,
-                    "level_text": "(5th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Adult Whisper Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "sending",
+                "aonid": 1665,
+                "game-obj": "Spells",
+                "name": "sending",
+                "type": "link"
+              },
+              {
+                "alt": "synaptic pulse",
+                "aonid": 1710,
+                "game-obj": "Spells",
+                "name": "synaptic pulse",
+                "type": "link"
+              },
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "detect scrying",
+                "aonid": 1487,
+                "game-obj": "Spells",
+                "name": "detect scrying",
+                "type": "link"
+              },
+              {
+                "alt": "rewrite memory",
+                "aonid": 1655,
+                "game-obj": "Spells",
+                "name": "rewrite memory",
+                "type": "link"
+              },
+              {
+                "alt": "dream message",
+                "aonid": 1503,
+                "game-obj": "Spells",
+                "name": "dream message",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -895,193 +341,62 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As adult whisper dragon"
-                ],
-                "saving_throw": {
-                  "dc": 37,
-                  "subtype": "save_dc",
-                  "text": "DC 37",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 29,
-                "spell_list": [
-                  {
-                    "level": 7,
-                    "level_text": "7th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "interplanar teleport",
-                            "aonid": 1576,
-                            "game-obj": "Spells",
-                            "name": "interplanar teleport",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "interplanar teleport",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "project image",
-                            "aonid": 1640,
-                            "game-obj": "Spells",
-                            "name": "project image",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "project image",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "retrocognition",
-                            "aonid": 1652,
-                            "game-obj": "Spells",
-                            "name": "retrocognition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "retrocognition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scrying",
-                            "aonid": 1662,
-                            "game-obj": "Spells",
-                            "name": "scrying",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scrying",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "teleport",
-                            "aonid": 1720,
-                            "game-obj": "Spells",
-                            "name": "teleport",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "teleport",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "zealous conviction",
-                            "aonid": 1760,
-                            "game-obj": "Spells",
-                            "name": "zealous conviction",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "zealous conviction",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "scouting eye",
-                            "aonid": 1661,
-                            "game-obj": "Spells",
-                            "name": "scouting eye",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "scouting eye",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 7,
-                    "level_text": "(7th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hando",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Ancient Whisper Dragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "interplanar teleport",
+                "aonid": 1576,
+                "game-obj": "Spells",
+                "name": "interplanar teleport",
+                "type": "link"
+              },
+              {
+                "alt": "project image",
+                "aonid": 1640,
+                "game-obj": "Spells",
+                "name": "project image",
+                "type": "link"
+              },
+              {
+                "alt": "retrocognition",
+                "aonid": 1652,
+                "game-obj": "Spells",
+                "name": "retrocognition",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 1662,
+                "game-obj": "Spells",
+                "name": "scrying",
+                "type": "link"
+              },
+              {
+                "alt": "teleport",
+                "aonid": 1720,
+                "game-obj": "Spells",
+                "name": "teleport",
+                "type": "link"
+              },
+              {
+                "alt": "zealous conviction",
+                "aonid": 1760,
+                "game-obj": "Spells",
+                "name": "zealous conviction",
+                "type": "link"
+              },
+              {
+                "alt": "scouting eye",
+                "aonid": 1661,
+                "game-obj": "Spells",
+                "name": "scouting eye",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1097,155 +412,48 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Prepared Spells",
-                "notes": [
-                  "As ancient whisper dragon"
-                ],
-                "saving_throw": {
-                  "dc": 42,
-                  "subtype": "save_dc",
-                  "text": "DC 42",
-                  "type": "stat_block_section"
-                },
-                "spell_attack": 34,
-                "spell_list": [
-                  {
-                    "level": 9,
-                    "level_text": "9th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "overwhelming presence",
-                            "aonid": 1621,
-                            "game-obj": "Spells",
-                            "name": "overwhelming presence",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "overwhelming presence",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telepathic demand",
-                            "aonid": 2036,
-                            "game-obj": "Spells",
-                            "name": "telepathic demand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telepathic demand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 8,
-                    "level_text": "8th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disappearance",
-                            "aonid": 1490,
-                            "game-obj": "Spells",
-                            "name": "disappearance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disappearance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hidden mind",
-                            "aonid": 1556,
-                            "game-obj": "Spells",
-                            "name": "hidden mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hidden mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unrelenting observation",
-                            "aonid": 1734,
-                            "game-obj": "Spells",
-                            "name": "unrelenting observation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unrelenting observation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 9,
-                    "level_text": "(9th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "forbidding ward",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Prepared Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Whisper Archdragon')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "overwhelming presence",
+                "aonid": 1621,
+                "game-obj": "Spells",
+                "name": "overwhelming presence",
+                "type": "link"
+              },
+              {
+                "alt": "telepathic demand",
+                "aonid": 2036,
+                "game-obj": "Spells",
+                "name": "telepathic demand",
+                "type": "link"
+              },
+              {
+                "alt": "disappearance",
+                "aonid": 1490,
+                "game-obj": "Spells",
+                "name": "disappearance",
+                "type": "link"
+              },
+              {
+                "alt": "hidden mind",
+                "aonid": 1556,
+                "game-obj": "Spells",
+                "name": "hidden mind",
+                "type": "link"
+              },
+              {
+                "alt": "unrelenting observation",
+                "aonid": 1734,
+                "game-obj": "Spells",
+                "name": "unrelenting observation",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1260,48 +468,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Arcane Dragons",
-                "subtype": "ability",
-                "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Divine Dragons",
-                "subtype": "ability",
-                "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Occult Dragons",
-                "subtype": "ability",
-                "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Primal Dragons",
-                "subtype": "ability",
-                "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Draconic Families",
-                "subtype": "ability",
-                "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Draconic Groupings')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1312,263 +483,47 @@
         ],
         "name": "Draconic Groupings",
         "subtype": "monster_family",
-        "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Draconic Spellcasters')].sections[?(@.name=='Shape-Changing Dragons')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1578,7 +533,6 @@
         ],
         "name": "Shape-Changing Dragons",
         "subtype": "monster_family",
-        "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:",
         "type": "stat_block_section"
       }
     ],
@@ -1587,6 +541,467 @@
   "name": "Dragon, Whisper",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "wish",
+              "aonid": 125,
+              "game-obj": "Rituals",
+              "name": "wish",
+              "type": "link"
+            }
+          ],
+          "name": "Draft Contract",
+          "subtype": "ability",
+          "text": "The dragon produces a contract for a single living mortal. This contract can grant a single boon or ability, the extent of which is dependent on the power of the dragon, in exchange for one piece of knowledge the mortal possesses. The mortal must willingly sign their true name to the contract, as well as the knowledge they wish to surrender. Upon signing, the mortal forgets the bartered information, which cannot be restored by any means short of a *wish* ritual; if they restore this knowledge, they lose the boon granted by the contract.",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "manipulate",
+                "aonid": 645,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              "name": "manipulate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "Sustain",
+              "aonid": 2317,
+              "game-obj": "Actions",
+              "name": "Sustain",
+              "type": "link"
+            },
+            {
+              "alt": "Dismiss",
+              "aonid": 2311,
+              "game-obj": "Actions",
+              "name": "Dismiss",
+              "type": "link"
+            }
+          ],
+          "name": "Share Sight",
+          "range": {
+            "range": 100,
+            "subtype": "range",
+            "text": "within 100 miles",
+            "type": "stat_block_section",
+            "unit": "miles"
+          },
+          "subtype": "ability",
+          "text": "The dragon states the name of an allied informant within 100 miles, giving them a mental alert. The informant can choose whether to accept the contact. If they consent, the dragon projects their senses into the informant\u2019s, allowing them to perceive through their informant. When they do, they lose all sensory information from their own body. The dragon can Sustain this effect for up to 1 hour and Dismiss it as a free action. A whisper dragon might take on a humanoid guise to gather information without attracting notice. To make a dragon with this ability, give them the following ability.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "scrying",
+                "aonid": 689,
+                "game-obj": "Traits",
+                "name": "scrying",
+                "type": "link"
+              },
+              "name": "scrying",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The dragon takes on the appearance of a Small or Medium humanoid. Their humanoid shape has a specific, persistent appearance. In humanoid shape, the dragon loses their jaws, claws, and tail Strikes, but retains their attack bonuses with any weapons they wield. Their Speed is reduced to 25 feet.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 55,
+            "edition": "remastered",
+            "game-id": "cfccadd6ae22a706a897a80c7d209862",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 2388,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 38,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 358",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 358",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 358,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "classes": [
+                  "template"
+                ],
+                "edition": "legacy",
+                "game-id": "070ae8282a8ee960fa04002421f6d345",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  }
+                ],
+                "name": "[Magical Tradition]",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 628",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 628",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 628,
+                    "type": "source"
+                  }
+                ],
+                "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        }
+      ],
+      "links": [
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 645,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "wish",
+          "aonid": 125,
+          "game-obj": "Rituals",
+          "name": "wish",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 689,
+          "game-obj": "Traits",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "Sustain",
+          "aonid": 2317,
+          "game-obj": "Actions",
+          "name": "Sustain",
+          "type": "link"
+        },
+        {
+          "alt": "Dismiss",
+          "aonid": 2311,
+          "game-obj": "Actions",
+          "name": "Dismiss",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 133",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 133",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 133,
+          "type": "source"
+        }
+      ],
+      "text": "Whisper dragons can develop different skills and abilities than are typical. You can apply the following adjustments to whisper dragons of any age.  \n  \nSome whisper dragons bind an informant\u2019s secrets into contracts, obtaining their information in exchange for granting them a boon. To make a dragon with this ability, replace Steal Knowledge with the following.   \n  \n**Draft Contract** [###] (occult, manipulate) The dragon produces a contract for a single living mortal. This contract can grant a single boon or ability, the extent of which is dependent on the power of the dragon, in exchange for one piece of knowledge the mortal possesses. The mortal must willingly sign their true name to the contract, as well as the knowledge they wish to surrender. Upon signing, the mortal forgets the bartered information, which cannot be restored by any means short of a *wish* ritual; if they restore this knowledge, they lose the boon granted by the contract.  \n  \nA whisper dragon can develop strong bonds with their informants that allow them to view the world through their informants\u2019 senses. To make a dragon with this ability, replace Information Network with the following ability.  \n  \n**Share Sight** [##] (concentrate, occult, scrying) The dragon states the name of an allied informant within 100 miles, giving them a mental alert. The informant can choose whether to accept the contact. If they consent, the dragon projects their senses into the informant\u2019s, allowing them to perceive through their informant. When they do, they lose all sensory information from their own body. The dragon can Sustain this effect for up to 1 hour and Dismiss it as a free action. A whisper dragon might take on a humanoid guise to gather information without attracting notice. To make a dragon with this ability, give them the following ability.  \n  \n**Change Shape** [#] (concentrate, occult, polymorph) The dragon takes on the appearance of a Small or Medium humanoid. Their humanoid shape has a specific, persistent appearance. In humanoid shape, the dragon loses their jaws, claws, and tail Strikes, but retains their attack bonuses with any weapons they wield. Their Speed is reduced to 25 feet.",
+      "type": "section"
+    },
     {
       "name": "Naizraa",
       "sources": [
@@ -1623,6 +1038,1067 @@
         }
       ],
       "text": "Whisper dragon spellcasters tend to cast the following spells.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "hypercognition",
+          "aonid": 1563,
+          "game-obj": "Spells",
+          "name": "hypercognition",
+          "type": "link"
+        },
+        {
+          "alt": "ring of truth",
+          "aonid": 1656,
+          "game-obj": "Spells",
+          "name": "ring of truth",
+          "type": "link"
+        },
+        {
+          "alt": "clear mind",
+          "aonid": 1469,
+          "game-obj": "Spells",
+          "name": "clear mind",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 1560,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "see the unseen",
+          "aonid": 1663,
+          "game-obj": "Spells",
+          "name": "see the unseen",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "disguise magic",
+          "aonid": 1491,
+          "game-obj": "Spells",
+          "name": "disguise magic",
+          "type": "link"
+        },
+        {
+          "alt": "mindlink",
+          "aonid": 1603,
+          "game-obj": "Spells",
+          "name": "mindlink",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "forbidding ward",
+          "aonid": 1535,
+          "game-obj": "Spells",
+          "name": "forbidding ward",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        }
+      ],
+      "name": "Young Whisper Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 133",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 133",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 133,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "saving_throw": {
+            "dc": 25,
+            "subtype": "save_dc",
+            "text": "DC 25",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 17,
+          "spell_list": [
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hypercognition",
+                      "aonid": 1563,
+                      "game-obj": "Spells",
+                      "name": "hypercognition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hypercognition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ring of truth",
+                      "aonid": 1656,
+                      "game-obj": "Spells",
+                      "name": "ring of truth",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ring of truth",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clear mind",
+                      "aonid": 1469,
+                      "game-obj": "Spells",
+                      "name": "clear mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clear mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 1560,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "see the unseen",
+                      "aonid": 1663,
+                      "game-obj": "Spells",
+                      "name": "see the unseen",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "see the unseen",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disguise magic",
+                      "aonid": 1491,
+                      "game-obj": "Spells",
+                      "name": "disguise magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disguise magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mindlink",
+                      "aonid": 1603,
+                      "game-obj": "Spells",
+                      "name": "mindlink",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mindlink",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 3,
+              "level_text": "(3rd)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "forbidding ward",
+                      "aonid": 1535,
+                      "game-obj": "Spells",
+                      "name": "forbidding ward",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 25, attack +17; **3rd** *hypercognition*, *ring of truth*; **2nd** *clear mind*, *humanoid form*, *see the unseen*; **1st** *command*, *disguise magic*, *mindlink*; **Cantrips (3rd)** *daze*, *detect magic*, *forbidding ward*, *message*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "sending",
+          "aonid": 1665,
+          "game-obj": "Spells",
+          "name": "sending",
+          "type": "link"
+        },
+        {
+          "alt": "synaptic pulse",
+          "aonid": 1710,
+          "game-obj": "Spells",
+          "name": "synaptic pulse",
+          "type": "link"
+        },
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "detect scrying",
+          "aonid": 1487,
+          "game-obj": "Spells",
+          "name": "detect scrying",
+          "type": "link"
+        },
+        {
+          "alt": "rewrite memory",
+          "aonid": 1655,
+          "game-obj": "Spells",
+          "name": "rewrite memory",
+          "type": "link"
+        },
+        {
+          "alt": "dream message",
+          "aonid": 1503,
+          "game-obj": "Spells",
+          "name": "dream message",
+          "type": "link"
+        }
+      ],
+      "name": "Adult Whisper Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 133",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 133",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 133,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As young whisper dragon"
+          ],
+          "saving_throw": {
+            "dc": 30,
+            "subtype": "save_dc",
+            "text": "DC 30",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 22,
+          "spell_list": [
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sending",
+                      "aonid": 1665,
+                      "game-obj": "Spells",
+                      "name": "sending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "synaptic pulse",
+                      "aonid": 1710,
+                      "game-obj": "Spells",
+                      "name": "synaptic pulse",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "synaptic pulse",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect scrying",
+                      "aonid": 1487,
+                      "game-obj": "Spells",
+                      "name": "detect scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "rewrite memory",
+                      "aonid": 1655,
+                      "game-obj": "Spells",
+                      "name": "rewrite memory",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "rewrite memory",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dream message",
+                      "aonid": 1503,
+                      "game-obj": "Spells",
+                      "name": "dream message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dream message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 5,
+              "level_text": "(5th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 30, attack +22; As young whisper dragon, plus **5th** *sending*, *synaptic pulse*; **4th** *confusion*, *detect scrying*, *rewrite memory*; **3rd** *dream message*; **Cantrips (5th)** *daze*, *detect magic*, *forbidding ward*, *message*, *telekinetic hand*",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "interplanar teleport",
+          "aonid": 1576,
+          "game-obj": "Spells",
+          "name": "interplanar teleport",
+          "type": "link"
+        },
+        {
+          "alt": "project image",
+          "aonid": 1640,
+          "game-obj": "Spells",
+          "name": "project image",
+          "type": "link"
+        },
+        {
+          "alt": "retrocognition",
+          "aonid": 1652,
+          "game-obj": "Spells",
+          "name": "retrocognition",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 1662,
+          "game-obj": "Spells",
+          "name": "scrying",
+          "type": "link"
+        },
+        {
+          "alt": "teleport",
+          "aonid": 1720,
+          "game-obj": "Spells",
+          "name": "teleport",
+          "type": "link"
+        },
+        {
+          "alt": "zealous conviction",
+          "aonid": 1760,
+          "game-obj": "Spells",
+          "name": "zealous conviction",
+          "type": "link"
+        },
+        {
+          "alt": "scouting eye",
+          "aonid": 1661,
+          "game-obj": "Spells",
+          "name": "scouting eye",
+          "type": "link"
+        }
+      ],
+      "name": "Ancient Whisper Dragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 133",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 133",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 133,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As adult whisper dragon"
+          ],
+          "saving_throw": {
+            "dc": 37,
+            "subtype": "save_dc",
+            "text": "DC 37",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 29,
+          "spell_list": [
+            {
+              "level": 7,
+              "level_text": "7th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "interplanar teleport",
+                      "aonid": 1576,
+                      "game-obj": "Spells",
+                      "name": "interplanar teleport",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "interplanar teleport",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "project image",
+                      "aonid": 1640,
+                      "game-obj": "Spells",
+                      "name": "project image",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "project image",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "retrocognition",
+                      "aonid": 1652,
+                      "game-obj": "Spells",
+                      "name": "retrocognition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "retrocognition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scrying",
+                      "aonid": 1662,
+                      "game-obj": "Spells",
+                      "name": "scrying",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scrying",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "teleport",
+                      "aonid": 1720,
+                      "game-obj": "Spells",
+                      "name": "teleport",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "teleport",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "zealous conviction",
+                      "aonid": 1760,
+                      "game-obj": "Spells",
+                      "name": "zealous conviction",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "zealous conviction",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "scouting eye",
+                      "aonid": 1661,
+                      "game-obj": "Spells",
+                      "name": "scouting eye",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "scouting eye",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 7,
+              "level_text": "(7th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hando",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 37, attack +29; As adult whisper dragon, plus **7th** *interplanar teleport*, *project image*, *retrocognition*; **6th** *scrying*, *teleport*, *zealous conviction*; **5th** *scouting eye*; **Cantrips (7th)** *daze*, *detect magic*, *forbidding ward*, *message*, *telekinetic hand*o",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "overwhelming presence",
+          "aonid": 1621,
+          "game-obj": "Spells",
+          "name": "overwhelming presence",
+          "type": "link"
+        },
+        {
+          "alt": "telepathic demand",
+          "aonid": 2036,
+          "game-obj": "Spells",
+          "name": "telepathic demand",
+          "type": "link"
+        },
+        {
+          "alt": "disappearance",
+          "aonid": 1490,
+          "game-obj": "Spells",
+          "name": "disappearance",
+          "type": "link"
+        },
+        {
+          "alt": "hidden mind",
+          "aonid": 1556,
+          "game-obj": "Spells",
+          "name": "hidden mind",
+          "type": "link"
+        },
+        {
+          "alt": "unrelenting observation",
+          "aonid": 1734,
+          "game-obj": "Spells",
+          "name": "unrelenting observation",
+          "type": "link"
+        }
+      ],
+      "name": "Whisper Archdragon",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 133",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 133",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 133,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Prepared Spells",
+          "notes": [
+            "As ancient whisper dragon"
+          ],
+          "saving_throw": {
+            "dc": 42,
+            "subtype": "save_dc",
+            "text": "DC 42",
+            "type": "stat_block_section"
+          },
+          "spell_attack": 34,
+          "spell_list": [
+            {
+              "level": 9,
+              "level_text": "9th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "overwhelming presence",
+                      "aonid": 1621,
+                      "game-obj": "Spells",
+                      "name": "overwhelming presence",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "overwhelming presence",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telepathic demand",
+                      "aonid": 2036,
+                      "game-obj": "Spells",
+                      "name": "telepathic demand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telepathic demand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 8,
+              "level_text": "8th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disappearance",
+                      "aonid": 1490,
+                      "game-obj": "Spells",
+                      "name": "disappearance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disappearance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hidden mind",
+                      "aonid": 1556,
+                      "game-obj": "Spells",
+                      "name": "hidden mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hidden mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unrelenting observation",
+                      "aonid": 1734,
+                      "game-obj": "Spells",
+                      "name": "unrelenting observation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unrelenting observation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 9,
+              "level_text": "(9th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "forbidding ward",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Prepared Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "**Occult Prepared Spells** DC 42, attack +34; As ancient whisper dragon plus **9th** *overwhelming presence*, *telepathic demand*; **8th** *disappearance*, *hidden mind*, *unrelenting observation*; **Cantrips (9th)** *daze*, *detect magic*, *forbidding ward*, *message*, *telekinetic hand*",
       "type": "section"
     },
     {
@@ -1937,6 +2413,62 @@
       "name": "Draconic Spellcasters",
       "sections": [
         {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "name": "Arcane Dragons",
+              "subtype": "ability",
+              "text": ": These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Divine Dragons",
+              "subtype": "ability",
+              "text": ": While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Occult Dragons",
+              "subtype": "ability",
+              "text": ": At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Primal Dragons",
+              "subtype": "ability",
+              "text": ": While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "name": "Draconic Families",
+              "subtype": "ability",
+              "text": ": In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Draconic Groupings",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 133",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 133",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 133,
+              "type": "source"
+            }
+          ],
+          "text": "The broader grouping of dragons is generally sorted into more granular categories, the first of which is based on the four magical traditions. Each dragon falls into one of these large categories, and dragons in a given category share a number of common traits.  \n  \n**Arcane Dragons**: These dragons seem to have greater control over magic and their innate abilities. Many arcane dragons have mastery over a certain subset of magic, such as illusions or teleportation. Other arcane dragons have the ability to tap into or manipulate raw magical energies, regardless of their origins. Their bodies tend to be more slender than other dragons due to their reliance on magic for hunting. Their scales generally come in perfect patterns or very organized shapes.  \n  \n**Divine Dragons**: While the name might suggest dragons directly related to deific entities, divine dragons instead derive their power from planes other than the mortal Universe. Similar to how a god grants power to a cleric, these dragons receive magical abilities and other influences from another plane. As such, divine dragons are among the most varied of dragons. These dragons generally take on an appearance similar to other native creatures of their influential planes, making it difficult for them to hide their planar connections.  \n  \n**Occult Dragons**: At times alien and off-putting and other times alluring and mysterious, occult dragons derive their powers from the inexplicable and unknown. These dragons use magic that seems to exist within the crevices and shadows between other forms of magic. Whether it's due to this strange magical influence or something else, occult dragons are most likely to directly interact with other creatures. While generally sporting similar builds to other dragons, occult dragons make greater use of their wings as supplementary appendages, leaving their forward limbs free to use for other things. Their scales and plating generally feature strange shapes and patterns that are rarely seen in the natural world.  \n  \n**Primal Dragons**: While all dragons are fierce and terrifying in their own way, primal dragons seem to embody the most bestial traits among dragons. These dragons derive their power from the magic of the natural world. While primal dragons aren't directly bound to serve nature, many of them choose to act as keepers of their habitats. Primal dragons are generally larger than other dragons and fall back on their instincts more often, making them particularly dangerous when threatened. Their scales typically have less elaborate shapes than other dragons, or will sometimes resemble natural terrain. Some dragons even grow natural features like small plants on their bodies.  \n  \n**Draconic Families**: In addition to these classifications, dragons are sometimes grouped into families. These include the enigmatic esoteric dragons, the regal imperial dragons, the space-faring outer dragons, and the mighty skymetal dragons. Draconic families are sometimes made up of dragons with obvious physiological similarities, while other families seem to be made up of dragons of similar color, habitat, behavior, or other traits that make for vague connections. Often, families include dragons of varied magical traditions. As such, the members of a given family are sometimes the subject of debate and scholarly arguments.",
+          "type": "section"
+        },
+        {
           "links": [
             {
               "alt": "Apsu",
@@ -2084,6 +2616,300 @@
             }
           ],
           "text": "While other draconic creatures like drakes and linnorms exist, the magical connection of the dragons in these pages has earned them a distinct place among draconic classifications. While terms like high dragons, magical dragons, primordial dragons, source dragons, traditional dragons, and others have been used by scholars throughout time to classify these dragons, the most common term is great dragons. Most commoners are aware of the term great dragon, but less are aware of specific nuances between great dragons and their draconic cousins. As such, the term great dragon can often get thrown around whenever a somewhat draconic creature larger than a human makes an appearance.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "One Action",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "link": {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              "links": [
+                {
+                  "alt": "humanoid",
+                  "aonid": 628,
+                  "game-obj": "Traits",
+                  "name": "humanoid",
+                  "type": "link"
+                }
+              ],
+              "name": "Change Shape",
+              "subtype": "ability",
+              "text": "The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "concentrate",
+                    "aonid": 561,
+                    "game-obj": "Traits",
+                    "name": "concentrate",
+                    "type": "link"
+                  },
+                  "name": "concentrate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "polymorph",
+                    "aonid": 670,
+                    "game-obj": "Traits",
+                    "name": "polymorph",
+                    "type": "link"
+                  },
+                  "name": "polymorph",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "action_type": {
+                  "name": "One Action",
+                  "subtype": "action_type",
+                  "type": "stat_block_section"
+                },
+                "aonid": 55,
+                "edition": "remastered",
+                "game-id": "cfccadd6ae22a706a897a80c7d209862",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "Impersonate",
+                    "aonid": 2388,
+                    "game-obj": "Actions",
+                    "name": "Impersonate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "Deception",
+                    "aonid": 38,
+                    "game-obj": "Skills",
+                    "name": "Deception",
+                    "type": "link"
+                  }
+                ],
+                "name": "Change Shape",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "1.1",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "1.1",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Monster Core pg. 358",
+                      "aonid": 221,
+                      "game-obj": "Sources",
+                      "name": "Monster Core pg. 358",
+                      "type": "link"
+                    },
+                    "name": "Monster Core",
+                    "page": 358,
+                    "type": "source"
+                  }
+                ],
+                "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+                "traits": [
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 32,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "e32d877417a40fe977d27634dc14f99f",
+                    "game-obj": "Traits",
+                    "name": "Concentrate",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 454",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 454",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 454,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                    "type": "trait"
+                  },
+                  {
+                    "classes": [
+                      "template"
+                    ],
+                    "edition": "legacy",
+                    "game-id": "070ae8282a8ee960fa04002421f6d345",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "[Magical Tradition]",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "4.0",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "4.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Core Rulebook pg. 628",
+                          "aonid": 1,
+                          "game-obj": "Sources",
+                          "name": "Core Rulebook pg. 628",
+                          "type": "link"
+                        },
+                        "name": "Core Rulebook",
+                        "page": 628,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                    "type": "trait"
+                  },
+                  {
+                    "alternate_link": {
+                      "alternate_type": "legacy",
+                      "aonid": 127,
+                      "game-obj": "Traits",
+                      "type": "alternate_link"
+                    },
+                    "edition": "remastered",
+                    "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                    "game-obj": "Traits",
+                    "links": [
+                      {
+                        "alt": "counteract",
+                        "aonid": 371,
+                        "game-obj": "Rules",
+                        "name": "counteract",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "magical",
+                        "aonid": 103,
+                        "game-obj": "Traits",
+                        "name": "magical",
+                        "type": "link"
+                      },
+                      {
+                        "alt": "manipulate",
+                        "aonid": 104,
+                        "game-obj": "Traits",
+                        "name": "manipulate",
+                        "type": "link"
+                      }
+                    ],
+                    "name": "Polymorph",
+                    "sources": [
+                      {
+                        "errata": {
+                          "alt": "2.0",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "2.0",
+                          "type": "link"
+                        },
+                        "link": {
+                          "alt": "Player Core pg. 301",
+                          "aonid": 216,
+                          "game-obj": "Sources",
+                          "name": "Player Core pg. 301",
+                          "type": "link"
+                        },
+                        "name": "Player Core",
+                        "page": 301,
+                        "type": "source"
+                      }
+                    ],
+                    "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                    "type": "trait"
+                  }
+                ],
+                "type": "ability"
+              }
+            }
+          ],
+          "links": [
+            {
+              "alt": "Change Shape",
+              "aonid": 55,
+              "game-obj": "MonsterAbilities",
+              "name": "Change Shape",
+              "type": "link"
+            },
+            {
+              "alt": "concentrate",
+              "aonid": 561,
+              "game-obj": "Traits",
+              "name": "concentrate",
+              "type": "link"
+            },
+            {
+              "alt": "polymorph",
+              "aonid": 670,
+              "game-obj": "Traits",
+              "name": "polymorph",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Shape-Changing Dragons",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 133",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 133",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 133,
+              "type": "source"
+            }
+          ],
+          "text": "Though it's uncommon, some dragons can take humanoid forms. They gain the following ability:  \n  \n**Change Shape** [#] (concentrate, polymorph); The dragon takes on the appearance of any Small or Medium humanoid. This doesn't change their Speed or attack and damage bonuses with their Strikes but might change the damage type their Strikes deal (typically to bludgeoning).",
           "type": "section"
         }
       ],

--- a/monster_families/monster_core_2/ravener.json
+++ b/monster_families/monster_core_2/ravener.json
@@ -205,460 +205,175 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 59,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "undead",
-                    "aonid": 722,
-                    "game-obj": "Traits",
-                    "name": "undead",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "celestials",
-                    "aonid": 551,
-                    "game-obj": "Traits",
-                    "name": "celestials",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fiends",
-                    "aonid": 600,
-                    "game-obj": "Traits",
-                    "name": "fiends",
-                    "type": "link"
-                  }
-                ],
-                "name": "Soulsense",
-                "subtype": "ability",
-                "text": "A ravener senses the spiritual essence of living and undead creatures within the listed range. Creatures whose material bodies are one unit with their souls, like celestials and fiends, appear brighter to this sense.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 83,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "bleed, death effects, disease, paralyzed, poison, unconscious",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightful presence",
-                    "aonid": 64,
-                    "game-obj": "MonsterAbilities",
-                    "name": "frightful presence",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened 2",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "immobilized",
-                    "aonid": 81,
-                    "game-obj": "Conditions",
-                    "name": "immobilized",
-                    "type": "link"
-                  }
-                ],
-                "name": "Cowering Fear",
-                "subtype": "ability",
-                "text": "A ravener's frightful presence causes creatures to cower in fear as well. As long as a creature is at least frightened 2 or more as a result of the ravener's frightful presence, it's also immobilized from the fear.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "ravener husk",
-                    "aonid": 784,
-                    "game-obj": "Monsters",
-                    "name": "ravener husk",
-                    "type": "link"
-                  }
-                ],
-                "name": "Soul Ward",
-                "subtype": "ability",
-                "text": "An intangible field of necromantic energy protects a ravener from total destruction. A soul ward has 150 maximum Hit Points, or 200 if the ravener is level 21 or higher. Whenever a ravener would be reduced below 1 Hit Point, all damage in excess of what would reduce them to 1 Hit Point is instead dealt to their soul ward. If this damage reduces the soul ward to fewer than 0 Hit Points, the ravener is destroyed. A soul ward's Hit Points can be restored only via specific ravener abilities such as Consume Soul, Void Breath, or vicious criticals. A ravener who goes more than a week without successfully using Consume Soul to feed on a dying creature starves, and their soul ward loses 1d4 Hit Points each day until they feed. If the ravener's soul ward loses all its Hit Points while the ravener still has more than 1 HP, they become a ravener husk.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ravener tears the creature's soul from its body with their maw and gulps it down. The dying creature must attempt a Fortitude save with the same DC as the ravener's breath ability.",
-                "name": "Consume Soul",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "death",
-                      "aonid": 571,
-                      "game-obj": "Traits",
-                      "name": "death",
-                      "type": "link"
-                    },
-                    "name": "death",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "A living creature within 30 feet of the ravener dies",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The ravener tears off a small chunk of the creature's soul. If the victim is restored to life, they are drained 1 in addition to any other side effects of returning to life. The ravener adds a number of Hit Points to their soul ward equal to half the creature's level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "As success, but the creature's soul is ravaged. The creature is drained 3 and the ravener adds a number of Hit Points to their soul ward equal to the creature's level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "wish",
-                    "aonid": 377,
-                    "game-obj": "Spells",
-                    "name": "wish",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, but the ravener devours the entire soul. The victim can't be restored to life as long as the ravener exists except via powerful magic such as a *wish* ritual, and the ravener adds a number of Hit Points to their soul ward equal to twice the creature's level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The ravener draws deeply into their soul ward, discorporating their body into soul energy to escape. They take 50 damage to their soul ward and their physical body vanishes, reappearing 1d4 hours later in a random location within 1 mile from the location where they used Discorporate.",
-                "name": "Discorporate",
-                "range": {
-                  "range": 1,
-                  "subtype": "range",
-                  "text": "within 1 mile",
-                  "type": "stat_block_section",
-                  "unit": "miles"
-                },
-                "subtype": "ability",
-                "trigger": "The ravener takes excess damage to their soul ward but still has at least 51 Hit Points in their soul ward",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Void Breath",
-                "subtype": "ability",
-                "text": "A ravener's Void Breath is infused with void energy and strips life essence from the victims. Any creature that fails its save against the ravener's Void Breath is drained 1 (or drained 2 on a critical failure). If at least one creature is drained by the ravener's Void Breath, the ravener's soul ward gains 5 Hit Points.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Vicious Criticals",
-                "subtype": "ability",
-                "text": "The ravener treats an attack roll as a critical hit on a roll of 19 or 20, as long as the attack roll was a success. Additionally, whenever the ravener makes a critical hit with one of their Strikes, the target must succeed at a Fortitude save or gain the drained 1 condition. If the target already has a drained value of greater than 0, their drained value instead increases by 1, to a maximum of drained 4. Whenever the ravener applies drain to a creature in this way, their soul ward gains 5 Hit Points.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Ravener Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Darkvision",
+                "aonid": 59,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "undead",
+                "aonid": 722,
+                "game-obj": "Traits",
+                "name": "undead",
+                "type": "link"
+              },
+              {
+                "alt": "celestials",
+                "aonid": 551,
+                "game-obj": "Traits",
+                "name": "celestials",
+                "type": "link"
+              },
+              {
+                "alt": "fiends",
+                "aonid": 600,
+                "game-obj": "Traits",
+                "name": "fiends",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 83,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "frightful presence",
+                "aonid": 64,
+                "game-obj": "MonsterAbilities",
+                "name": "frightful presence",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 2",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened 2",
+                "type": "link"
+              },
+              {
+                "alt": "immobilized",
+                "aonid": 81,
+                "game-obj": "Conditions",
+                "name": "immobilized",
+                "type": "link"
+              },
+              {
+                "alt": "ravener husk",
+                "aonid": 784,
+                "game-obj": "Monsters",
+                "name": "ravener husk",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "wish",
+                "aonid": 377,
+                "game-obj": "Spells",
+                "name": "wish",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -668,7 +383,6 @@
         ],
         "name": "Ravener Abilities",
         "subtype": "monster_family",
-        "text": "A ravener gains the following abilities. Several of these abilities gain the tradition trait matching the original dragon's tradition trait.",
         "type": "stat_block_section"
       }
     ],
@@ -710,6 +424,753 @@
         }
       ],
       "text": "Any dragon of at least level 13 can become a ravener, although it's exceedingly rare for a dragon younger than an ancient dragon to do so. Typically, the dragon must perform a rare ritual called *ravenous reanimation*, but this requirement can be waived if the prospective ravener has the aid of a powerful patron. In certain unique conditions, such as the intervention of a vile god of undeath, a dragon can transform into a ravener after death without the use of this rite at all. A ravener is a powerful creature that's likely to have a major impact on your game, so you might want to create each one as a custom monster. If you don't have time, you can also create a ravener via the following steps.  \n  \n Increase the dragon's level by 2 and change their statistics as follows. \n\n|  |  |  |\n| --- | --- | --- |\n| **Starting Level** | **HP Increase** | **Weakness** |\n| 13\u201320 | 50 | 15 |\n| 21 or greater | 80 | 20 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Darkvision",
+            "aonid": 59,
+            "game-obj": "MonsterAbilities",
+            "name": "Darkvision",
+            "type": "link"
+          },
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 722,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "celestials",
+              "aonid": 551,
+              "game-obj": "Traits",
+              "name": "celestials",
+              "type": "link"
+            },
+            {
+              "alt": "fiends",
+              "aonid": 600,
+              "game-obj": "Traits",
+              "name": "fiends",
+              "type": "link"
+            }
+          ],
+          "name": "Soulsense",
+          "subtype": "ability",
+          "text": "A ravener senses the spiritual essence of living and undead creatures within the listed range. Creatures whose material bodies are one unit with their souls, like celestials and fiends, appear brighter to this sense.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 83,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "bleed, death effects, disease, paralyzed, poison, unconscious",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "frightful presence",
+              "aonid": 64,
+              "game-obj": "MonsterAbilities",
+              "name": "frightful presence",
+              "type": "link"
+            },
+            {
+              "alt": "frightened 2",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened 2",
+              "type": "link"
+            },
+            {
+              "alt": "immobilized",
+              "aonid": 81,
+              "game-obj": "Conditions",
+              "name": "immobilized",
+              "type": "link"
+            }
+          ],
+          "name": "Cowering Fear",
+          "subtype": "ability",
+          "text": "A ravener's frightful presence causes creatures to cower in fear as well. As long as a creature is at least frightened 2 or more as a result of the ravener's frightful presence, it's also immobilized from the fear.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "ravener husk",
+              "aonid": 784,
+              "game-obj": "Monsters",
+              "name": "ravener husk",
+              "type": "link"
+            }
+          ],
+          "name": "Soul Ward",
+          "subtype": "ability",
+          "text": "An intangible field of necromantic energy protects a ravener from total destruction. A soul ward has 150 maximum Hit Points, or 200 if the ravener is level 21 or higher. Whenever a ravener would be reduced below 1 Hit Point, all damage in excess of what would reduce them to 1 Hit Point is instead dealt to their soul ward. If this damage reduces the soul ward to fewer than 0 Hit Points, the ravener is destroyed. A soul ward's Hit Points can be restored only via specific ravener abilities such as Consume Soul, Void Breath, or vicious criticals. A ravener who goes more than a week without successfully using Consume Soul to feed on a dying creature starves, and their soul ward loses 1d4 Hit Points each day until they feed. If the ravener's soul ward loses all its Hit Points while the ravener still has more than 1 HP, they become a ravener husk.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The ravener tears the creature's soul from its body with their maw and gulps it down. The dying creature must attempt a Fortitude save with the same DC as the ravener's breath ability.",
+          "name": "Consume Soul",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              "name": "death",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "trigger": "A living creature within 30 feet of the ravener dies",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The ravener tears off a small chunk of the creature's soul. If the victim is restored to life, they are drained 1 in addition to any other side effects of returning to life. The ravener adds a number of Hit Points to their soul ward equal to half the creature's level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "As success, but the creature's soul is ravaged. The creature is drained 3 and the ravener adds a number of Hit Points to their soul ward equal to the creature's level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "wish",
+              "aonid": 377,
+              "game-obj": "Spells",
+              "name": "wish",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, but the ravener devours the entire soul. The victim can't be restored to life as long as the ravener exists except via powerful magic such as a *wish* ritual, and the ravener adds a number of Hit Points to their soul ward equal to twice the creature's level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The ravener draws deeply into their soul ward, discorporating their body into soul energy to escape. They take 50 damage to their soul ward and their physical body vanishes, reappearing 1d4 hours later in a random location within 1 mile from the location where they used Discorporate.",
+          "name": "Discorporate",
+          "range": {
+            "range": 1,
+            "subtype": "range",
+            "text": "within 1 mile",
+            "type": "stat_block_section",
+            "unit": "miles"
+          },
+          "subtype": "ability",
+          "trigger": "The ravener takes excess damage to their soul ward but still has at least 51 Hit Points in their soul ward",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Void Breath",
+          "subtype": "ability",
+          "text": "A ravener's Void Breath is infused with void energy and strips life essence from the victims. Any creature that fails its save against the ravener's Void Breath is drained 1 (or drained 2 on a critical failure). If at least one creature is drained by the ravener's Void Breath, the ravener's soul ward gains 5 Hit Points.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Vicious Criticals",
+          "subtype": "ability",
+          "text": "The ravener treats an attack roll as a critical hit on a roll of 19 or 20, as long as the attack roll was a success. Additionally, whenever the ravener makes a critical hit with one of their Strikes, the target must succeed at a Fortitude save or gain the drained 1 condition. If the target already has a drained value of greater than 0, their drained value instead increases by 1, to a maximum of drained 4. Whenever the ravener applies drain to a creature in this way, their soul ward gains 5 Hit Points.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Darkvision",
+          "aonid": 59,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "undead",
+          "aonid": 722,
+          "game-obj": "Traits",
+          "name": "undead",
+          "type": "link"
+        },
+        {
+          "alt": "celestials",
+          "aonid": 551,
+          "game-obj": "Traits",
+          "name": "celestials",
+          "type": "link"
+        },
+        {
+          "alt": "fiends",
+          "aonid": 600,
+          "game-obj": "Traits",
+          "name": "fiends",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "frightful presence",
+          "aonid": 64,
+          "game-obj": "MonsterAbilities",
+          "name": "frightful presence",
+          "type": "link"
+        },
+        {
+          "alt": "frightened 2",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened 2",
+          "type": "link"
+        },
+        {
+          "alt": "immobilized",
+          "aonid": 81,
+          "game-obj": "Conditions",
+          "name": "immobilized",
+          "type": "link"
+        },
+        {
+          "alt": "ravener husk",
+          "aonid": 784,
+          "game-obj": "Monsters",
+          "name": "ravener husk",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "wish",
+          "aonid": 377,
+          "game-obj": "Spells",
+          "name": "wish",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        }
+      ],
+      "name": "Ravener Abilities",
+      "sections": [
+        {
+          "name": "Ravener Lairs",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 268",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 268",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 268,
+              "type": "source"
+            }
+          ],
+          "text": "Cunning and paranoid, raveners prefer to make their lairs in places hostile to mortal life: atop peaks so high that living creatures struggle to breathe the rarefied air, submerged beneath pools of magma in the caldera of an active volcano, and so on. Some raveners even go so far as to deliberately fill their entire lair with lethally poisonous gases, and raveners that are capable of advanced spellcasting often seal their lairs completely, accessing them exclusively via spells such as teleport or vapor form. Of course, raveners must feed on the living to persist, so they never locate their lairs so far from sources of life that they\u2019ll starve.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 722,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "incorporeal",
+              "aonid": 632,
+              "game-obj": "Traits",
+              "name": "incorporeal",
+              "type": "link"
+            },
+            {
+              "alt": "ghosts",
+              "aonid": 418,
+              "game-obj": "MonsterFamilies",
+              "name": "ghosts",
+              "type": "link"
+            },
+            {
+              "alt": "wraiths",
+              "aonid": 164,
+              "game-obj": "MonsterFamilies",
+              "name": "wraiths",
+              "type": "link"
+            },
+            {
+              "alt": "skeletons",
+              "aonid": 472,
+              "game-obj": "MonsterFamilies",
+              "name": "skeletons",
+              "type": "link"
+            },
+            {
+              "alt": "zombies",
+              "aonid": 487,
+              "game-obj": "MonsterFamilies",
+              "name": "zombies",
+              "type": "link"
+            },
+            {
+              "alt": "demon lords",
+              "aonid": 5,
+              "game-obj": "DeityCategories",
+              "name": "demon lords",
+              "type": "link"
+            },
+            {
+              "alt": "necromancers",
+              "aonid": 3538,
+              "game-obj": "Monsters",
+              "name": "necromancers",
+              "type": "link"
+            }
+          ],
+          "name": "Ravener Minions",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 268",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 268",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 268,
+              "type": "source"
+            }
+          ],
+          "text": "Raveners view most undead creatures with little more respect than they have for living creatures, but they often make use of them as servants. They prefer incorporeal undead such as ghosts and wraiths over such crude and simple minions as skeletons and zombies.  \n  \nWhile most dragons are too prideful to turn to anyone, even the gods, for help, a few who seek to become raveners are so desperate to stave off death that they might turn to powerful patrons for aid, such as demon lords, unholy deities, or powerful necromancers, offering service in exchange for their transformation.",
+          "type": "section"
+        },
+        {
+          "name": "Ravener Treasure",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 268",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 268",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 268,
+              "type": "source"
+            }
+          ],
+          "text": "Because they change lairs more often than living dragons, raveners prefer treasure that\u2019s compact and easily transported. Instead of a sprawling mountains of coins, they tend to prefer precious gems, art objects, and especially magic items, particularly magic items they\u2019re capable of using.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 268",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 268",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 268,
+          "type": "source"
+        }
+      ],
+      "text": "A ravener gains the following abilities. Several of these abilities gain the tradition trait matching the original dragon's tradition trait.  \n  \n**Darkvision**  \n  \n**Soulsense** A ravener senses the spiritual essence of living and undead creatures within the listed range. Creatures whose material bodies are one unit with their souls, like celestials and fiends, appear brighter to this sense.  \n  \n**Void Healing**   \n  \n**Immunities** bleed, death effects, disease, paralyzed, poison, unconscious  \n  \n**Cowering Fear** (aura, emotion, fear, mental) A ravener's frightful presence causes creatures to cower in fear as well. As long as a creature is at least frightened 2 or more as a result of the ravener's frightful presence, it's also immobilized from the fear.  \n  \n**Soul Ward** An intangible field of necromantic energy protects a ravener from total destruction. A soul ward has 150 maximum Hit Points, or 200 if the ravener is level 21 or higher. Whenever a ravener would be reduced below 1 Hit Point, all damage in excess of what would reduce them to 1 Hit Point is instead dealt to their soul ward. If this damage reduces the soul ward to fewer than 0 Hit Points, the ravener is destroyed. A soul ward's Hit Points can be restored only via specific ravener abilities such as Consume Soul, Void Breath, or vicious criticals. A ravener who goes more than a week without successfully using Consume Soul to feed on a dying creature starves, and their soul ward loses 1d4 Hit Points each day until they feed. If the ravener's soul ward loses all its Hit Points while the ravener still has more than 1 HP, they become a ravener husk.  \n  \n**Consume Soul** [-] (death) **Trigger** A living creature within 30 feet of the ravener dies; **Effect** The ravener tears the creature's soul from its body with their maw and gulps it down. The dying creature must attempt a Fortitude save with the same DC as the ravener's breath ability.  \n  \n**Critical Success** The creature is unaffected.  \n**Success** The ravener tears off a small chunk of the creature's soul. If the victim is restored to life, they are drained 1 in addition to any other side effects of returning to life. The ravener adds a number of Hit Points to their soul ward equal to half the creature's level.  \n**Failure** As success, but the creature's soul is ravaged. The creature is drained 3 and the ravener adds a number of Hit Points to their soul ward equal to the creature's level.  \n**Critical Failure** As failure, but the ravener devours the entire soul. The victim can't be restored to life as long as the ravener exists except via powerful magic such as a *wish* ritual, and the ravener adds a number of Hit Points to their soul ward equal to twice the creature's level.  \n  \n**Discorporate** [-] **Trigger** The ravener takes excess damage to their soul ward but still has at least 51 Hit Points in their soul ward; **Effect** The ravener draws deeply into their soul ward, discorporating their body into soul energy to escape. They take 50 damage to their soul ward and their physical body vanishes, reappearing 1d4 hours later in a random location within 1 mile from the location where they used Discorporate.  \n  \n**Void Breath** A ravener's Void Breath is infused with void energy and strips life essence from the victims. Any creature that fails its save against the ravener's Void Breath is drained 1 (or drained 2 on a critical failure). If at least one creature is drained by the ravener's Void Breath, the ravener's soul ward gains 5 Hit Points.  \n  \n**Vicious Criticals** The ravener treats an attack roll as a critical hit on a roll of 19 or 20, as long as the attack roll was a success. Additionally, whenever the ravener makes a critical hit with one of their Strikes, the target must succeed at a Fortitude save or gain the drained 1 condition. If the target already has a drained value of greater than 0, their drained value instead increases by 1, to a maximum of drained 4. Whenever the ravener applies drain to a creature in this way, their soul ward gains 5 Hit Points.",
       "type": "section"
     }
   ],

--- a/monster_families/monster_core_2/spawn_of_rovagug.json
+++ b/monster_families/monster_core_2/spawn_of_rovagug.json
@@ -68,79 +68,49 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "regeneration",
-                    "aonid": 72,
-                    "game-obj": "MonsterAbilities",
-                    "name": "regeneration",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "death",
-                    "aonid": 70,
-                    "game-obj": "Domains",
-                    "name": "death",
-                    "type": "link"
-                  }
-                ],
-                "name": "Absolute Regeneration",
-                "subtype": "ability",
-                "text": "This functions as regeneration, though it requires very specific actions to be deactivated. A Spawn of Rovagug's regeneration is powerful enough to revive it even if slain by a death effect. If the Spawn fails a save against an effect that would kill it instantly, it rises from death 3 rounds later with 1 Hit Point. A Spawn can still be banished, imprisoned, or transported away as a means to save a region or kept in a state of dying by an effect that deals constant damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 1,
-                    "subtype": "area",
-                    "text": "1-mile emanation",
-                    "type": "stat_block_section",
-                    "unit": "miles"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "detection",
-                    "aonid": 574,
-                    "game-obj": "Traits",
-                    "name": "detection",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "revelation",
-                    "aonid": 686,
-                    "game-obj": "Traits",
-                    "name": "revelation",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "scrying",
-                    "aonid": 689,
-                    "game-obj": "Traits",
-                    "name": "scrying",
-                    "type": "link"
-                  }
-                ],
-                "name": "Slumbering Armageddon",
-                "subtype": "ability",
-                "text": "Spawn of Rovagug can sleep for centuries in a regenerative hibernation. While slumbering, a Spawn doesn't need to eat, drink, or even breathe, and its resistances double in value. It can't be located by detection, revelation, or scrying effects, and for any saving throw, it uses the outcome one degree of success better than the result. With no outlet while the Spawn slumbers, its massive destructive energies turn outward and infect its surroundings, causing natural disasters of a type matching the Spawn to occur more frequently and with greater severity in a 1-mile emanation from the Spawn's resting place, increasing in radius by roughly a mile every decade the Spawn slumbers.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Spawn Of Rovagug Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "regeneration",
+                "aonid": 72,
+                "game-obj": "MonsterAbilities",
+                "name": "regeneration",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 70,
+                "game-obj": "Domains",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "detection",
+                "aonid": 574,
+                "game-obj": "Traits",
+                "name": "detection",
+                "type": "link"
+              },
+              {
+                "alt": "revelation",
+                "aonid": 686,
+                "game-obj": "Traits",
+                "name": "revelation",
+                "type": "link"
+              },
+              {
+                "alt": "scrying",
+                "aonid": 689,
+                "game-obj": "Traits",
+                "name": "scrying",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -150,7 +120,6 @@
         ],
         "name": "Spawn Of Rovagug Abilities",
         "subtype": "monster_family",
-        "text": "Spawn of Rovagug are diverse in shape and destructive capabilities, but all have the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -158,6 +127,266 @@
   },
   "name": "Spawn of Rovagug",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "regeneration",
+              "aonid": 72,
+              "game-obj": "MonsterAbilities",
+              "name": "regeneration",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 70,
+              "game-obj": "Domains",
+              "name": "death",
+              "type": "link"
+            }
+          ],
+          "name": "Absolute Regeneration",
+          "subtype": "ability",
+          "text": "This functions as regeneration, though it requires very specific actions to be deactivated. A Spawn of Rovagug's regeneration is powerful enough to revive it even if slain by a death effect. If the Spawn fails a save against an effect that would kill it instantly, it rises from death 3 rounds later with 1 Hit Point. A Spawn can still be banished, imprisoned, or transported away as a means to save a region or kept in a state of dying by an effect that deals constant damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 1,
+              "subtype": "area",
+              "text": "1-mile emanation",
+              "type": "stat_block_section",
+              "unit": "miles"
+            }
+          ],
+          "links": [
+            {
+              "alt": "detection",
+              "aonid": 574,
+              "game-obj": "Traits",
+              "name": "detection",
+              "type": "link"
+            },
+            {
+              "alt": "revelation",
+              "aonid": 686,
+              "game-obj": "Traits",
+              "name": "revelation",
+              "type": "link"
+            },
+            {
+              "alt": "scrying",
+              "aonid": 689,
+              "game-obj": "Traits",
+              "name": "scrying",
+              "type": "link"
+            }
+          ],
+          "name": "Slumbering Armageddon",
+          "subtype": "ability",
+          "text": "Spawn of Rovagug can sleep for centuries in a regenerative hibernation. While slumbering, a Spawn doesn't need to eat, drink, or even breathe, and its resistances double in value. It can't be located by detection, revelation, or scrying effects, and for any saving throw, it uses the outcome one degree of success better than the result. With no outlet while the Spawn slumbers, its massive destructive energies turn outward and infect its surroundings, causing natural disasters of a type matching the Spawn to occur more frequently and with greater severity in a 1-mile emanation from the Spawn's resting place, increasing in radius by roughly a mile every decade the Spawn slumbers.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "regeneration",
+          "aonid": 72,
+          "game-obj": "MonsterAbilities",
+          "name": "regeneration",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 70,
+          "game-obj": "Domains",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "detection",
+          "aonid": 574,
+          "game-obj": "Traits",
+          "name": "detection",
+          "type": "link"
+        },
+        {
+          "alt": "revelation",
+          "aonid": 686,
+          "game-obj": "Traits",
+          "name": "revelation",
+          "type": "link"
+        },
+        {
+          "alt": "scrying",
+          "aonid": 689,
+          "game-obj": "Traits",
+          "name": "scrying",
+          "type": "link"
+        }
+      ],
+      "name": "Spawn Of Rovagug Abilities",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "Erastil",
+              "aonid": 282,
+              "game-obj": "Deities",
+              "name": "Erastil",
+              "type": "link"
+            }
+          ],
+          "name": "Lesser Spawn of Rovagug",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 298",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 298",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 298,
+              "type": "source"
+            }
+          ],
+          "text": "The history of Golarion includes stories of massive creatures that, while not conclusively Spawn of Rovagug, have earned the title of \u201clesser Spawn\u201d due to their ferocity and similar regenerative abilities. Legends say that Old-Mage Jatembe, Azure Leopard, and more than 100 Tempest-Sun Mages trapped the insectile Agohbindi, the Splintering Child, in a forest of twisting roots near the Vanji River before liquefying the creature\u2019s body. Cultists of Rovagug unleashed a thundering behemoth called Djakobu against the early Shory Empire; the magic invented for its defeat brought an age of prosperity to the empire. The manyheaded, crab-like Gray-Stag-Devourer terrorized the area that would become Irrisen and was driven off by the Grim White Stag, herald of Erastil.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Kothogaz",
+              "aonid": 1730,
+              "game-obj": "Monsters",
+              "name": "Kothogaz",
+              "type": "link"
+            },
+            {
+              "alt": "Xotani",
+              "aonid": 491,
+              "game-obj": "Monsters",
+              "name": "Xotani",
+              "type": "link"
+            }
+          ],
+          "name": "Other Spawn",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 298",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 298",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 298,
+              "type": "source"
+            }
+          ],
+          "text": "Tales and myths detail other Spawn of Rovagug that have appeared on Golarion. Chemnosit, the Monarch Worm, is feared throughout the Darklands. Kothogaz, the Dance of Disharmony, reportedly slew a million Vudrani in Casmaron before being defeated by a potent psychic. After the titanic beetle Ulunat, the Unholy First, was finally thwarted, ancient Osirians formed the city of Sothis around its carapace. Xotani the Firebleeder's corpse lies deep within Pale Mountain in Katapesh, seemingly still infused with the faintest spark of life.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Rovagug",
+              "aonid": 291,
+              "game-obj": "Deities",
+              "name": "Rovagug",
+              "type": "link"
+            }
+          ],
+          "name": "Spawn in Your Campaigns",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 298",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 298",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 298,
+              "type": "source"
+            }
+          ],
+          "text": "Defeating (or even just surviving) a Spawn of Rovagug should be an important event in any campaign. It might even be the culmination of several adventures as the characters research ways to prevent the Spawn from rising immediately after it\u2019s been slain and gather necessary allies for the fight. Along the way, the PCs might also have to deal with natural disasters precipitated by the Spawn\u2019s approach and priests of Rovagug who believe the Spawn\u2019s rampage will free their god.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Verex",
+              "aonid": 3409,
+              "game-obj": "Monsters",
+              "name": "Verex",
+              "type": "link"
+            },
+            {
+              "alt": "Gorum\u2019s",
+              "aonid": 283,
+              "game-obj": "Deities",
+              "name": "Gorum\u2019s",
+              "type": "link"
+            },
+            {
+              "alt": "Pathfinder War of Immortals",
+              "aonid": 232,
+              "game-obj": "Sources",
+              "name": "Pathfinder War of Immortals",
+              "type": "link"
+            }
+          ],
+          "name": "Verex-That-Was",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 298",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 298",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 298,
+              "type": "source"
+            }
+          ],
+          "text": "Not even gods are immune to Rovagug\u2019s fell influence. While searching for means of greater power, the orc god Verex the Despoiler was caught by the Dead Vault\u2019s corrupting energies and was nearly destroyed in his escape. However, when a drop of Gorum\u2019s blood fell on his broken body, he was transformed into a horrible, twisted Spawn of Rovagug. Read more about this mythic threat in *Pathfinder War of Immortals*.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 298",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 298",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 298,
+          "type": "source"
+        }
+      ],
+      "text": "Spawn of Rovagug are diverse in shape and destructive capabilities, but all have the following abilities.  \n  \n**Absolute Regeneration** This functions as regeneration, though it requires very specific actions to be deactivated. A Spawn of Rovagug's regeneration is powerful enough to revive it even if slain by a death effect. If the Spawn fails a save against an effect that would kill it instantly, it rises from death 3 rounds later with 1 Hit Point. A Spawn can still be banished, imprisoned, or transported away as a means to save a region or kept in a state of dying by an effect that deals constant damage.  \n  \n**Slumbering Armageddon** Spawn of Rovagug can sleep for centuries in a regenerative hibernation. While slumbering, a Spawn doesn't need to eat, drink, or even breathe, and its resistances double in value. It can't be located by detection, revelation, or scrying effects, and for any saving throw, it uses the outcome one degree of success better than the result. With no outlet while the Spawn slumbers, its massive destructive energies turn outward and infect its surroundings, causing natural disasters of a type matching the Spawn to occur more frequently and with greater severity in a 1-mile emanation from the Spawn's resting place, increasing in radius by roughly a mile every decade the Spawn slumbers.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/monster_core_2/swarm_strider.json
+++ b/monster_families/monster_core_2/swarm_strider.json
@@ -53,417 +53,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 59,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Tremorsense",
-                  "aonid": 82,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Tremorsense",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "imprecise",
-                    "aonid": 412,
-                    "game-obj": "Rules",
-                    "name": "imprecise",
-                    "type": "link"
-                  }
-                ],
-                "name": "Tremorsense",
-                "subtype": "ability",
-                "text": "30 feet (imprecise)",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 82,
-                  "edition": "remastered",
-                  "game-id": "de5ae240559088dd0c3243f2545f0d80",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "imprecise",
-                      "aonid": 412,
-                      "game-obj": "Rules",
-                      "name": "imprecise",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Tremorsense",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "Tremorsense allows a monster to feel the vibrations through a solid surface caused by movement. It is usually an imprecise sense with a limited range (listed in the ability). Tremorsense functions only if the monster is on the same surface as the subject, and only if the subject is moving along (or burrowing through) the surface.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "All-around Vision",
-                  "aonid": 49,
-                  "game-obj": "MonsterAbilities",
-                  "name": "All-around Vision",
-                  "type": "link"
-                },
-                "name": "All-around Vision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 49,
-                  "edition": "remastered",
-                  "game-id": "5f55b2fba849673880f57bcabb36c1e9",
-                  "game-obj": "MonsterAbilities",
-                  "name": "All-Around Vision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "This monster can see in all directions simultaneously and therefore can't be flanked.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d4",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "persistent piercing damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent piercing damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Clinging Remnants",
-                "subtype": "ability",
-                "text": "A swarm strider's melee Strikes and ranged Strikes made against targets within their weapon's first range increment deposit biting vermin on the target, dealing 1d4 persistent piercing damage, increasing to 2d4 at 5th level, 3d4 at 10th level, 4d4 at 15th level, and 5d4 at 20th level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Discorporate",
-                "subtype": "ability",
-                "text": "When the swarm strider is reduced to 0 HP, their constituent creatures collapse, scattering on the ground under their space and each adjacent square. If even one of the creatures gets away, the swarm strider can eventually re-form over 1d10 days (potentially longer in areas where there are few invertebrates).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "swarm mind",
-                    "aonid": 78,
-                    "game-obj": "MonsterAbilities",
-                    "name": "swarm mind",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "precision, swarm mind",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "resistance 2 to physical and poison, increasing to 5 at 5th level, 10 at 10th level, 15 at 15th level, and 20 at 20th level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "splash",
-                    "aonid": 699,
-                    "game-obj": "Traits",
-                    "name": "splash",
-                    "type": "link"
-                  }
-                ],
-                "name": "Weaknesses",
-                "subtype": "ability",
-                "text": "weakness 2 to area damage and splash damage, increasing to 5 at 5th level, 10 at 10th level, 15 at 15th level, and 20 at 20th level",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Draw Bugs",
-                "subtype": "ability",
-                "text": "The swarm strider draws more arthropods from the environment around them to reconstitute some of their damaged body. They regain the listed number of HP, which is typically 5 HP, increasing to 10 at 5th level, 15 at 10th level, and 20 at 15th level. At the GM's discretion, the swarm strider doesn't recover HP in areas where there aren't enough arthropods to call to themselves.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    "name": "healing",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "swarm strider's level",
-                    "aonid": 2629,
-                    "game-obj": "Rules",
-                    "name": "swarm strider's level",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Burrow",
-                    "aonid": 2310,
-                    "game-obj": "Actions",
-                    "name": "Burrow",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Climb",
-                    "aonid": 2374,
-                    "game-obj": "Actions",
-                    "name": "Climb",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Fly",
-                    "aonid": 2312,
-                    "game-obj": "Actions",
-                    "name": "Fly",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Swim",
-                    "aonid": 2381,
-                    "game-obj": "Actions",
-                    "name": "Swim",
-                    "type": "link"
-                  }
-                ],
-                "name": "Squirming Embrace",
-                "subtype": "ability",
-                "text": "The swarm strider Strides. If they end their movement sharing a space with a creature, they deal 1d6 piercing damage to the creature, with a basic Reflex save. The save DC is the high spell DC for the swarm strider's level. The damage increases by 1d6 at 4th level and every 3 levels thereafter. The swarm strider can Burrow, Climb, Fly, or Swim instead of Striding if they have the corresponding movement type.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "attack",
-                    "aonid": 540,
-                    "game-obj": "Traits",
-                    "name": "attack",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Squeeze",
-                    "aonid": 2372,
-                    "game-obj": "Actions",
-                    "name": "Squeeze",
-                    "type": "link"
-                  }
-                ],
-                "name": "Swarm Shape",
-                "subtype": "ability",
-                "text": "The swarm strider collapses into a shapeless swarm of their constituent creatures. They drops all items in their possession. In this form, the swarm strider can't use attack actions and can't cast spells, but they can move through areas small enough for their constituent creatures to fit without having to Squeeze. They can use the same action to coalesce from their swarm shape back into their normal form.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Swarm Strider Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -495,6 +89,132 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 59,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Tremorsense",
+                "aonid": 82,
+                "game-obj": "MonsterAbilities",
+                "name": "Tremorsense",
+                "type": "link"
+              },
+              {
+                "alt": "imprecise",
+                "aonid": 412,
+                "game-obj": "Rules",
+                "name": "imprecise",
+                "type": "link"
+              },
+              {
+                "alt": "All-around Vision",
+                "aonid": 49,
+                "game-obj": "MonsterAbilities",
+                "name": "All-around Vision",
+                "type": "link"
+              },
+              {
+                "alt": "persistent piercing damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent piercing damage",
+                "type": "link"
+              },
+              {
+                "alt": "swarm mind",
+                "aonid": 78,
+                "game-obj": "MonsterAbilities",
+                "name": "swarm mind",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "splash",
+                "aonid": 699,
+                "game-obj": "Traits",
+                "name": "splash",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "swarm strider's level",
+                "aonid": 2629,
+                "game-obj": "Rules",
+                "name": "swarm strider's level",
+                "type": "link"
+              },
+              {
+                "alt": "Burrow",
+                "aonid": 2310,
+                "game-obj": "Actions",
+                "name": "Burrow",
+                "type": "link"
+              },
+              {
+                "alt": "Climb",
+                "aonid": 2374,
+                "game-obj": "Actions",
+                "name": "Climb",
+                "type": "link"
+              },
+              {
+                "alt": "Fly",
+                "aonid": 2312,
+                "game-obj": "Actions",
+                "name": "Fly",
+                "type": "link"
+              },
+              {
+                "alt": "Swim",
+                "aonid": 2381,
+                "game-obj": "Actions",
+                "name": "Swim",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "attack",
+                "aonid": 540,
+                "game-obj": "Traits",
+                "name": "attack",
+                "type": "link"
+              },
+              {
+                "alt": "Squeeze",
+                "aonid": 2372,
+                "game-obj": "Actions",
+                "name": "Squeeze",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -508,88 +228,42 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "name": "Bookworm:",
-                    "subtype": "ability",
-                    "text": "Born students trapped in labyrinthine libraries, these swarm striders voraciously consume knowledge\u2014including the spellbooks and scrolls of those damaged by their Squirming Embrace!",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "counteract",
-                        "aonid": 3280,
-                        "game-obj": "Rules",
-                        "name": "counteract",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "auditory",
-                        "aonid": 541,
-                        "game-obj": "Traits",
-                        "name": "auditory",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Cicada:",
-                    "subtype": "ability",
-                    "text": "These noisome swarm striders often hibernate for years at a time, and their screeching is known to counteract auditory effects.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "kraken\u2019s",
-                        "aonid": 3075,
-                        "game-obj": "Monsters",
-                        "name": "kraken\u2019s",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Lamprey:",
-                    "subtype": "ability",
-                    "text": "A kraken\u2019s corpse or awakened whalefall can seep intelligence into the lampreys that feast on their flesh, creating aquatic swarm striders with prodigious size and reach.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "persistent bleed damage",
-                        "aonid": 86,
-                        "game-obj": "Conditions",
-                        "name": "persistent bleed damage",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Leech:",
-                    "subtype": "ability",
-                    "text": "This bloodsucking swarm strider usually forms from a fresh corpse exsanguinated in a leechinfested swamp, gaining both the ability to swim and to deal persistent bleed damage instead of piercing damage.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "name": "Wasp:",
-                    "subtype": "ability",
-                    "text": "Stinging and buzzing, a wasp strider flies, moving much faster in the air than on the ground.",
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Swarm Strider Abilities')].sections[?(@.name=='Swarms of Different Forms')].abilities",
                     "target": "$.defense.automatic_abilities"
+                  }
+                ],
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 3280,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "auditory",
+                    "aonid": 541,
+                    "game-obj": "Traits",
+                    "name": "auditory",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "kraken\u2019s",
+                    "aonid": 3075,
+                    "game-obj": "Monsters",
+                    "name": "kraken\u2019s",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "persistent bleed damage",
+                    "aonid": 86,
+                    "game-obj": "Conditions",
+                    "name": "persistent bleed damage",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -599,11 +273,9 @@
             ],
             "name": "Swarms of Different Forms",
             "subtype": "monster_family",
-            "text": "In the right environments\u2014particularly where other invertebrates are most common\u2014swarm striders might be composed of unlikely critters. The following are several possible variants.",
             "type": "stat_block_section"
           }
         ],
-        "text": "A swarm strider gains the aberration and swarm traits. They lose any traits that represent their former life, such as human and humanoid, though they usually remain the same size, keep the same items, and use the same weapons as they did before their rebirth. Swarm striders typically have the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -611,6 +283,782 @@
   },
   "name": "Swarm Strider",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Darkvision",
+            "aonid": 59,
+            "game-obj": "MonsterAbilities",
+            "name": "Darkvision",
+            "type": "link"
+          },
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Tremorsense",
+            "aonid": 82,
+            "game-obj": "MonsterAbilities",
+            "name": "Tremorsense",
+            "type": "link"
+          },
+          "links": [
+            {
+              "alt": "imprecise",
+              "aonid": 412,
+              "game-obj": "Rules",
+              "name": "imprecise",
+              "type": "link"
+            }
+          ],
+          "name": "Tremorsense",
+          "subtype": "ability",
+          "text": "30 feet (imprecise)",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 82,
+            "edition": "remastered",
+            "game-id": "de5ae240559088dd0c3243f2545f0d80",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "imprecise",
+                "aonid": 412,
+                "game-obj": "Rules",
+                "name": "imprecise",
+                "type": "link"
+              }
+            ],
+            "name": "Tremorsense",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "Tremorsense allows a monster to feel the vibrations through a solid surface caused by movement. It is usually an imprecise sense with a limited range (listed in the ability). Tremorsense functions only if the monster is on the same surface as the subject, and only if the subject is moving along (or burrowing through) the surface.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "All-around Vision",
+            "aonid": 49,
+            "game-obj": "MonsterAbilities",
+            "name": "All-around Vision",
+            "type": "link"
+          },
+          "name": "All-around Vision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 49,
+            "edition": "remastered",
+            "game-id": "5f55b2fba849673880f57bcabb36c1e9",
+            "game-obj": "MonsterAbilities",
+            "name": "All-Around Vision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 358",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 358",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 358,
+                "type": "source"
+              }
+            ],
+            "text": "This monster can see in all directions simultaneously and therefore can't be flanked.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "piercing",
+              "formula": "1d4",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "persistent piercing damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent piercing damage",
+              "type": "link"
+            }
+          ],
+          "name": "Clinging Remnants",
+          "subtype": "ability",
+          "text": "A swarm strider's melee Strikes and ranged Strikes made against targets within their weapon's first range increment deposit biting vermin on the target, dealing 1d4 persistent piercing damage, increasing to 2d4 at 5th level, 3d4 at 10th level, 4d4 at 15th level, and 5d4 at 20th level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Discorporate",
+          "subtype": "ability",
+          "text": "When the swarm strider is reduced to 0 HP, their constituent creatures collapse, scattering on the ground under their space and each adjacent square. If even one of the creatures gets away, the swarm strider can eventually re-form over 1d10 days (potentially longer in areas where there are few invertebrates).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "swarm mind",
+              "aonid": 78,
+              "game-obj": "MonsterAbilities",
+              "name": "swarm mind",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "precision, swarm mind",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            }
+          ],
+          "name": "Resistances",
+          "subtype": "ability",
+          "text": "resistance 2 to physical and poison, increasing to 5 at 5th level, 10 at 10th level, 15 at 15th level, and 20 at 20th level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "splash",
+              "aonid": 699,
+              "game-obj": "Traits",
+              "name": "splash",
+              "type": "link"
+            }
+          ],
+          "name": "Weaknesses",
+          "subtype": "ability",
+          "text": "weakness 2 to area damage and splash damage, increasing to 5 at 5th level, 10 at 10th level, 15 at 15th level, and 20 at 20th level",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Draw Bugs",
+          "subtype": "ability",
+          "text": "The swarm strider draws more arthropods from the environment around them to reconstitute some of their damaged body. They regain the listed number of HP, which is typically 5 HP, increasing to 10 at 5th level, 15 at 10th level, and 20 at 15th level. At the GM's discretion, the swarm strider doesn't recover HP in areas where there aren't enough arthropods to call to themselves.",
+          "traits": [
+            {
+              "link": {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              "name": "healing",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "piercing",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "swarm strider's level",
+              "aonid": 2629,
+              "game-obj": "Rules",
+              "name": "swarm strider's level",
+              "type": "link"
+            },
+            {
+              "alt": "Burrow",
+              "aonid": 2310,
+              "game-obj": "Actions",
+              "name": "Burrow",
+              "type": "link"
+            },
+            {
+              "alt": "Climb",
+              "aonid": 2374,
+              "game-obj": "Actions",
+              "name": "Climb",
+              "type": "link"
+            },
+            {
+              "alt": "Fly",
+              "aonid": 2312,
+              "game-obj": "Actions",
+              "name": "Fly",
+              "type": "link"
+            },
+            {
+              "alt": "Swim",
+              "aonid": 2381,
+              "game-obj": "Actions",
+              "name": "Swim",
+              "type": "link"
+            }
+          ],
+          "name": "Squirming Embrace",
+          "subtype": "ability",
+          "text": "The swarm strider Strides. If they end their movement sharing a space with a creature, they deal 1d6 piercing damage to the creature, with a basic Reflex save. The save DC is the high spell DC for the swarm strider's level. The damage increases by 1d6 at 4th level and every 3 levels thereafter. The swarm strider can Burrow, Climb, Fly, or Swim instead of Striding if they have the corresponding movement type.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "attack",
+              "aonid": 540,
+              "game-obj": "Traits",
+              "name": "attack",
+              "type": "link"
+            },
+            {
+              "alt": "Squeeze",
+              "aonid": 2372,
+              "game-obj": "Actions",
+              "name": "Squeeze",
+              "type": "link"
+            }
+          ],
+          "name": "Swarm Shape",
+          "subtype": "ability",
+          "text": "The swarm strider collapses into a shapeless swarm of their constituent creatures. They drops all items in their possession. In this form, the swarm strider can't use attack actions and can't cast spells, but they can move through areas small enough for their constituent creatures to fit without having to Squeeze. They can use the same action to coalesce from their swarm shape back into their normal form.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "aberration",
+          "aonid": 523,
+          "game-obj": "Traits",
+          "name": "aberration",
+          "type": "link"
+        },
+        {
+          "alt": "swarm",
+          "aonid": 707,
+          "game-obj": "Traits",
+          "name": "swarm",
+          "type": "link"
+        },
+        {
+          "alt": "human",
+          "aonid": 627,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Darkvision",
+          "aonid": 59,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Tremorsense",
+          "aonid": 82,
+          "game-obj": "MonsterAbilities",
+          "name": "Tremorsense",
+          "type": "link"
+        },
+        {
+          "alt": "imprecise",
+          "aonid": 412,
+          "game-obj": "Rules",
+          "name": "imprecise",
+          "type": "link"
+        },
+        {
+          "alt": "All-around Vision",
+          "aonid": 49,
+          "game-obj": "MonsterAbilities",
+          "name": "All-around Vision",
+          "type": "link"
+        },
+        {
+          "alt": "persistent piercing damage",
+          "aonid": 29,
+          "game-obj": "Conditions",
+          "name": "persistent piercing damage",
+          "type": "link"
+        },
+        {
+          "alt": "swarm mind",
+          "aonid": 78,
+          "game-obj": "MonsterAbilities",
+          "name": "swarm mind",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "splash",
+          "aonid": 699,
+          "game-obj": "Traits",
+          "name": "splash",
+          "type": "link"
+        },
+        {
+          "alt": "healing",
+          "aonid": 623,
+          "game-obj": "Traits",
+          "name": "healing",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "swarm strider's level",
+          "aonid": 2629,
+          "game-obj": "Rules",
+          "name": "swarm strider's level",
+          "type": "link"
+        },
+        {
+          "alt": "Burrow",
+          "aonid": 2310,
+          "game-obj": "Actions",
+          "name": "Burrow",
+          "type": "link"
+        },
+        {
+          "alt": "Climb",
+          "aonid": 2374,
+          "game-obj": "Actions",
+          "name": "Climb",
+          "type": "link"
+        },
+        {
+          "alt": "Fly",
+          "aonid": 2312,
+          "game-obj": "Actions",
+          "name": "Fly",
+          "type": "link"
+        },
+        {
+          "alt": "Swim",
+          "aonid": 2381,
+          "game-obj": "Actions",
+          "name": "Swim",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "attack",
+          "aonid": 540,
+          "game-obj": "Traits",
+          "name": "attack",
+          "type": "link"
+        },
+        {
+          "alt": "Squeeze",
+          "aonid": 2372,
+          "game-obj": "Actions",
+          "name": "Squeeze",
+          "type": "link"
+        }
+      ],
+      "name": "Swarm Strider Abilities",
+      "sections": [
+        {
+          "name": "A Swarm's Hoard",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 310",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 310",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 310,
+              "type": "source"
+            }
+          ],
+          "text": "A swarm strider often cradles an assortment of trinkets and talismans within their undulating body, along with clothing and armor that\u2019s flexible enough that it might fit through cracks when the creature discorporates. Any other valuables are buried, often hidden beneath several feet of soil in the swarm strider\u2019s lair. Thus, recovering the creature\u2019s wealth often requires a shovel, determination, and hours of backbreaking labor.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "First World",
+              "aonid": 35,
+              "game-obj": "Planes",
+              "name": "First World",
+              "type": "link"
+            }
+          ],
+          "name": "Fantastical Feasts",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 310",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 310",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 310,
+              "type": "source"
+            }
+          ],
+          "text": "Otherworldly beings and magical environments can spawn truly fantastical swarm striders. The Sarkoris Scar\u2019s soil imparts fiendish features and malevolent impulses, especially to swarm striders that feast on demon flesh. Beings comprised entirely of blood-drinking moths aren\u2019t unheard of in Gebbite society. There are even swarm striders of chameleonic birds said to live near First World rifts.",
+          "type": "section"
+        },
+        {
+          "name": "Split Personality",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 310",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 310",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 310,
+              "type": "source"
+            }
+          ],
+          "text": "Even though a swarm strider has a collective intelligence and many memories from their past life, the nature of that intelligence can shift over time. Each of the constituent creatures acts like a specific neuron within a brain, and as they\u2019re lost or replaced, the associated facets of the swarm strider\u2019s personality might change. Destroying most of a swarm strider might leave the regenerated whole with amnesia. Likewise, if two or more depleted swarm striders combine, their personalities often meld into a whole new identity.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Bookworm:",
+              "subtype": "ability",
+              "text": "Born students trapped in labyrinthine libraries, these swarm striders voraciously consume knowledge\u2014including the spellbooks and scrolls of those damaged by their Squirming Embrace!",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "counteract",
+                  "aonid": 3280,
+                  "game-obj": "Rules",
+                  "name": "counteract",
+                  "type": "link"
+                },
+                {
+                  "alt": "auditory",
+                  "aonid": 541,
+                  "game-obj": "Traits",
+                  "name": "auditory",
+                  "type": "link"
+                }
+              ],
+              "name": "Cicada:",
+              "subtype": "ability",
+              "text": "These noisome swarm striders often hibernate for years at a time, and their screeching is known to counteract auditory effects.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "kraken\u2019s",
+                  "aonid": 3075,
+                  "game-obj": "Monsters",
+                  "name": "kraken\u2019s",
+                  "type": "link"
+                }
+              ],
+              "name": "Lamprey:",
+              "subtype": "ability",
+              "text": "A kraken\u2019s corpse or awakened whalefall can seep intelligence into the lampreys that feast on their flesh, creating aquatic swarm striders with prodigious size and reach.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "persistent bleed damage",
+                  "aonid": 86,
+                  "game-obj": "Conditions",
+                  "name": "persistent bleed damage",
+                  "type": "link"
+                }
+              ],
+              "name": "Leech:",
+              "subtype": "ability",
+              "text": "This bloodsucking swarm strider usually forms from a fresh corpse exsanguinated in a leechinfested swamp, gaining both the ability to swim and to deal persistent bleed damage instead of piercing damage.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Wasp:",
+              "subtype": "ability",
+              "text": "Stinging and buzzing, a wasp strider flies, moving much faster in the air than on the ground.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "counteract",
+              "aonid": 3280,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            },
+            {
+              "alt": "auditory",
+              "aonid": 541,
+              "game-obj": "Traits",
+              "name": "auditory",
+              "type": "link"
+            },
+            {
+              "alt": "kraken\u2019s",
+              "aonid": 3075,
+              "game-obj": "Monsters",
+              "name": "kraken\u2019s",
+              "type": "link"
+            },
+            {
+              "alt": "persistent bleed damage",
+              "aonid": 86,
+              "game-obj": "Conditions",
+              "name": "persistent bleed damage",
+              "type": "link"
+            }
+          ],
+          "name": "Swarms of Different Forms",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 310",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 310",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 310,
+              "type": "source"
+            }
+          ],
+          "text": "In the right environments\u2014particularly where other invertebrates are most common\u2014swarm striders might be composed of unlikely critters. The following are several possible variants.   \n  \n**Bookworm:** Born students trapped in labyrinthine libraries, these swarm striders voraciously consume knowledge\u2014including the spellbooks and scrolls of those damaged by their Squirming Embrace!   \n  \n**Cicada:** These noisome swarm striders often hibernate for years at a time, and their screeching is known to counteract auditory effects.   \n  \n**Lamprey:** A kraken\u2019s corpse or awakened whalefall can seep intelligence into the lampreys that feast on their flesh, creating aquatic swarm striders with prodigious size and reach.   \n  \n**Leech:** This bloodsucking swarm strider usually forms from a fresh corpse exsanguinated in a leechinfested swamp, gaining both the ability to swim and to deal persistent bleed damage instead of piercing damage.  \n  \n**Wasp:** Stinging and buzzing, a wasp strider flies, moving much faster in the air than on the ground.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 310",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 310",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 310,
+          "type": "source"
+        }
+      ],
+      "text": "A swarm strider gains the aberration and swarm traits. They lose any traits that represent their former life, such as human and humanoid, though they usually remain the same size, keep the same items, and use the same weapons as they did before their rebirth. Swarm striders typically have the following abilities.  \n  \n**Darkvision**  \n  \n**Tremorsense** 30 feet (imprecise)  \n  \n**All-around Vision**  \n  \n**Clinging Remnants** A swarm strider's melee Strikes and ranged Strikes made against targets within their weapon's first range increment deposit biting vermin on the target, dealing 1d4 persistent piercing damage, increasing to 2d4 at 5th level, 3d4 at 10th level, 4d4 at 15th level, and 5d4 at 20th level.  \n  \n**Discorporate** When the swarm strider is reduced to 0 HP, their constituent creatures collapse, scattering on the ground under their space and each adjacent square. If even one of the creatures gets away, the swarm strider can eventually re-form over 1d10 days (potentially longer in areas where there are few invertebrates).  \n The scattered invertebrates must be destroyed within 1 round to destroy the swarm strider permanently. The invertebrates have a collective pool of HP, typically equal to 1/4 of the swarm strider's maximum HP, and the same AC, saves, immunities, resistances, and weaknesses as the swarm strider. The invertebrates can't take actions but they escape automatically once the round elapses. At the GM's discretion, clever means of trapping or eliminating the creatures might be sufficient to destroy the swarm strider.  \n  \n**Immunities** precision, swarm mind **Resistances** resistance 2 to physical and poison, increasing to 5 at 5th level, 10 at 10th level, 15 at 15th level, and 20 at 20th level.  \n  \n**Weaknesses** weakness 2 to area damage and splash damage, increasing to 5 at 5th level, 10 at 10th level, 15 at 15th level, and 20 at 20th level  \n  \n**Draw Bugs** [#] (healing) The swarm strider draws more arthropods from the environment around them to reconstitute some of their damaged body. They regain the listed number of HP, which is typically 5 HP, increasing to 10 at 5th level, 15 at 10th level, and 20 at 15th level. At the GM's discretion, the swarm strider doesn't recover HP in areas where there aren't enough arthropods to call to themselves.  \n  \n**Squirming Embrace** [#] The swarm strider Strides. If they end their movement sharing a space with a creature, they deal 1d6 piercing damage to the creature, with a basic Reflex save. The save DC is the high spell DC for the swarm strider's level. The damage increases by 1d6 at 4th level and every 3 levels thereafter. The swarm strider can Burrow, Climb, Fly, or Swim instead of Striding if they have the corresponding movement type.  \n  \n**Swarm Shape** [#] (concentrate) The swarm strider collapses into a shapeless swarm of their constituent creatures. They drops all items in their possession. In this form, the swarm strider can't use attack actions and can't cast spells, but they can move through areas small enough for their constituent creatures to fit without having to Squeeze. They can use the same action to coalesce from their swarm shape back into their normal form.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/monster_core_2/vampire_nosferatu.json
+++ b/monster_families/monster_core_2/vampire_nosferatu.json
@@ -373,876 +373,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 59,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 83,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 696,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Plagued Coffin Restoration",
-                "subtype": "ability",
-                "text": "Unlike other undead, a nosferatu isn't destroyed at 0 HP. Instead, they disperse into an immense number of rats heading in every direction in an attempt to return to their coffin. If even a single rat reaches the coffin, the nosferatu can recover. A nosferatu regains their strength through resting in earth taken from the grave of a creature that died of plague. If their body rests in their earth-filled coffin for 1 hour, the nosferatu gains 1 HP, after which their fast healing begins to function normally. If the coffin doesn't contain this plagued grave dirt, they instead need to rest in their coffin for 1 day before they gain 1 HP and regain their fast healing.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    },
-                    "name": "void",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Nosferatu Vulnerabilities",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 526,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the creature had hands, their fingernails thicken and grow, granting them an unarmed claw Strike that deals slashing damage and has the agile trait. If the creature had any agile attacks, the damage dealt by their claws should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their claws should deal three-quarters that damage. A creature struck by a nosferatu's claw Strike is also exposed to plague of ancients (see below).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "moderate to high damage for the nosferatu's level",
-                    "aonid": 2897,
-                    "game-obj": "Rules",
-                    "name": "moderate to high damage for the nosferatu's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fangs",
-                "subtype": "ability",
-                "text": "If the creature had teeth, their canines grow long and pointy, granting them an unarmed fangs Strike that deals piercing damage. This attack deals moderate to high damage for the nosferatu's level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "frequency": "three times per day",
-                "links": [
-                  {
-                    "alt": "telekinetic haul",
-                    "aonid": 1716,
-                    "game-obj": "Spells",
-                    "name": "telekinetic haul",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high DC for their level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high DC for their level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Innate Spells",
-                "subtype": "ability",
-                "text": "The nosferatu can cast *telekinetic haul* (heightened to half their level rounded up) three times per day as a divine innate spell. They use a high DC for their level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d10",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "link": {
-                  "alt": "Change Shape",
-                  "aonid": 55,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Change Shape",
-                  "type": "link"
-                },
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high DC for the nosferatu's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high DC for the nosferatu's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Shape",
-                "subtype": "ability",
-                "text": "The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. In this swarm form, the nosferatu can take an action to deal each enemy in the swarm's space 2d10 piercing damage with a basic Reflex save, with a high DC for the nosferatu's level. A creature that fails its save is also exposed to plague of ancients (see below).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 55,
-                  "edition": "remastered",
-                  "game-id": "cfccadd6ae22a706a897a80c7d209862",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "Impersonate",
-                      "aonid": 2388,
-                      "game-obj": "Actions",
-                      "name": "Impersonate",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Deception",
-                      "aonid": 38,
-                      "game-obj": "Skills",
-                      "name": "Deception",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Change Shape",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 358",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 358",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 358,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
-                  "traits": [
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 32,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "e32d877417a40fe977d27634dc14f99f",
-                      "game-obj": "Traits",
-                      "name": "Concentrate",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 454",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 454",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 454,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "An action with this trait requires a degree of mental concentration and discipline.",
-                      "type": "trait"
-                    },
-                    {
-                      "classes": [
-                        "template"
-                      ],
-                      "edition": "legacy",
-                      "game-id": "070ae8282a8ee960fa04002421f6d345",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "[Magical Tradition]",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "4.0",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "4.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Core Rulebook pg. 628",
-                            "aonid": 1,
-                            "game-obj": "Sources",
-                            "name": "Core Rulebook pg. 628",
-                            "type": "link"
-                          },
-                          "name": "Core Rulebook",
-                          "page": 628,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
-                      "type": "trait"
-                    },
-                    {
-                      "alternate_link": {
-                        "alternate_type": "legacy",
-                        "aonid": 127,
-                        "game-obj": "Traits",
-                        "type": "alternate_link"
-                      },
-                      "edition": "remastered",
-                      "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
-                      "game-obj": "Traits",
-                      "links": [
-                        {
-                          "alt": "counteract",
-                          "aonid": 371,
-                          "game-obj": "Rules",
-                          "name": "counteract",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "magical",
-                          "aonid": 103,
-                          "game-obj": "Traits",
-                          "name": "magical",
-                          "type": "link"
-                        },
-                        {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        }
-                      ],
-                      "name": "Polymorph",
-                      "sources": [
-                        {
-                          "errata": {
-                            "alt": "2.0",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "2.0",
-                            "type": "link"
-                          },
-                          "link": {
-                            "alt": "Player Core pg. 301",
-                            "aonid": 216,
-                            "game-obj": "Sources",
-                            "name": "Player Core pg. 301",
-                            "type": "link"
-                          },
-                          "name": "Player Core",
-                          "page": 301,
-                          "type": "source"
-                        }
-                      ],
-                      "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
-                      "type": "trait"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The nosferatu gives a single command to one of their thralls, which the thrall follows to the best of its ability during its next turn.",
-                "name": "Command Thrall",
-                "requirement": "One of the nosferatu's thralls is present and can hear the nosferatu",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 541,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 1501,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "visual",
-                    "aonid": 727,
-                    "game-obj": "Traits",
-                    "name": "visual",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high DC for the nosferatu's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high DC for the nosferatu's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dominate",
-                "subtype": "ability",
-                "text": "The nosferatu can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses a high DC for the nosferatu's level, and a creature that succeeds is temporarily immune to that nosferatu's Dominate for 24 hours. Fully destroying the nosferatu ends the domination, but merely reducing the nosferatu to 0 HP is insufficient to break the spell.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 631,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The nosferatu sinks their fangs into the targeted creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the nosferatu regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the nosferatu but increases the creature's drained condition value by 1, killing the victim when it reaches drained 5. A nosferatu can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.",
-                "links": [
-                  {
-                    "alt": "Athletics",
-                    "aonid": 36,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Blood",
-                "requirement": "The nosferatu's last action was a successful fangs Strike",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "links": [
-                  {
-                    "alt": "high DC for the nosferatu's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "high DC for the nosferatu's level",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "enfeebled 2",
-                    "aonid": 71,
-                    "game-obj": "Conditions",
-                    "name": "enfeebled 2",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "doomed 1",
-                    "aonid": 67,
-                    "game-obj": "Conditions",
-                    "name": "doomed 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Plague of Ancients",
-                "onset": "1 day",
-                "saving_throw": [
-                  {
-                    "modifiers": [
-                      {
-                        "name": "use a high DC for the nosferatu's level",
-                        "subtype": "modifier",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "Fortitude (use a high DC for the nosferatu's level)",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "drained 1 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "drained 2 and enfeebled 2 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 1, drained 3, and enfeebled 3 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 4",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 2, drained 3, and enfeebled 3 (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 5",
-                    "subtype": "affliction_stage",
-                    "text": "unconscious (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 6",
-                    "subtype": "affliction_stage",
-                    "text": "death",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 578,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "virulent",
-                      "aonid": 726,
-                      "game-obj": "Traits",
-                      "name": "virulent",
-                      "type": "link"
-                    },
-                    "name": "virulent",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Basic Nosferatu Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -1260,6 +395,286 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 59,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 83,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 696,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 526,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "moderate to high damage for the nosferatu's level",
+                "aonid": 2897,
+                "game-obj": "Rules",
+                "name": "moderate to high damage for the nosferatu's level",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic haul",
+                "aonid": 1716,
+                "game-obj": "Spells",
+                "name": "telekinetic haul",
+                "type": "link"
+              },
+              {
+                "alt": "high DC for their level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high DC for their level",
+                "type": "link"
+              },
+              {
+                "alt": "Change Shape",
+                "aonid": 55,
+                "game-obj": "MonsterAbilities",
+                "name": "Change Shape",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "high DC for the nosferatu's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high DC for the nosferatu's level",
+                "type": "link"
+              },
+              {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "high DC for the nosferatu's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high DC for the nosferatu's level",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 36,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "Medicine",
+                "aonid": 42,
+                "game-obj": "Skills",
+                "name": "Medicine",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "virulent",
+                "aonid": 726,
+                "game-obj": "Traits",
+                "name": "virulent",
+                "type": "link"
+              },
+              {
+                "alt": "high DC for the nosferatu's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "high DC for the nosferatu's level",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "enfeebled 2",
+                "aonid": 71,
+                "game-obj": "Conditions",
+                "name": "enfeebled 2",
+                "type": "link"
+              },
+              {
+                "alt": "doomed 1",
+                "aonid": 67,
+                "game-obj": "Conditions",
+                "name": "doomed 1",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1269,229 +684,117 @@
         ],
         "name": "Basic Nosferatu Abilities",
         "subtype": "monster_family",
-        "text": "All nosferatus gain the following abilities. If the base creature becoming a nosferatu has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the nosferatu's theme.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "moderate DC for the nosferatu's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "moderate DC for the nosferatu's level",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 91,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "diseases",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "diseases",
-                    "type": "link"
-                  }
-                ],
-                "name": "Air of Sickness",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "A creature entering or starting its turn in the aura must attempt a Fortitude save with a moderate DC for the nosferatu's level. On a failure, the creature is sickened 1 and takes a \u20132 status penalty to saves to resist diseases and remove the sickened condition for 1 hour.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "frequency": "twice per day",
-                "links": [
-                  {
-                    "alt": "vampiric exsanguination",
-                    "aonid": 1735,
-                    "game-obj": "Spells",
-                    "name": "vampiric exsanguination",
-                    "type": "link"
-                  }
-                ],
-                "name": "Divine Innate Spells",
-                "subtype": "ability",
-                "text": "As nosferatu, but they can also cast *vampiric exsanguination* twice per day as a divine innate spell.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The nosferatu drags the target of the Strike close and freezes its mind in terror. The target must attempt a Will save with a moderate DC for the nosferatu's level.",
-                "links": [
-                  {
-                    "alt": "moderate DC for the nosferatu's level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "moderate DC for the nosferatu's level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Paralytic Fear",
-                "requirement": "The nosferatu overlord's last action was a successful claw Strike",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 631,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The target is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "immobilized",
-                    "aonid": 81,
-                    "game-obj": "Conditions",
-                    "name": "immobilized",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The target is immobilized by fear until the end of the nosferatu's next turn.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "restrained",
-                    "aonid": 90,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The target is restrained and takes a \u20132 circumstance penalty to its Fortitude DC against the nosferatu's Drink Blood ability until the end of the nosferatu's next turn.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "frightened 2",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, and the target is frightened 2.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Nosferatu Overlord Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "moderate DC for the nosferatu's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "moderate DC for the nosferatu's level",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
+              },
+              {
+                "alt": "diseases",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "diseases",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric exsanguination",
+                "aonid": 1735,
+                "game-obj": "Spells",
+                "name": "vampiric exsanguination",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "moderate DC for the nosferatu's level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "moderate DC for the nosferatu's level",
+                "type": "link"
+              },
+              {
+                "alt": "immobilized",
+                "aonid": 81,
+                "game-obj": "Conditions",
+                "name": "immobilized",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 90,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 2",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened 2",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1501,151 +804,54 @@
         ],
         "name": "Nosferatu Overlord Abilities",
         "subtype": "monster_family",
-        "text": "A truly primeval nosferatu can gain extraordinary powers. Creatures must have lived for millennia and be 14th level or higher to become a nosferatu overlord.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "fast healing 5",
-                    "aonid": 62,
-                    "game-obj": "MonsterAbilities",
-                    "name": "fast healing 5",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fast Healing",
-                "subtype": "ability",
-                "text": "A thrall gains fast healing 5 from being sustained by their master's blood.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 62,
-                  "edition": "remastered",
-                  "game-id": "0ef9d33a04f2132af69c1fb22a516b56",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Fast Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with this ability regains the given number of Hit Points each round at the beginning of its turn.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "mental",
-                    "aonid": 647,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Weaknesses",
-                "subtype": "ability",
-                "text": "The strain of being controlled wears on the thrall's mind, giving them weakness 10 to mental damage.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "controlled",
-                    "aonid": 64,
-                    "game-obj": "Conditions",
-                    "name": "controlled",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteract",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mindbound",
-                "subtype": "ability",
-                "text": "A nosferatu master exerts a fierce hold over their thrall's mind. If any creature other than the thrall's master targets them with an effect that would give them the controlled condition, the thrall's master rolls a counteract check against it using their Dominate DC \u2013 10 as the counteract check modifier.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The thrall throws themself in front of their master, taking half the damage of the attack (before applying any weaknesses or resistances). The thrall's master takes the remaining damage, applying any weaknesses or resistances as normal.",
-                "name": "Mortal Shield",
-                "subtype": "ability",
-                "trigger": "The thrall's master would take damage from a Strike or spell attack and is in an adjacent square",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The thrall Strides up to their Speed toward their master.",
-                "name": "Rally",
-                "subtype": "ability",
-                "trigger": "The thrall ends their turn more than 30 feet away from their master",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Nosferatu Thrall Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fast healing 5",
+                "aonid": 62,
+                "game-obj": "MonsterAbilities",
+                "name": "fast healing 5",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "controlled",
+                "aonid": 64,
+                "game-obj": "Conditions",
+                "name": "controlled",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1655,7 +861,6 @@
         ],
         "name": "Nosferatu Thrall Abilities",
         "subtype": "monster_family",
-        "text": "Any creature under a nosferatu's thrall gains the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -1690,6 +895,1850 @@
         }
       ],
       "text": "You can turn an existing living creature into a nosferatu using the following steps. A creature below 8th level isn't significant enough to be a nosferatu and should likely be a regular vampire instead.  \n  \n Increase the creature's level by 1 and change its statistics as follows. \n\n|  |  |  |\n| --- | --- | --- |\n| **Starting Level** | **HP Decrease** | **Fast Healing/Resistance** |\n| 8\u201314  | \u201340  | 10 |\n| 15+  | \u201360  | 15 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Darkvision",
+            "aonid": 59,
+            "game-obj": "MonsterAbilities",
+            "name": "Darkvision",
+            "type": "link"
+          },
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 83,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 696,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "death effects, disease, paralyzed, poison, sleep",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Plagued Coffin Restoration",
+          "subtype": "ability",
+          "text": "Unlike other undead, a nosferatu isn't destroyed at 0 HP. Instead, they disperse into an immense number of rats heading in every direction in an attempt to return to their coffin. If even a single rat reaches the coffin, the nosferatu can recover. A nosferatu regains their strength through resting in earth taken from the grave of a creature that died of plague. If their body rests in their earth-filled coffin for 1 hour, the nosferatu gains 1 HP, after which their fast healing begins to function normally. If the coffin doesn't contain this plagued grave dirt, they instead need to rest in their coffin for 1 day before they gain 1 HP and regain their fast healing.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              "name": "void",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Nosferatu Vulnerabilities",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 526,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            }
+          ],
+          "name": "Claws",
+          "subtype": "ability",
+          "text": "If the creature had hands, their fingernails thicken and grow, granting them an unarmed claw Strike that deals slashing damage and has the agile trait. If the creature had any agile attacks, the damage dealt by their claws should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their claws should deal three-quarters that damage. A creature struck by a nosferatu's claw Strike is also exposed to plague of ancients (see below).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "moderate to high damage for the nosferatu's level",
+              "aonid": 2897,
+              "game-obj": "Rules",
+              "name": "moderate to high damage for the nosferatu's level",
+              "type": "link"
+            }
+          ],
+          "name": "Fangs",
+          "subtype": "ability",
+          "text": "If the creature had teeth, their canines grow long and pointy, granting them an unarmed fangs Strike that deals piercing damage. This attack deals moderate to high damage for the nosferatu's level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "frequency": "three times per day",
+          "links": [
+            {
+              "alt": "telekinetic haul",
+              "aonid": 1716,
+              "game-obj": "Spells",
+              "name": "telekinetic haul",
+              "type": "link"
+            },
+            {
+              "alt": "high DC for their level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high DC for their level",
+              "type": "link"
+            }
+          ],
+          "name": "Divine Innate Spells",
+          "subtype": "ability",
+          "text": "The nosferatu can cast *telekinetic haul* (heightened to half their level rounded up) three times per day as a divine innate spell. They use a high DC for their level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "piercing",
+              "formula": "2d10",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "link": {
+            "alt": "Change Shape",
+            "aonid": 55,
+            "game-obj": "MonsterAbilities",
+            "name": "Change Shape",
+            "type": "link"
+          },
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "high DC for the nosferatu's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high DC for the nosferatu's level",
+              "type": "link"
+            }
+          ],
+          "name": "Change Shape",
+          "subtype": "ability",
+          "text": "The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. In this swarm form, the nosferatu can take an action to deal each enemy in the swarm's space 2d10 piercing damage with a basic Reflex save, with a high DC for the nosferatu's level. A creature that fails its save is also exposed to plague of ancients (see below).",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 55,
+            "edition": "remastered",
+            "game-id": "cfccadd6ae22a706a897a80c7d209862",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "Impersonate",
+                "aonid": 2388,
+                "game-obj": "Actions",
+                "name": "Impersonate",
+                "type": "link"
+              },
+              {
+                "alt": "Deception",
+                "aonid": 38,
+                "game-obj": "Skills",
+                "name": "Deception",
+                "type": "link"
+              }
+            ],
+            "name": "Change Shape",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 358",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 358",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 358,
+                "type": "source"
+              }
+            ],
+            "text": "The monster changes its shape indefinitely. It can use this action again to return to its natural shape or adopt a new shape. Unless otherwise noted, a monster cannot use Change Shape to appear as a specific individual. Using Change Shape counts as creating a disguise for the Impersonate use of Deception. The monster's transformation automatically defeats Perception DCs to determine whether the creature is a member of the ancestry or creature type into which it transformed, and it gains a +4 status bonus to its Deception DC to prevent others from seeing through its disguise. Change Shape abilities specify what shapes the monster can adopt. The monster doesn't gain any special abilities of the new shape, only its physical form. For example, in each shape, it replaces its normal Speeds and Strikes, and might potentially change its senses or size. Any changes are listed in its stat block.",
+            "traits": [
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 32,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "e32d877417a40fe977d27634dc14f99f",
+                "game-obj": "Traits",
+                "name": "Concentrate",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 454",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 454",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 454,
+                    "type": "source"
+                  }
+                ],
+                "text": "An action with this trait requires a degree of mental concentration and discipline.",
+                "type": "trait"
+              },
+              {
+                "classes": [
+                  "template"
+                ],
+                "edition": "legacy",
+                "game-id": "070ae8282a8ee960fa04002421f6d345",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  }
+                ],
+                "name": "[Magical Tradition]",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "4.0",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "4.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Core Rulebook pg. 628",
+                      "aonid": 1,
+                      "game-obj": "Sources",
+                      "name": "Core Rulebook pg. 628",
+                      "type": "link"
+                    },
+                    "name": "Core Rulebook",
+                    "page": 628,
+                    "type": "source"
+                  }
+                ],
+                "text": "This magic could come from any one of the four magical traditions. Anything with this trait is magical.",
+                "type": "trait"
+              },
+              {
+                "alternate_link": {
+                  "alternate_type": "legacy",
+                  "aonid": 127,
+                  "game-obj": "Traits",
+                  "type": "alternate_link"
+                },
+                "edition": "remastered",
+                "game-id": "69f30c8801710f12f6fbd5a2c7c0d91d",
+                "game-obj": "Traits",
+                "links": [
+                  {
+                    "alt": "counteract",
+                    "aonid": 371,
+                    "game-obj": "Rules",
+                    "name": "counteract",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "magical",
+                    "aonid": 103,
+                    "game-obj": "Traits",
+                    "name": "magical",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  }
+                ],
+                "name": "Polymorph",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Player Core pg. 301",
+                      "aonid": 216,
+                      "game-obj": "Sources",
+                      "name": "Player Core pg. 301",
+                      "type": "link"
+                    },
+                    "name": "Player Core",
+                    "page": 301,
+                    "type": "source"
+                  }
+                ],
+                "text": "These effects transform the target into a new form. A target can't be under the effect of more than one polymorph effect at a time. If it comes under the effect of a second polymorph effect, the second polymorph effect attempts to counteract the first. If it succeeds, it takes effect, and if it fails, the spell has no effect on that target. Any Strikes specifically granted by a polymorph effect are magical. Unless otherwise stated, polymorph spells don't allow the target to take on the appearance of a specific individual creature, but rather just a generic creature of a general type or ancestry.  \n  \n If you take on a battle form with a polymorph spell, the special statistics can be adjusted only by circumstance bonuses, status bonuses, and penalties. Unless otherwise noted, the battle form prevents you from casting spells, speaking, and using most manipulate actions that require hands. (If there's doubt about whether you can use an action, the GM decides.) Your gear is absorbed into you; the constant abilities of your gear still function, but you can't activate any items. If a polymorph effect causes you to increase in size, you must have space to expand into or the effect is disrupted.",
+                "type": "trait"
+              }
+            ],
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The nosferatu gives a single command to one of their thralls, which the thrall follows to the best of its ability during its next turn.",
+          "name": "Command Thrall",
+          "requirement": "One of the nosferatu's thralls is present and can hear the nosferatu",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "auditory",
+                "aonid": 541,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              "name": "auditory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "dominate",
+              "aonid": 1501,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 727,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "high DC for the nosferatu's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high DC for the nosferatu's level",
+              "type": "link"
+            }
+          ],
+          "name": "Dominate",
+          "subtype": "ability",
+          "text": "The nosferatu can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses a high DC for the nosferatu's level, and a creature that succeeds is temporarily immune to that nosferatu's Dominate for 24 hours. Fully destroying the nosferatu ends the domination, but merely reducing the nosferatu to 0 HP is insufficient to break the spell.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              "name": "incapacitation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The nosferatu sinks their fangs into the targeted creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the nosferatu regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the nosferatu but increases the creature's drained condition value by 1, killing the victim when it reaches drained 5. A nosferatu can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.",
+          "links": [
+            {
+              "alt": "Athletics",
+              "aonid": 36,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Drink Blood",
+          "requirement": "The nosferatu's last action was a successful fangs Strike",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "affliction",
+          "links": [
+            {
+              "alt": "high DC for the nosferatu's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "high DC for the nosferatu's level",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "enfeebled 2",
+              "aonid": 71,
+              "game-obj": "Conditions",
+              "name": "enfeebled 2",
+              "type": "link"
+            },
+            {
+              "alt": "doomed 1",
+              "aonid": 67,
+              "game-obj": "Conditions",
+              "name": "doomed 1",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Plague of Ancients",
+          "onset": "1 day",
+          "saving_throw": [
+            {
+              "modifiers": [
+                {
+                  "name": "use a high DC for the nosferatu's level",
+                  "subtype": "modifier",
+                  "type": "stat_block_section"
+                }
+              ],
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "Fortitude (use a high DC for the nosferatu's level)",
+              "type": "stat_block_section"
+            }
+          ],
+          "stages": [
+            {
+              "name": "Stage 1",
+              "subtype": "affliction_stage",
+              "text": "drained 1 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 2",
+              "subtype": "affliction_stage",
+              "text": "drained 2 and enfeebled 2 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 3",
+              "subtype": "affliction_stage",
+              "text": "doomed 1, drained 3, and enfeebled 3 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 4",
+              "subtype": "affliction_stage",
+              "text": "doomed 2, drained 3, and enfeebled 3 (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 5",
+              "subtype": "affliction_stage",
+              "text": "unconscious (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 6",
+              "subtype": "affliction_stage",
+              "text": "death",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "virulent",
+                "aonid": 726,
+                "game-obj": "Traits",
+                "name": "virulent",
+                "type": "link"
+              },
+              "name": "virulent",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "human",
+          "aonid": 627,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Darkvision",
+          "aonid": 59,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 696,
+          "game-obj": "Traits",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        },
+        {
+          "alt": "agile",
+          "aonid": 526,
+          "game-obj": "Traits",
+          "name": "agile",
+          "type": "link"
+        },
+        {
+          "alt": "moderate to high damage for the nosferatu's level",
+          "aonid": 2897,
+          "game-obj": "Rules",
+          "name": "moderate to high damage for the nosferatu's level",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic haul",
+          "aonid": 1716,
+          "game-obj": "Spells",
+          "name": "telekinetic haul",
+          "type": "link"
+        },
+        {
+          "alt": "high DC for their level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high DC for their level",
+          "type": "link"
+        },
+        {
+          "alt": "Change Shape",
+          "aonid": 55,
+          "game-obj": "MonsterAbilities",
+          "name": "Change Shape",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "high DC for the nosferatu's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high DC for the nosferatu's level",
+          "type": "link"
+        },
+        {
+          "alt": "auditory",
+          "aonid": 541,
+          "game-obj": "Traits",
+          "name": "auditory",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "incapacitation",
+          "aonid": 631,
+          "game-obj": "Traits",
+          "name": "incapacitation",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "high DC for the nosferatu's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high DC for the nosferatu's level",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 36,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "Medicine",
+          "aonid": 42,
+          "game-obj": "Skills",
+          "name": "Medicine",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "virulent",
+          "aonid": 726,
+          "game-obj": "Traits",
+          "name": "virulent",
+          "type": "link"
+        },
+        {
+          "alt": "high DC for the nosferatu's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "high DC for the nosferatu's level",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "enfeebled 2",
+          "aonid": 71,
+          "game-obj": "Conditions",
+          "name": "enfeebled 2",
+          "type": "link"
+        },
+        {
+          "alt": "doomed 1",
+          "aonid": 67,
+          "game-obj": "Conditions",
+          "name": "doomed 1",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        }
+      ],
+      "name": "Basic Nosferatu Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 338",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 338",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 338,
+          "type": "source"
+        }
+      ],
+      "text": "All nosferatus gain the following abilities. If the base creature becoming a nosferatu has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the nosferatu's theme.  \n  \n**Darkvision**  \n  \n**Void Healing**  \n  \n**Immunities** death effects, disease, paralyzed, poison, sleep  \n  \n**Plagued Coffin Restoration** (divine, void) Unlike other undead, a nosferatu isn't destroyed at 0 HP. Instead, they disperse into an immense number of rats heading in every direction in an attempt to return to their coffin. If even a single rat reaches the coffin, the nosferatu can recover. A nosferatu regains their strength through resting in earth taken from the grave of a creature that died of plague. If their body rests in their earth-filled coffin for 1 hour, the nosferatu gains 1 HP, after which their fast healing begins to function normally. If the coffin doesn't contain this plagued grave dirt, they instead need to rest in their coffin for 1 day before they gain 1 HP and regain their fast healing.  \n  \n**Nosferatu Vulnerabilities** **Claws** If the creature had hands, their fingernails thicken and grow, granting them an unarmed claw Strike that deals slashing damage and has the agile trait. If the creature had any agile attacks, the damage dealt by their claws should be roughly the same as the damage dealt by those attacks. If they had only non-agile attacks, their claws should deal three-quarters that damage. A creature struck by a nosferatu's claw Strike is also exposed to plague of ancients (see below).  \n  \n**Fangs** If the creature had teeth, their canines grow long and pointy, granting them an unarmed fangs Strike that deals piercing damage. This attack deals moderate to high damage for the nosferatu's level.  \n  \n**Divine Innate Spells** The nosferatu can cast *telekinetic haul* (heightened to half their level rounded up) three times per day as a divine innate spell. They use a high DC for their level.  \n  \n**Change Shape** [#] (concentrate, divine, polymorph) The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. In this swarm form, the nosferatu can take an action to deal each enemy in the swarm's space 2d10 piercing damage with a basic Reflex save, with a high DC for the nosferatu's level. A creature that fails its save is also exposed to plague of ancients (see below).  \n  \n**Command Thrall** [-] (auditory, divine, mental) **Requirements** One of the nosferatu's thralls is present and can hear the nosferatu; **Effect** The nosferatu gives a single command to one of their thralls, which the thrall follows to the best of its ability during its next turn.   \n  \n**Dominate** [##] (divine, incapacitation, mental, visual) The nosferatu can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses a high DC for the nosferatu's level, and a creature that succeeds is temporarily immune to that nosferatu's Dominate for 24 hours. Fully destroying the nosferatu ends the domination, but merely reducing the nosferatu to 0 HP is insufficient to break the spell.  \n  \n**Drink Blood** [#] (divine) **Requirements** The nosferatu's last action was a successful fangs Strike; **Effect** The nosferatu sinks their fangs into the targeted creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes drained 1, and the nosferatu regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the nosferatu but increases the creature's drained condition value by 1, killing the victim when it reaches drained 5. A nosferatu can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.  \n The target creature's drained condition value decreases by 1 per week. A blood transfusion, which requires a successful DC 20 Medicine check and sufficient blood or a blood donor, reduces the drained value by 1 after 10 minutes.   \n  \n**Plague of Ancients** (disease, virulent) **Saving Throw** Fortitude (use a high DC for the nosferatu's level); **Onset** 1 day; **Stage 1** drained 1 (1 day); **Stage 2** drained 2 and enfeebled 2 (1 day); **Stage 3** doomed 1, drained 3, and enfeebled 3 (1 day); **Stage 4** doomed 2, drained 3, and enfeebled 3 (1 day); **Stage 5** unconscious (1 day); **Stage 6** death",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "moderate DC for the nosferatu's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "moderate DC for the nosferatu's level",
+              "type": "link"
+            },
+            {
+              "alt": "sickened 1",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            },
+            {
+              "alt": "diseases",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "diseases",
+              "type": "link"
+            }
+          ],
+          "name": "Air of Sickness",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "A creature entering or starting its turn in the aura must attempt a Fortitude save with a moderate DC for the nosferatu's level. On a failure, the creature is sickened 1 and takes a \u20132 status penalty to saves to resist diseases and remove the sickened condition for 1 hour.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "frequency": "twice per day",
+          "links": [
+            {
+              "alt": "vampiric exsanguination",
+              "aonid": 1735,
+              "game-obj": "Spells",
+              "name": "vampiric exsanguination",
+              "type": "link"
+            }
+          ],
+          "name": "Divine Innate Spells",
+          "subtype": "ability",
+          "text": "As nosferatu, but they can also cast *vampiric exsanguination* twice per day as a divine innate spell.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The nosferatu drags the target of the Strike close and freezes its mind in terror. The target must attempt a Will save with a moderate DC for the nosferatu's level.",
+          "links": [
+            {
+              "alt": "moderate DC for the nosferatu's level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "moderate DC for the nosferatu's level",
+              "type": "link"
+            }
+          ],
+          "name": "Paralytic Fear",
+          "requirement": "The nosferatu overlord's last action was a successful claw Strike",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              "name": "incapacitation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The target is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "immobilized",
+              "aonid": 81,
+              "game-obj": "Conditions",
+              "name": "immobilized",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The target is immobilized by fear until the end of the nosferatu's next turn.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "restrained",
+              "aonid": 90,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            }
+          ],
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The target is restrained and takes a \u20132 circumstance penalty to its Fortitude DC against the nosferatu's Drink Blood ability until the end of the nosferatu's next turn.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "frightened 2",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened 2",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, and the target is frightened 2.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "moderate DC for the nosferatu's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "moderate DC for the nosferatu's level",
+          "type": "link"
+        },
+        {
+          "alt": "sickened 1",
+          "aonid": 91,
+          "game-obj": "Conditions",
+          "name": "sickened 1",
+          "type": "link"
+        },
+        {
+          "alt": "diseases",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "diseases",
+          "type": "link"
+        },
+        {
+          "alt": "vampiric exsanguination",
+          "aonid": 1735,
+          "game-obj": "Spells",
+          "name": "vampiric exsanguination",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "incapacitation",
+          "aonid": 631,
+          "game-obj": "Traits",
+          "name": "incapacitation",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "moderate DC for the nosferatu's level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "moderate DC for the nosferatu's level",
+          "type": "link"
+        },
+        {
+          "alt": "immobilized",
+          "aonid": 81,
+          "game-obj": "Conditions",
+          "name": "immobilized",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 90,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        },
+        {
+          "alt": "frightened 2",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened 2",
+          "type": "link"
+        }
+      ],
+      "name": "Nosferatu Overlord Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 338",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 338",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 338,
+          "type": "source"
+        }
+      ],
+      "text": "A truly primeval nosferatu can gain extraordinary powers. Creatures must have lived for millennia and be 14th level or higher to become a nosferatu overlord.  \n  \n**Air of Sickness** (aura) 30 feet. A creature entering or starting its turn in the aura must attempt a Fortitude save with a moderate DC for the nosferatu's level. On a failure, the creature is sickened 1 and takes a \u20132 status penalty to saves to resist diseases and remove the sickened condition for 1 hour.  \n  \n**Divine Innate Spells** As nosferatu, but they can also cast *vampiric exsanguination* twice per day as a divine innate spell.  \n  \n**Paralytic Fear** [#] (divine, emotion, fear, incapacitation, mental) **Requirements** The nosferatu overlord's last action was a successful claw Strike; **Effect** The nosferatu drags the target of the Strike close and freezes its mind in terror. The target must attempt a Will save with a moderate DC for the nosferatu's level.  \n**Critical Success** The target is unaffected.  \n**Success** The target is immobilized by fear until the end of the nosferatu's next turn.  \n**Failure** The target is restrained and takes a \u20132 circumstance penalty to its Fortitude DC against the nosferatu's Drink Blood ability until the end of the nosferatu's next turn.  \n**Critical Failure** As failure, and the target is frightened 2.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "fast healing 5",
+              "aonid": 62,
+              "game-obj": "MonsterAbilities",
+              "name": "fast healing 5",
+              "type": "link"
+            }
+          ],
+          "name": "Fast Healing",
+          "subtype": "ability",
+          "text": "A thrall gains fast healing 5 from being sustained by their master's blood.",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 62,
+            "edition": "remastered",
+            "game-id": "0ef9d33a04f2132af69c1fb22a516b56",
+            "game-obj": "MonsterAbilities",
+            "name": "Fast Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with this ability regains the given number of Hit Points each round at the beginning of its turn.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            }
+          ],
+          "name": "Weaknesses",
+          "subtype": "ability",
+          "text": "The strain of being controlled wears on the thrall's mind, giving them weakness 10 to mental damage.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "controlled",
+              "aonid": 64,
+              "game-obj": "Conditions",
+              "name": "controlled",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            }
+          ],
+          "name": "Mindbound",
+          "subtype": "ability",
+          "text": "A nosferatu master exerts a fierce hold over their thrall's mind. If any creature other than the thrall's master targets them with an effect that would give them the controlled condition, the thrall's master rolls a counteract check against it using their Dominate DC \u2013 10 as the counteract check modifier.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The thrall throws themself in front of their master, taking half the damage of the attack (before applying any weaknesses or resistances). The thrall's master takes the remaining damage, applying any weaknesses or resistances as normal.",
+          "name": "Mortal Shield",
+          "subtype": "ability",
+          "trigger": "The thrall's master would take damage from a Strike or spell attack and is in an adjacent square",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The thrall Strides up to their Speed toward their master.",
+          "name": "Rally",
+          "subtype": "ability",
+          "trigger": "The thrall ends their turn more than 30 feet away from their master",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "fast healing 5",
+          "aonid": 62,
+          "game-obj": "MonsterAbilities",
+          "name": "fast healing 5",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "controlled",
+          "aonid": 64,
+          "game-obj": "Conditions",
+          "name": "controlled",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 371,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        }
+      ],
+      "name": "Nosferatu Thrall Abilities",
+      "sections": [
+        {
+          "name": "Among the Living",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 338",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 338",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 338,
+              "type": "source"
+            }
+          ],
+          "text": "Though terrifying in appearance, nosferatus typically dwell among mortals. They might reside in a decrepit manor nestled in a quiet neighborhood. They can also occupy an abandoned castle, preying on weary travelers who mistake their lair as a haven from the elements.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "standard monster creation rules",
+              "aonid": 2874,
+              "game-obj": "Rules",
+              "name": "standard monster creation rules",
+              "type": "link"
+            },
+            {
+              "alt": "nosferatu thrall",
+              "aonid": 1356,
+              "game-obj": "Monsters",
+              "name": "nosferatu thrall",
+              "type": "link"
+            },
+            {
+              "alt": "nosferatu malefactor",
+              "aonid": 1357,
+              "game-obj": "Monsters",
+              "name": "nosferatu malefactor",
+              "type": "link"
+            },
+            {
+              "alt": "nosferatu overlord",
+              "aonid": 1358,
+              "game-obj": "Monsters",
+              "name": "nosferatu overlord",
+              "type": "link"
+            },
+            {
+              "alt": "void healing",
+              "aonid": 83,
+              "game-obj": "MonsterAbilities",
+              "name": "void healing",
+              "type": "link"
+            }
+          ],
+          "name": "Building a Nosferatu",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 338",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 338",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 338,
+              "type": "source"
+            }
+          ],
+          "text": "Though nosferatus can\u2019t create more of their kind, many of these ancient vampires lurk in the world\u2019s various shadows, taking a variety of forms. If you have time, it\u2019s more effective to build a new nosferatu from the ground up using the standard monster creation rules, which were used to create the nosferatu thrall, nosferatu malefactor, and nosferatu overlord. However, you can also use the guidelines presented under Creating a Nosferatu to turn an existing creature into a nosferatu, adjusting the monster as you see fit. In either case, specific nosferatu abilities like void healing, Dominate, and Drink Blood work the same.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "mindless",
+              "aonid": 652,
+              "game-obj": "Traits",
+              "name": "mindless",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "monster creation rules",
+              "aonid": 2874,
+              "game-obj": "Rules",
+              "name": "monster creation rules",
+              "type": "link"
+            },
+            {
+              "alt": "GM Core",
+              "aonid": 218,
+              "game-obj": "Sources",
+              "name": "GM Core",
+              "type": "link"
+            }
+          ],
+          "name": "Building a Nosferatu Thrall",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 338",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 338",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 338,
+              "type": "source"
+            }
+          ],
+          "text": "While a nosferatu can\u2019t turn a living creature into another nosferatu, they can create a thrall through a 1-day ritual. They can maintain a number of thralls up to their Charisma modifier; creating new thralls beyond this limit releases earlier thralls from service. You can convert any non-mindless living creature into a nosferatu thrall by applying the nosferatu thrall abilities and increasing its level by 1. A creature that\u2019s immune to mental effects can\u2019t become a nosferatu thrall. You can also build a nosferatu thrall from scratch using the monster creation rules in *GM Core* and applying the above modifications.",
+          "type": "section"
+        },
+        {
+          "name": "Monsters of Legend",
+          "sources": [
+            {
+              "link": {
+                "alt": "Monster Core 2 pg. 338",
+                "aonid": 276,
+                "game-obj": "Sources",
+                "name": "Monster Core 2 pg. 338",
+                "type": "link"
+              },
+              "name": "Monster Core 2",
+              "page": 338,
+              "type": "source"
+            }
+          ],
+          "text": "The word nosferatu has appeared in print since the mid\u201318th century, purported by Western European writers to be a Romanian word for vampire, inspiring some of horror fiction\u2019s best minds. No clear etymology exists, and while it\u2019s unknown whether the word\u2019s roots are actually Romanian, the vampire itself is an enduring element of Romanian folklore.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Monster Core 2 pg. 338",
+            "aonid": 276,
+            "game-obj": "Sources",
+            "name": "Monster Core 2 pg. 338",
+            "type": "link"
+          },
+          "name": "Monster Core 2",
+          "page": 338,
+          "type": "source"
+        }
+      ],
+      "text": "Any creature under a nosferatu's thrall gains the following abilities.  \n  \n**Fast Healing** A thrall gains fast healing 5 from being sustained by their master's blood. **Weaknesses** The strain of being controlled wears on the thrall's mind, giving them weakness 10 to mental damage.  \n  \n**Mindbound** (divine) A nosferatu master exerts a fierce hold over their thrall's mind. If any creature other than the thrall's master targets them with an effect that would give them the controlled condition, the thrall's master rolls a counteract check against it using their Dominate DC \u2013 10 as the counteract check modifier.  \n  \n**Mortal Shield** [@] **Trigger** The thrall's master would take damage from a Strike or spell attack and is in an adjacent square; **Effect** The thrall throws themself in front of their master, taking half the damage of the attack (before applying any weaknesses or resistances). The thrall's master takes the remaining damage, applying any weaknesses or resistances as normal.  \n  \n**Rally** [@] **Trigger** The thrall ends their turn more than 30 feet away from their master; **Effect** The thrall Strides up to their Speed toward their master.",
       "type": "section"
     },
     {

--- a/monster_families/npc_core/courtier.json
+++ b/monster_families/npc_core/courtier.json
@@ -59,20 +59,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Ball",
-                "subtype": "ability",
-                "text": ": a formal dance party that often includes a banquet",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Know Your Social Events')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -83,7 +74,6 @@
         ],
         "name": "Know Your Social Events",
         "subtype": "monster_family",
-        "text": "* \n* **Banquet**: an elaborate formal meal for a large number of people\n* **Debutante Ball**: a ball where upper-class youths formally enter society as adults\n* **Gala**: a social occasion with special entertainment or performances\n* **Hunt**: a formal hunting competition among the nobility and royals of court\n* **Masque**: a dramatic performance with singing, dancing, pantomime, and dialogue",
         "type": "stat_block_section"
       }
     ],
@@ -137,6 +127,34 @@
         }
       ],
       "text": "The royal court is filled with intrigue! Here are some examples of who might be scheming. \n* The monarch's spouse or children\n* The royal pet (a druid in disguise)\n* The grand vizier\n* Visiting ambassadors or nobles\n* Palace champion\n* Palace doctor\n* Kitchen staff\n* Court jester",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Ball",
+          "subtype": "ability",
+          "text": ": a formal dance party that often includes a banquet",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Know Your Social Events",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 12",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 12",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 12,
+          "type": "source"
+        }
+      ],
+      "text": "* **Ball**: a formal dance party that often includes a banquet\n* **Banquet**: an elaborate formal meal for a large number of people\n* **Debutante Ball**: a ball where upper-class youths formally enter society as adults\n* **Gala**: a social occasion with special entertainment or performances\n* **Hunt**: a formal hunting competition among the nobility and royals of court\n* **Masque**: a dramatic performance with singing, dancing, pantomime, and dialogue",
       "type": "section"
     },
     {

--- a/monster_families/npc_core/devotee.json
+++ b/monster_families/npc_core/devotee.json
@@ -59,41 +59,29 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "harm",
-                    "aonid": 1552,
-                    "game-obj": "Spells",
-                    "name": "harm",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "heal",
-                    "aonid": 1554,
-                    "game-obj": "Spells",
-                    "name": "heal",
-                    "type": "link"
-                  }
-                ],
-                "name": "Selective Energy",
-                "subtype": "ability",
-                "text": "When the devotee casts a version of *harm* or *heal* that has an area, they can designate up to 5 creatures in the area. Those creatures are not targeted by the spell.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Swapping Deities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
             "links": [
+              {
+                "alt": "harm",
+                "aonid": 1552,
+                "game-obj": "Spells",
+                "name": "harm",
+                "type": "link"
+              },
+              {
+                "alt": "heal",
+                "aonid": 1554,
+                "game-obj": "Spells",
+                "name": "heal",
+                "type": "link"
+              },
               {
                 "alt": "domains and domain spells here",
                 "href": "Domains.aspx",
@@ -118,170 +106,11 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "bind undead",
-                        "aonid": 1449,
-                        "game-obj": "Spells",
-                        "name": "bind undead",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "chilling darkness",
-                        "aonid": 1464,
-                        "game-obj": "Spells",
-                        "name": "chilling darkness",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "harm",
-                        "aonid": 1552,
-                        "game-obj": "Spells",
-                        "name": "harm",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "vampiric feast",
-                        "aonid": 1736,
-                        "game-obj": "Spells",
-                        "name": "vampiric feast",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "3rd",
-                    "subtype": "ability",
-                    "text": "*bind undead*, *chilling darkness*, *harm* (\u00d75), *vampiric feast*;",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "blood vendetta",
-                        "aonid": 1454,
-                        "game-obj": "Spells",
-                        "name": "blood vendetta",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "false vitality",
-                        "aonid": 1523,
-                        "game-obj": "Spells",
-                        "name": "false vitality",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "spiritual armament",
-                        "aonid": 1687,
-                        "game-obj": "Spells",
-                        "name": "spiritual armament",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "2nd",
-                    "subtype": "ability",
-                    "text": "*blood vendetta*, *false vitality*, *spiritual armament*;",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "enfeeble",
-                        "aonid": 1513,
-                        "game-obj": "Spells",
-                        "name": "enfeeble",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "fear",
-                        "aonid": 1524,
-                        "game-obj": "Spells",
-                        "name": "fear",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "goblin pox",
-                        "aonid": 1545,
-                        "game-obj": "Spells",
-                        "name": "goblin pox",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "1st",
-                    "subtype": "ability",
-                    "text": "*enfeeble*, *fear*, *goblin pox*;",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "detect magic",
-                        "aonid": 1485,
-                        "game-obj": "Spells",
-                        "name": "detect magic",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "divine lance",
-                        "aonid": 1498,
-                        "game-obj": "Spells",
-                        "name": "divine lance",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "guidance",
-                        "aonid": 1549,
-                        "game-obj": "Spells",
-                        "name": "guidance",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "read aura",
-                        "aonid": 1646,
-                        "game-obj": "Spells",
-                        "name": "read aura",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "void warp",
-                        "aonid": 1745,
-                        "game-obj": "Spells",
-                        "name": "void warp",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Cantrips",
-                    "subtype": "ability",
-                    "text": "*detect magic*, *divine lance*, *guidance*, *read aura*, *void warp*;",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "touch of undeath",
-                        "aonid": 1846,
-                        "game-obj": "Spells",
-                        "name": "touch of undeath",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Cleric Domain Spell",
-                    "subtype": "ability",
-                    "text": "*touch of undeath*",
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Swapping Deities')].sections[?(@.name=='Deity Swap Example')].abilities",
                     "target": "$.defense.automatic_abilities"
                   }
                 ],
@@ -355,6 +184,118 @@
                     "game-obj": "Domains",
                     "name": "undeath",
                     "type": "link"
+                  },
+                  {
+                    "alt": "bind undead",
+                    "aonid": 1449,
+                    "game-obj": "Spells",
+                    "name": "bind undead",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "chilling darkness",
+                    "aonid": 1464,
+                    "game-obj": "Spells",
+                    "name": "chilling darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "harm",
+                    "aonid": 1552,
+                    "game-obj": "Spells",
+                    "name": "harm",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "vampiric feast",
+                    "aonid": 1736,
+                    "game-obj": "Spells",
+                    "name": "vampiric feast",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "blood vendetta",
+                    "aonid": 1454,
+                    "game-obj": "Spells",
+                    "name": "blood vendetta",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "false vitality",
+                    "aonid": 1523,
+                    "game-obj": "Spells",
+                    "name": "false vitality",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "spiritual armament",
+                    "aonid": 1687,
+                    "game-obj": "Spells",
+                    "name": "spiritual armament",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "enfeeble",
+                    "aonid": 1513,
+                    "game-obj": "Spells",
+                    "name": "enfeeble",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "fear",
+                    "aonid": 1524,
+                    "game-obj": "Spells",
+                    "name": "fear",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "goblin pox",
+                    "aonid": 1545,
+                    "game-obj": "Spells",
+                    "name": "goblin pox",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "detect magic",
+                    "aonid": 1485,
+                    "game-obj": "Spells",
+                    "name": "detect magic",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "divine lance",
+                    "aonid": 1498,
+                    "game-obj": "Spells",
+                    "name": "divine lance",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "guidance",
+                    "aonid": 1549,
+                    "game-obj": "Spells",
+                    "name": "guidance",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "read aura",
+                    "aonid": 1646,
+                    "game-obj": "Spells",
+                    "name": "read aura",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "void warp",
+                    "aonid": 1745,
+                    "game-obj": "Spells",
+                    "name": "void warp",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "touch of undeath",
+                    "aonid": 1846,
+                    "game-obj": "Spells",
+                    "name": "touch of undeath",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -364,11 +305,9 @@
             ],
             "name": "Deity Swap Example",
             "subtype": "monster_family",
-            "text": "To make a priest of Urgathoa, you would make the following changes to the priest of Sarenrae, following the bullet points above. \n* Change the holy trait to unholy.\n* Add Intimidation +14 and remove Medicine +14.\n* Change their scimitar to a scythe. You can change the 1d6+7 damage to the equivalent 1d10+5 if you want to use the scythe's normal damage die.\n* Change the spells as follows, and replace healing hands with selective energy. This list includes an example of swapping the sun domain for the undeath domain.",
             "type": "stat_block_section"
           }
         ],
-        "text": "You can customize an acolyte, zealot, priest, or other NPC tied to a specific deity to match another deity. \n* Change the NPC's sanctification to match the new deity.\n* Add the deity's divine skill at the highest skill modifier the PC has. You can optionally remove the old deity's divine skill.\n* Change their weapon to the new deity's favored weapon. You can usually leave the weapon damage as-is.\n* If the NPC has multiple harm or heal spells at their top spell rank (mimicking a cleric's divine font), change that spell to match the new deity's font. If the NPC has the healing hands ability, change it to selective energy.\n* Swap some spells out for devotee spells or others that match the new deity's style. You can swap out domain spells if you choose, but this is a more involved process, and it's best to reference Player Core (see domains and domain spells here).\n For information on deity mechanics, see the deitiy table here.",
         "type": "stat_block_section"
       }
     ],
@@ -376,6 +315,653 @@
   },
   "name": "Devotee",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "harm",
+              "aonid": 1552,
+              "game-obj": "Spells",
+              "name": "harm",
+              "type": "link"
+            },
+            {
+              "alt": "heal",
+              "aonid": 1554,
+              "game-obj": "Spells",
+              "name": "heal",
+              "type": "link"
+            }
+          ],
+          "name": "Selective Energy",
+          "subtype": "ability",
+          "text": "When the devotee casts a version of *harm* or *heal* that has an area, they can designate up to 5 creatures in the area. Those creatures are not targeted by the spell.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "harm",
+          "aonid": 1552,
+          "game-obj": "Spells",
+          "name": "harm",
+          "type": "link"
+        },
+        {
+          "alt": "heal",
+          "aonid": 1554,
+          "game-obj": "Spells",
+          "name": "heal",
+          "type": "link"
+        },
+        {
+          "alt": "domains and domain spells here",
+          "href": "Domains.aspx",
+          "name": "domains and domain spells here",
+          "type": "link"
+        },
+        {
+          "alt": "here",
+          "href": "Deities.aspx",
+          "name": "here",
+          "type": "link"
+        }
+      ],
+      "name": "Swapping Deities",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "bind undead",
+                  "aonid": 1449,
+                  "game-obj": "Spells",
+                  "name": "bind undead",
+                  "type": "link"
+                },
+                {
+                  "alt": "chilling darkness",
+                  "aonid": 1464,
+                  "game-obj": "Spells",
+                  "name": "chilling darkness",
+                  "type": "link"
+                },
+                {
+                  "alt": "harm",
+                  "aonid": 1552,
+                  "game-obj": "Spells",
+                  "name": "harm",
+                  "type": "link"
+                },
+                {
+                  "alt": "vampiric feast",
+                  "aonid": 1736,
+                  "game-obj": "Spells",
+                  "name": "vampiric feast",
+                  "type": "link"
+                }
+              ],
+              "name": "3rd",
+              "subtype": "ability",
+              "text": "*bind undead*, *chilling darkness*, *harm* (\u00d75), *vampiric feast*;",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "blood vendetta",
+                  "aonid": 1454,
+                  "game-obj": "Spells",
+                  "name": "blood vendetta",
+                  "type": "link"
+                },
+                {
+                  "alt": "false vitality",
+                  "aonid": 1523,
+                  "game-obj": "Spells",
+                  "name": "false vitality",
+                  "type": "link"
+                },
+                {
+                  "alt": "spiritual armament",
+                  "aonid": 1687,
+                  "game-obj": "Spells",
+                  "name": "spiritual armament",
+                  "type": "link"
+                }
+              ],
+              "name": "2nd",
+              "subtype": "ability",
+              "text": "*blood vendetta*, *false vitality*, *spiritual armament*;",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "enfeeble",
+                  "aonid": 1513,
+                  "game-obj": "Spells",
+                  "name": "enfeeble",
+                  "type": "link"
+                },
+                {
+                  "alt": "fear",
+                  "aonid": 1524,
+                  "game-obj": "Spells",
+                  "name": "fear",
+                  "type": "link"
+                },
+                {
+                  "alt": "goblin pox",
+                  "aonid": 1545,
+                  "game-obj": "Spells",
+                  "name": "goblin pox",
+                  "type": "link"
+                }
+              ],
+              "name": "1st",
+              "subtype": "ability",
+              "text": "*enfeeble*, *fear*, *goblin pox*;",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "detect magic",
+                  "aonid": 1485,
+                  "game-obj": "Spells",
+                  "name": "detect magic",
+                  "type": "link"
+                },
+                {
+                  "alt": "divine lance",
+                  "aonid": 1498,
+                  "game-obj": "Spells",
+                  "name": "divine lance",
+                  "type": "link"
+                },
+                {
+                  "alt": "guidance",
+                  "aonid": 1549,
+                  "game-obj": "Spells",
+                  "name": "guidance",
+                  "type": "link"
+                },
+                {
+                  "alt": "read aura",
+                  "aonid": 1646,
+                  "game-obj": "Spells",
+                  "name": "read aura",
+                  "type": "link"
+                },
+                {
+                  "alt": "void warp",
+                  "aonid": 1745,
+                  "game-obj": "Spells",
+                  "name": "void warp",
+                  "type": "link"
+                }
+              ],
+              "name": "Cantrips",
+              "subtype": "ability",
+              "text": "*detect magic*, *divine lance*, *guidance*, *read aura*, *void warp*;",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "touch of undeath",
+                  "aonid": 1846,
+                  "game-obj": "Spells",
+                  "name": "touch of undeath",
+                  "type": "link"
+                }
+              ],
+              "name": "Cleric Domain Spell",
+              "subtype": "ability",
+              "text": "*touch of undeath*",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Urgathoa",
+              "aonid": 295,
+              "game-obj": "Deities",
+              "name": "Urgathoa",
+              "type": "link"
+            },
+            {
+              "alt": "priest of Sarenrae",
+              "aonid": 3445,
+              "game-obj": "NPCs",
+              "name": "priest of Sarenrae",
+              "type": "link"
+            },
+            {
+              "alt": "holy",
+              "aonid": 517,
+              "game-obj": "Traits",
+              "name": "holy",
+              "type": "link"
+            },
+            {
+              "alt": "unholy",
+              "aonid": 521,
+              "game-obj": "Traits",
+              "name": "unholy",
+              "type": "link"
+            },
+            {
+              "alt": "Intimidation",
+              "aonid": 40,
+              "game-obj": "Skills",
+              "name": "Intimidation",
+              "type": "link"
+            },
+            {
+              "alt": "Medicine",
+              "aonid": 42,
+              "game-obj": "Skills",
+              "name": "Medicine",
+              "type": "link"
+            },
+            {
+              "alt": "scimitar",
+              "aonid": 393,
+              "game-obj": "Weapons",
+              "name": "scimitar",
+              "type": "link"
+            },
+            {
+              "alt": "scythe",
+              "aonid": 394,
+              "game-obj": "Weapons",
+              "name": "scythe",
+              "type": "link"
+            },
+            {
+              "alt": "sun",
+              "aonid": 92,
+              "game-obj": "Domains",
+              "name": "sun",
+              "type": "link"
+            },
+            {
+              "alt": "undeath",
+              "aonid": 97,
+              "game-obj": "Domains",
+              "name": "undeath",
+              "type": "link"
+            },
+            {
+              "alt": "bind undead",
+              "aonid": 1449,
+              "game-obj": "Spells",
+              "name": "bind undead",
+              "type": "link"
+            },
+            {
+              "alt": "chilling darkness",
+              "aonid": 1464,
+              "game-obj": "Spells",
+              "name": "chilling darkness",
+              "type": "link"
+            },
+            {
+              "alt": "harm",
+              "aonid": 1552,
+              "game-obj": "Spells",
+              "name": "harm",
+              "type": "link"
+            },
+            {
+              "alt": "vampiric feast",
+              "aonid": 1736,
+              "game-obj": "Spells",
+              "name": "vampiric feast",
+              "type": "link"
+            },
+            {
+              "alt": "blood vendetta",
+              "aonid": 1454,
+              "game-obj": "Spells",
+              "name": "blood vendetta",
+              "type": "link"
+            },
+            {
+              "alt": "false vitality",
+              "aonid": 1523,
+              "game-obj": "Spells",
+              "name": "false vitality",
+              "type": "link"
+            },
+            {
+              "alt": "spiritual armament",
+              "aonid": 1687,
+              "game-obj": "Spells",
+              "name": "spiritual armament",
+              "type": "link"
+            },
+            {
+              "alt": "enfeeble",
+              "aonid": 1513,
+              "game-obj": "Spells",
+              "name": "enfeeble",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 1524,
+              "game-obj": "Spells",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "goblin pox",
+              "aonid": 1545,
+              "game-obj": "Spells",
+              "name": "goblin pox",
+              "type": "link"
+            },
+            {
+              "alt": "detect magic",
+              "aonid": 1485,
+              "game-obj": "Spells",
+              "name": "detect magic",
+              "type": "link"
+            },
+            {
+              "alt": "divine lance",
+              "aonid": 1498,
+              "game-obj": "Spells",
+              "name": "divine lance",
+              "type": "link"
+            },
+            {
+              "alt": "guidance",
+              "aonid": 1549,
+              "game-obj": "Spells",
+              "name": "guidance",
+              "type": "link"
+            },
+            {
+              "alt": "read aura",
+              "aonid": 1646,
+              "game-obj": "Spells",
+              "name": "read aura",
+              "type": "link"
+            },
+            {
+              "alt": "void warp",
+              "aonid": 1745,
+              "game-obj": "Spells",
+              "name": "void warp",
+              "type": "link"
+            },
+            {
+              "alt": "touch of undeath",
+              "aonid": 1846,
+              "game-obj": "Spells",
+              "name": "touch of undeath",
+              "type": "link"
+            }
+          ],
+          "name": "Deity Swap Example",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "To make a priest of Urgathoa, you would make the following changes to the priest of Sarenrae, following the bullet points above. \n* Change the holy trait to unholy.\n* Add Intimidation +14 and remove Medicine +14.\n* Change their scimitar to a scythe. You can change the 1d6+7 damage to the equivalent 1d10+5 if you want to use the scythe's normal damage die.\n* Change the spells as follows, and replace healing hands with selective energy. This list includes an example of swapping the sun domain for the undeath domain.  **3rd** *bind undead*, *chilling darkness*, *harm* (\u00d75), *vampiric feast*; **2nd** *blood vendetta*, *false vitality*, *spiritual armament*; **1st** *enfeeble*, *fear*, *goblin pox*; **Cantrips** *detect magic*, *divine lance*, *guidance*, *read aura*, *void warp*; **Cleric Domain Spell** *touch of undeath*",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "here",
+              "href": "Causes.aspx",
+              "name": "here",
+              "type": "link"
+            },
+            {
+              "alt": "champion of Shelyn",
+              "aonid": 3446,
+              "game-obj": "NPCs",
+              "name": "champion of Shelyn",
+              "type": "link"
+            },
+            {
+              "alt": "deific champion of Iomedae",
+              "aonid": 3450,
+              "game-obj": "NPCs",
+              "name": "deific champion of Iomedae",
+              "type": "link"
+            },
+            {
+              "alt": "lay on hands",
+              "aonid": 2047,
+              "game-obj": "Spells",
+              "name": "lay on hands",
+              "type": "link"
+            },
+            {
+              "alt": "touch of the void",
+              "aonid": 2048,
+              "game-obj": "Spells",
+              "name": "touch of the void",
+              "type": "link"
+            },
+            {
+              "alt": "shields of the spirit",
+              "aonid": 2049,
+              "game-obj": "Spells",
+              "name": "shields of the spirit",
+              "type": "link"
+            }
+          ],
+          "name": "Swapping Champion Deities",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "To make the swap for a champion, use the causes found here. \n* Change the sanctification and divine skill, as noted above.\n* Change the favored weapon as noted above. If the champion had a two-handed weapon and the new deity has a one-handed favored weapon, reduce the champion's AC by 1 and give them a steel shield. Conversely, if the stat block had a one-handed favored weapon and shield, increase the champion's AC by 1, remove the shield, and change the shields of the spirit focus spell if the champion had it (see below).\n* Swap out the champion's reaction (Liberating Step for the champion of Shelyn or Exalted Retributive Strike for the deific champion of Iomedae) for the one listed in the new cause. Include the exalted reaction benefit if the champion's level is high enough.\n* If needed, change the champion's focus spell to *lay on hands* if the deity allows heal for their divine font or to *touch of the void* if the deity allows harm. If your champion uses a shield, you can change the focus spell to *shields of the spirit*.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Spirit priest",
+              "aonid": 3627,
+              "game-obj": "NPCs",
+              "name": "Spirit priest",
+              "type": "link"
+            }
+          ],
+          "name": "Crossover Ancestry NPCs",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "Several of the NPCs elsewhere in NPC Core can fit well in this group: Spirit priest (level 5)",
+          "type": "section"
+        },
+        {
+          "name": "Divinatory Herbs",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "Revered herbs and other plants hold a sacred role in divine practice, especially in the trances of sibyls and other oracular rituals. These herbs can shift between nations and growing seasons, but common herbs are bay leaves, chamomile, ivy, lavender, and mugwort.",
+          "type": "section"
+        },
+        {
+          "name": "Faithless Goals",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "What sets a blasphemer apart from the prophet comes down to the blasphemer's at least partial awareness that they're purposefully corrupting the word of their deity. Blasphemers don't have the ability to cast cleric spells, since they're not following the tenets of their god; however, they may have additional spellcasting abilities they use to conceal this fact",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "religious symbol",
+              "aonid": 2745,
+              "game-obj": "Equipment",
+              "name": "religious symbol",
+              "type": "link"
+            },
+            {
+              "alt": "Sarenrae",
+              "aonid": 292,
+              "game-obj": "Deities",
+              "name": "Sarenrae",
+              "type": "link"
+            },
+            {
+              "alt": "Zon-Kuthon's",
+              "aonid": 296,
+              "game-obj": "Deities",
+              "name": "Zon-Kuthon's",
+              "type": "link"
+            }
+          ],
+          "name": "Implements Of Faith",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "The most essential equipment to display one's faith is the religious symbol of their deity, and those traveling in dangerous areas make sure to have the deity's favored weapon at hand. Expressing devotion through their other accoutrement is also a priority, such as blue-and-gold clothing and a golden religious symbol for a follower of Sarenrae or black clothes, chains, and spikes for one of Zon-Kuthon's faithful.",
+          "type": "section"
+        },
+        {
+          "name": "Redemption Through Penance",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "Gods have many demands, and even the devoted can fail to meet them. It is important to understand what might cause one to lose a connection with their deity and what steps are necessary to atone and regain their place among the devoted, as these vary widely between deities. Though the penitent is the most likely to have fallen from their faith, many of these NPCs could have their divine abilities removed to appear as fallen or excommunicated characters.",
+          "type": "section"
+        },
+        {
+          "name": "Walking In Faith",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 28",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 28",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 28,
+              "type": "source"
+            }
+          ],
+          "text": "Devotees who travel the world endeavor to spread word of their faith. They might call upon divine magic (for rituals to strengthen communities, spells to aid the grieving, or to provide protection) to exemplify the ideals of their faith and thwart those that would bring harm. Followers of unholy deities might take a different path, leaving behind ruin, undeath, or other scars that show the power of their deity",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 28",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 28",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 28,
+          "type": "source"
+        }
+      ],
+      "text": "You can customize an acolyte, zealot, priest, or other NPC tied to a specific deity to match another deity. \n* Change the NPC's sanctification to match the new deity.\n* Add the deity's divine skill at the highest skill modifier the PC has. You can optionally remove the old deity's divine skill.\n* Change their weapon to the new deity's favored weapon. You can usually leave the weapon damage as-is.\n* If the NPC has multiple harm or heal spells at their top spell rank (mimicking a cleric's divine font), change that spell to match the new deity's font. If the NPC has the healing hands ability, change it to selective energy.  **Selective Energy** When the devotee casts a version of *harm* or *heal* that has an area, they can designate up to 5 creatures in the area. Those creatures are not targeted by the spell.\n* Swap some spells out for devotee spells or others that match the new deity's style. You can swap out domain spells if you choose, but this is a more involved process, and it's best to reference Player Core (see domains and domain spells here).\n For information on deity mechanics, see the deitiy table here.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/npc_core/explorer.json
+++ b/monster_families/npc_core/explorer.json
@@ -59,45 +59,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Verduran Forest",
-                "subtype": "ability",
-                "text": "is the largest woodland on the continent of Avistan; the druids and rangers of the Wildwood Lodge earned the forest great autonomy through a thousand-year treaty. The",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Forest of Spirits",
-                "subtype": "ability",
-                "text": "stretches over a thousand miles of Tian Xia and is the primeval birthplace of the nature spirits known as kami. The",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Fangwood",
-                "subtype": "ability",
-                "text": "in Nirmathas and the Gravelands is home to Crystalhurst, a village of druids who fought the terrible Darkblight that devastated the 7,000-year-old fey court who once guarded the wood. The",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Fierani Forest",
-                "subtype": "ability",
-                "text": "covers the majority of the elven nation Kyonin.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Famed Forests')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -108,7 +74,6 @@
         ],
         "name": "Famed Forests",
         "subtype": "monster_family",
-        "text": "The",
         "type": "stat_block_section"
       }
     ],
@@ -171,6 +136,59 @@
         }
       ],
       "text": "Several of the NPCs elsewhere in NPC Core can fit well in this group: Bleachling survivor (level 2), orc gamekeeper (level 4), tripkee camoufleur (level 2), tripkee scout (level 1), woodland scouts (level 8)",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Verduran Forest",
+          "subtype": "ability",
+          "text": "is the largest woodland on the continent of Avistan; the druids and rangers of the Wildwood Lodge earned the forest great autonomy through a thousand-year treaty. The",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Forest of Spirits",
+          "subtype": "ability",
+          "text": "stretches over a thousand miles of Tian Xia and is the primeval birthplace of the nature spirits known as kami. The",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Fangwood",
+          "subtype": "ability",
+          "text": "in Nirmathas and the Gravelands is home to Crystalhurst, a village of druids who fought the terrible Darkblight that devastated the 7,000-year-old fey court who once guarded the wood. The",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Fierani Forest",
+          "subtype": "ability",
+          "text": "covers the majority of the elven nation Kyonin.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Famed Forests",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 52",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 52",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 52,
+          "type": "source"
+        }
+      ],
+      "text": "The **Verduran Forest** is the largest woodland on the continent of Avistan; the druids and rangers of the Wildwood Lodge earned the forest great autonomy through a thousand-year treaty. The **Forest of Spirits** stretches over a thousand miles of Tian Xia and is the primeval birthplace of the nature spirits known as kami. The **Fangwood** in Nirmathas and the Gravelands is home to Crystalhurst, a village of druids who fought the terrible Darkblight that devastated the 7,000-year-old fey court who once guarded the wood. The **Fierani Forest** covers the majority of the elven nation Kyonin.",
       "type": "section"
     },
     {

--- a/monster_families/npc_core/healer.json
+++ b/monster_families/npc_core/healer.json
@@ -59,63 +59,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Identify Affliction",
-                "subtype": "ability",
-                "text": ": 1 sp",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Treat Wounds",
-                  "aonid": 2399,
-                  "game-obj": "Actions",
-                  "name": "Treat Wounds",
-                  "type": "link"
-                },
-                "name": "Treat Wounds",
-                "subtype": "ability",
-                "text": ": 2 sp",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Treat Disease",
-                  "aonid": 2397,
-                  "game-obj": "Actions",
-                  "name": "Treat Disease",
-                  "type": "link"
-                },
-                "name": "Treat Disease",
-                "subtype": "ability",
-                "text": ": 1 gp",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "link": {
-                  "alt": "First Aid",
-                  "aonid": 2396,
-                  "game-obj": "Actions",
-                  "name": "First Aid",
-                  "type": "link"
-                },
-                "name": "First Aid or Treating a Poison",
-                "subtype": "ability",
-                "text": ": 1 sp",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Medical Service Prices')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "Treat Wounds",
+                "aonid": 2399,
+                "game-obj": "Actions",
+                "name": "Treat Wounds",
+                "type": "link"
+              },
+              {
+                "alt": "Treat Disease",
+                "aonid": 2397,
+                "game-obj": "Actions",
+                "name": "Treat Disease",
+                "type": "link"
+              },
+              {
+                "alt": "First Aid",
+                "aonid": 2396,
+                "game-obj": "Actions",
+                "name": "First Aid",
+                "type": "link"
+              },
+              {
+                "alt": "Treating a Poison",
+                "aonid": 2398,
+                "game-obj": "Actions",
+                "name": "Treating a Poison",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -125,7 +104,6 @@
         ],
         "name": "Medical Service Prices",
         "subtype": "monster_family",
-        "text": "The physician and surgeon are masters of Medicine; the apothecary and plague doctor are experts. Plague doctors charge five times this rate, and surgeons 10 times.",
         "type": "stat_block_section"
       }
     ],
@@ -211,6 +189,106 @@
         }
       ],
       "text": "Healers who don't use magic are always on the hunt for ingredients. NPCs like the apothecary, local herbalist, and tonic merchant might hire PCs to collect rare ingredients they've heard contain latent alchemical properties. Such a quest could involve traveling to an inhospitable area to collect plants, fungi, or minerals. Or it might require tracking down and slaying or capturing a creature with organs that produce ingredients useful in healing.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Identify Affliction",
+          "subtype": "ability",
+          "text": ": 1 sp",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "Treat Wounds",
+            "aonid": 2399,
+            "game-obj": "Actions",
+            "name": "Treat Wounds",
+            "type": "link"
+          },
+          "name": "Treat Wounds",
+          "subtype": "ability",
+          "text": ": 2 sp",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "Treat Disease",
+            "aonid": 2397,
+            "game-obj": "Actions",
+            "name": "Treat Disease",
+            "type": "link"
+          },
+          "name": "Treat Disease",
+          "subtype": "ability",
+          "text": ": 1 gp",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "link": {
+            "alt": "First Aid",
+            "aonid": 2396,
+            "game-obj": "Actions",
+            "name": "First Aid",
+            "type": "link"
+          },
+          "name": "First Aid or Treating a Poison",
+          "subtype": "ability",
+          "text": ": 1 sp",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "Treat Wounds",
+          "aonid": 2399,
+          "game-obj": "Actions",
+          "name": "Treat Wounds",
+          "type": "link"
+        },
+        {
+          "alt": "Treat Disease",
+          "aonid": 2397,
+          "game-obj": "Actions",
+          "name": "Treat Disease",
+          "type": "link"
+        },
+        {
+          "alt": "First Aid",
+          "aonid": 2396,
+          "game-obj": "Actions",
+          "name": "First Aid",
+          "type": "link"
+        },
+        {
+          "alt": "Treating a Poison",
+          "aonid": 2398,
+          "game-obj": "Actions",
+          "name": "Treating a Poison",
+          "type": "link"
+        }
+      ],
+      "name": "Medical Service Prices",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 60",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 60",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 60,
+          "type": "source"
+        }
+      ],
+      "text": "The physician and surgeon are masters of Medicine; the apothecary and plague doctor are experts. Plague doctors charge five times this rate, and surgeons 10 times.  \n**Identify Affliction**: 1 sp  \n**Treat Wounds**: 2 sp  \n**Treat Disease**: 1 gp  \n**First Aid or Treating a Poison**: 1 sp",
       "type": "section"
     }
   ],

--- a/monster_families/npc_core/laborer.json
+++ b/monster_families/npc_core/laborer.json
@@ -59,41 +59,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Ale",
-                "subtype": "ability",
-                "text": ": Andoren beer, Boulderhead bock, Cheerful Delver stout, Liquid Ghosts, Luglurch ale, Thileu lager.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Cider and Mead",
-                "subtype": "ability",
-                "text": ": Hardroot cider, Qadiran cider, Two Knight Brewery mead, Wineberry mead.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Wine",
-                "subtype": "ability",
-                "text": ": Irrisen icewine, sarain, syrinelle, Whiterose Abbey wine.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Spirits",
-                "subtype": "ability",
-                "text": ": Daggermark drip, dragon punch whiskey, Old Erebus, vjarik.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Tap List')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -251,6 +221,55 @@
         }
       ],
       "text": "Laborers have difficult jobs and long hours. The work itself isn't glamorous, and the pay isn't great. Despite this, some find enjoyment in what they do. They look at their job and see adventure in their daily lives. They're content to provide essential services, help save lives, travel, meet interesting people, or even face the ferocity of nature. Though the work may be lackluster, the perks can be great!",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Ale",
+          "subtype": "ability",
+          "text": ": Andoren beer, Boulderhead bock, Cheerful Delver stout, Liquid Ghosts, Luglurch ale, Thileu lager.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Cider and Mead",
+          "subtype": "ability",
+          "text": ": Hardroot cider, Qadiran cider, Two Knight Brewery mead, Wineberry mead.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Wine",
+          "subtype": "ability",
+          "text": ": Irrisen icewine, sarain, syrinelle, Whiterose Abbey wine.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Spirits",
+          "subtype": "ability",
+          "text": ": Daggermark drip, dragon punch whiskey, Old Erebus, vjarik.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Tap List",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 66",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 66",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 66,
+          "type": "source"
+        }
+      ],
+      "text": "**Ale**: Andoren beer, Boulderhead bock, Cheerful Delver stout, Liquid Ghosts, Luglurch ale, Thileu lager. **Cider and Mead**: Hardroot cider, Qadiran cider, Two Knight Brewery mead, Wineberry mead. **Wine**: Irrisen icewine, sarain, syrinelle, Whiterose Abbey wine. **Spirits**: Daggermark drip, dragon punch whiskey, Old Erebus, vjarik.",
       "type": "section"
     }
   ],

--- a/monster_families/npc_core/martial_artist.json
+++ b/monster_families/npc_core/martial_artist.json
@@ -53,242 +53,119 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "5d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "electricity",
-                    "formula": "2d8",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "effect": "The grandmaster tosses their target upwards and electrocutes them with a qi-infused double palm strike as they land. The target becomes prone, loses the grappled or restrained condition, and takes 5d6 bludgeoning damage and 2d8 persistent electricity damage (DC 38 basic Fortitude save).",
-                "links": [
-                  {
-                    "alt": "grappled",
-                    "aonid": 77,
-                    "game-obj": "Conditions",
-                    "name": "grappled",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 90,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "prone",
-                    "aonid": 88,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent electricity damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent electricity damage",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blazing Gate",
-                "requirement": "The grandmaster has a target grappled or restrained",
-                "saving_throw": [
-                  {
-                    "basic": true,
-                    "dc": 38,
-                    "save_type": "Fort",
-                    "subtype": "save_dc",
-                    "text": "DC 38 basic Fortitude save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "electricity",
-                      "aonid": 586,
-                      "game-obj": "Traits",
-                      "name": "electricity",
-                      "type": "link"
-                    },
-                    "name": "electricity",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Demoralize",
-                    "aonid": 2395,
-                    "game-obj": "Actions",
-                    "name": "Demoralize",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "off-guard",
-                    "aonid": 58,
-                    "game-obj": "Conditions",
-                    "name": "off-guard",
-                    "type": "link"
-                  }
-                ],
-                "name": "Competitive Taunt",
-                "subtype": "ability",
-                "text": "The tournament combatant attempts to Demoralize a target. On a success, the demoralized creature is off-guard until the end of their next turn. The tournament combatant gets a +2 circumstance bonus to their damage against a creature made off-guard in this way.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 590,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 598,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Feint",
-                    "aonid": 2390,
-                    "game-obj": "Actions",
-                    "name": "Feint",
-                    "type": "link"
-                  }
-                ],
-                "name": "Constant Feint Stance",
-                "subtype": "ability",
-                "text": "This stance option replaces a different Stance Shift option (usually Secure Grapple Stance). +2 to attempts to Feint. If the mixed martial artist rolls a critical failure to Feint, they get a failure instead. If they successfully Feint, they can use Stance Shift as a free action. Unlike other stances, in this stance the mixed martial artist can't make Strikes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The black belt makes a fist Strike designed to intercept and create distance. This Strike does not count towards the black belt's multiple attack penalty, and the black belt's multiple attack penalty doesn't apply to this Strike. On a successful hit, the target is pushed 5 feet away.",
-                "links": [
-                  {
-                    "alt": "move",
-                    "aonid": 658,
-                    "game-obj": "Traits",
-                    "name": "move",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "pushed",
-                    "aonid": 451,
-                    "game-obj": "Rules",
-                    "name": "pushed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Defensive Side Kick",
-                "subtype": "ability",
-                "trigger": "A creature within the black belt's reach uses a move action",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The martial student shouts to startle their adversary. If the Strike is successful, the target becomes frightened 1.",
-                "frequency": "once per turn",
-                "links": [
-                  {
-                    "alt": "frightened 1",
-                    "aonid": 76,
-                    "game-obj": "Conditions",
-                    "name": "frightened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Kiai!",
-                "requirement": "The martial student attempts a Strike",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Alternate Moves')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "electricity",
+                "aonid": 586,
+                "game-obj": "Traits",
+                "name": "electricity",
+                "type": "link"
+              },
+              {
+                "alt": "grappled",
+                "aonid": 77,
+                "game-obj": "Conditions",
+                "name": "grappled",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 90,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "prone",
+                "aonid": 88,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "persistent electricity damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent electricity damage",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "Demoralize",
+                "aonid": 2395,
+                "game-obj": "Actions",
+                "name": "Demoralize",
+                "type": "link"
+              },
+              {
+                "alt": "off-guard",
+                "aonid": 58,
+                "game-obj": "Conditions",
+                "name": "off-guard",
+                "type": "link"
+              },
+              {
+                "alt": "Feint",
+                "aonid": 2390,
+                "game-obj": "Actions",
+                "name": "Feint",
+                "type": "link"
+              },
+              {
+                "alt": "move",
+                "aonid": 658,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
+              },
+              {
+                "alt": "pushed",
+                "aonid": 451,
+                "game-obj": "Rules",
+                "name": "pushed",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 1",
+                "aonid": 76,
+                "game-obj": "Conditions",
+                "name": "frightened 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -298,154 +175,68 @@
         ],
         "name": "Alternate Moves",
         "subtype": "monster_family",
-        "text": "Martial artists rarely have the same repertoire. For variety, use the following table to tweak an NPC's stats: \n\n|  |  |  |\n| --- | --- | --- |\n| **NPC** | **Ability** | **Replace With** |\n| Martial Student |  Fancy Footwork |  Hi-yah! |\n| Tournament Combatant |  Work the Crowd  | Competitive Taunt |\n| Mixed Martial Artist  | Any Stance Shift option  | Constant Feint Stance |\n| Black Belt |  Blocking Counterattack  | Defensive Side Kick |\n| Grandmaster |  One-Millimeter Punch | Blazing Gate |",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "bleed",
-                    "formula": "1d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "effect": "Tiny spikes in the martial artist's gloves or footwear deal an additional 1d6 persistent bleed damage.",
-                "links": [
-                  {
-                    "alt": "persistent bleed damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent bleed damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Concealed Spikes",
-                "subtype": "ability",
-                "trigger": "The martial artist critically succeeds on an unarmed Strike",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "juggernaut mutagen",
-                    "aonid": 3318,
-                    "game-obj": "Equipment",
-                    "name": "juggernaut mutagen",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "quicksilver mutagen",
-                    "aonid": 3319,
-                    "game-obj": "Equipment",
-                    "name": "quicksilver mutagen",
-                    "type": "link"
-                  }
-                ],
-                "name": "Contraband Substance",
-                "subtype": "ability",
-                "text": "The martial artist pulls out a concealed alchemical vial of mutagen and drinks it to improve their combat prowess. The item is usually a juggernaut mutagen, or quicksilver mutagen. This ability can't be used again until the martial artist has time to acquire and hide a new mutagen. Some martial artists use concealed small vials, but others hide a syringe or soak the alchemical liquid into a garment they can put in their mouth.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "2d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "Athletics",
-                    "aonid": 36,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  }
-                ],
-                "name": "Illegal Bite",
-                "subtype": "ability",
-                "text": "The martial artist makes an Athletics check against a target's Fortitude DC to bite them in a vulnerable area. On a success, the martial artist deals 2d6 piercing damage (or double on a critical success).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "Feints",
-                    "aonid": 2390,
-                    "game-obj": "Actions",
-                    "name": "Feints",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "blinding",
-                    "aonid": 59,
-                    "game-obj": "Conditions",
-                    "name": "blinding",
-                    "type": "link"
-                  }
-                ],
-                "name": "Sand In Your Eye",
-                "subtype": "ability",
-                "text": "The martial artist Feints. On a success, the martial artist tosses sand into the face of one target, blinding them for 1 round or until the target Interacts to remove the blinded condition.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Dirty Fighting')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "persistent bleed damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent bleed damage",
+                "type": "link"
+              },
+              {
+                "alt": "juggernaut mutagen",
+                "aonid": 3318,
+                "game-obj": "Equipment",
+                "name": "juggernaut mutagen",
+                "type": "link"
+              },
+              {
+                "alt": "quicksilver mutagen",
+                "aonid": 3319,
+                "game-obj": "Equipment",
+                "name": "quicksilver mutagen",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 36,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "Feints",
+                "aonid": 2390,
+                "game-obj": "Actions",
+                "name": "Feints",
+                "type": "link"
+              },
+              {
+                "alt": "blinding",
+                "aonid": 59,
+                "game-obj": "Conditions",
+                "name": "blinding",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -455,245 +246,96 @@
         ],
         "name": "Dirty Fighting",
         "subtype": "monster_family",
-        "text": "Sometimes it doesn't pay to fight fair. You can give one of these dirty fighting tactics to any martial artist NPC. While tournament combatants are especially likely to look for an edge that will let them win, most black belts and grandmasters are unlikely to stoop to such chicanery.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "force",
-                    "formula": "3d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "doomed 1",
-                    "aonid": 67,
-                    "game-obj": "Conditions",
-                    "name": "doomed 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Life Burn Aura",
-                "subtype": "ability",
-                "text": "The grandmaster transmutes their lifespan into an expulsion of qi. For the next minute, the grandmaster is surrounded by a 30-foot emanation that deals 3d6 force damage to all creatures who start their turn within the emanation, including the grandmaster themself. While Life Burn Aura is active, the grandmaster's fist Strikes deal 2 additional die of weapon damage. When the aura disappears, the grandmaster is permanently doomed 1. This condition is cumulative.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "force",
-                      "aonid": 610,
-                      "game-obj": "Traits",
-                      "name": "force",
-                      "type": "link"
-                    },
-                    "name": "force",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 50,
-                    "subtype": "area",
-                    "text": "50-foot radius",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "name": "Solar Surge",
-                "saving_throw": [
-                  {
-                    "dc": 38,
-                    "save_type": "Ref",
-                    "subtype": "save_dc",
-                    "text": "DC 38 Reflex save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The grandmaster unleashes a qi wave as bright as the sun. All creatures within a 50-foot radius of the grandmaster who can see must attempt a DC 38 Reflex save, including the grandmaster themself.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "dazzled",
-                    "aonid": 65,
-                    "game-obj": "Conditions",
-                    "name": "dazzled",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is dazzled for 1 round.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "blinded",
-                    "aonid": 59,
-                    "game-obj": "Conditions",
-                    "name": "blinded",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is blinded for 1 round.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature is blinded for 1 day.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "The creature is permanently blinded.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "qi blast",
-                    "aonid": 2055,
-                    "game-obj": "Spells",
-                    "name": "qi blast",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Super Qi Blast",
-                "subtype": "ability",
-                "text": "The grandmaster's body expands as it prepares to exude an unfathomable amount of qi. If the grandmaster's next action is to cast the two-action version of *qi blast*, the size of the cone increases to 120 feet and the damage increases to 16d6. The grandmaster also becomes one size category larger for the next minute, dealing an additional +9 damage with their melee Strikes. Additionally, the grandmaster is permanently drained 1. This drained condition is cumulative.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "force",
-                      "aonid": 610,
-                      "game-obj": "Traits",
-                      "name": "force",
-                      "type": "link"
-                    },
-                    "name": "force",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "spellshape",
-                      "aonid": 513,
-                      "game-obj": "Traits",
-                      "name": "spellshape",
-                      "type": "link"
-                    },
-                    "name": "spellshape",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "polymorph",
-                      "aonid": 670,
-                      "game-obj": "Traits",
-                      "name": "polymorph",
-                      "type": "link"
-                    },
-                    "name": "polymorph",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Grandmaster Forbidden Knowledge')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "force",
+                "aonid": 610,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              {
+                "alt": "doomed 1",
+                "aonid": 67,
+                "game-obj": "Conditions",
+                "name": "doomed 1",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "dazzled",
+                "aonid": 65,
+                "game-obj": "Conditions",
+                "name": "dazzled",
+                "type": "link"
+              },
+              {
+                "alt": "blinded",
+                "aonid": 59,
+                "game-obj": "Conditions",
+                "name": "blinded",
+                "type": "link"
+              },
+              {
+                "alt": "force",
+                "aonid": 610,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              {
+                "alt": "spellshape",
+                "aonid": 513,
+                "game-obj": "Traits",
+                "name": "spellshape",
+                "type": "link"
+              },
+              {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              {
+                "alt": "qi blast",
+                "aonid": 2055,
+                "game-obj": "Spells",
+                "name": "qi blast",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -703,7 +345,6 @@
         ],
         "name": "Grandmaster Forbidden Knowledge",
         "subtype": "monster_family",
-        "text": "Grandmasters study techniques outlawed for their tendency to maim both the user and the victim. If the Forbidden Palm doesn't suit your grandmaster's style, swap it for one of the following moves\u2014if you dare.",
         "type": "stat_block_section"
       }
     ],
@@ -711,6 +352,991 @@
   },
   "name": "Martial Artist",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "bludgeoning",
+              "formula": "5d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            },
+            {
+              "damage_type": "electricity",
+              "formula": "2d8",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "effect": "The grandmaster tosses their target upwards and electrocutes them with a qi-infused double palm strike as they land. The target becomes prone, loses the grappled or restrained condition, and takes 5d6 bludgeoning damage and 2d8 persistent electricity damage (DC 38 basic Fortitude save).",
+          "links": [
+            {
+              "alt": "grappled",
+              "aonid": 77,
+              "game-obj": "Conditions",
+              "name": "grappled",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 90,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "prone",
+              "aonid": 88,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            },
+            {
+              "alt": "persistent electricity damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent electricity damage",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Blazing Gate",
+          "requirement": "The grandmaster has a target grappled or restrained",
+          "saving_throw": [
+            {
+              "basic": true,
+              "dc": 38,
+              "save_type": "Fort",
+              "subtype": "save_dc",
+              "text": "DC 38 basic Fortitude save",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "electricity",
+                "aonid": 586,
+                "game-obj": "Traits",
+                "name": "electricity",
+                "type": "link"
+              },
+              "name": "electricity",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "Demoralize",
+              "aonid": 2395,
+              "game-obj": "Actions",
+              "name": "Demoralize",
+              "type": "link"
+            },
+            {
+              "alt": "off-guard",
+              "aonid": 58,
+              "game-obj": "Conditions",
+              "name": "off-guard",
+              "type": "link"
+            }
+          ],
+          "name": "Competitive Taunt",
+          "subtype": "ability",
+          "text": "The tournament combatant attempts to Demoralize a target. On a success, the demoralized creature is off-guard until the end of their next turn. The tournament combatant gets a +2 circumstance bonus to their damage against a creature made off-guard in this way.",
+          "traits": [
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 590,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 598,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Feint",
+              "aonid": 2390,
+              "game-obj": "Actions",
+              "name": "Feint",
+              "type": "link"
+            }
+          ],
+          "name": "Constant Feint Stance",
+          "subtype": "ability",
+          "text": "This stance option replaces a different Stance Shift option (usually Secure Grapple Stance). +2 to attempts to Feint. If the mixed martial artist rolls a critical failure to Feint, they get a failure instead. If they successfully Feint, they can use Stance Shift as a free action. Unlike other stances, in this stance the mixed martial artist can't make Strikes.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The black belt makes a fist Strike designed to intercept and create distance. This Strike does not count towards the black belt's multiple attack penalty, and the black belt's multiple attack penalty doesn't apply to this Strike. On a successful hit, the target is pushed 5 feet away.",
+          "links": [
+            {
+              "alt": "move",
+              "aonid": 658,
+              "game-obj": "Traits",
+              "name": "move",
+              "type": "link"
+            },
+            {
+              "alt": "pushed",
+              "aonid": 451,
+              "game-obj": "Rules",
+              "name": "pushed",
+              "type": "link"
+            }
+          ],
+          "name": "Defensive Side Kick",
+          "subtype": "ability",
+          "trigger": "A creature within the black belt's reach uses a move action",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The martial student shouts to startle their adversary. If the Strike is successful, the target becomes frightened 1.",
+          "frequency": "once per turn",
+          "links": [
+            {
+              "alt": "frightened 1",
+              "aonid": 76,
+              "game-obj": "Conditions",
+              "name": "frightened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Kiai!",
+          "requirement": "The martial student attempts a Strike",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "electricity",
+          "aonid": 586,
+          "game-obj": "Traits",
+          "name": "electricity",
+          "type": "link"
+        },
+        {
+          "alt": "grappled",
+          "aonid": 77,
+          "game-obj": "Conditions",
+          "name": "grappled",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 90,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        },
+        {
+          "alt": "prone",
+          "aonid": 88,
+          "game-obj": "Conditions",
+          "name": "prone",
+          "type": "link"
+        },
+        {
+          "alt": "persistent electricity damage",
+          "aonid": 29,
+          "game-obj": "Conditions",
+          "name": "persistent electricity damage",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 590,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 598,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "Demoralize",
+          "aonid": 2395,
+          "game-obj": "Actions",
+          "name": "Demoralize",
+          "type": "link"
+        },
+        {
+          "alt": "off-guard",
+          "aonid": 58,
+          "game-obj": "Conditions",
+          "name": "off-guard",
+          "type": "link"
+        },
+        {
+          "alt": "Feint",
+          "aonid": 2390,
+          "game-obj": "Actions",
+          "name": "Feint",
+          "type": "link"
+        },
+        {
+          "alt": "move",
+          "aonid": 658,
+          "game-obj": "Traits",
+          "name": "move",
+          "type": "link"
+        },
+        {
+          "alt": "pushed",
+          "aonid": 451,
+          "game-obj": "Rules",
+          "name": "pushed",
+          "type": "link"
+        },
+        {
+          "alt": "frightened 1",
+          "aonid": 76,
+          "game-obj": "Conditions",
+          "name": "frightened 1",
+          "type": "link"
+        }
+      ],
+      "name": "Alternate Moves",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 72",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 72",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 72,
+          "type": "source"
+        }
+      ],
+      "text": "Martial artists rarely have the same repertoire. For variety, use the following table to tweak an NPC's stats: \n\n|  |  |  |\n| --- | --- | --- |\n| **NPC** | **Ability** | **Replace With** |\n| Martial Student |  Fancy Footwork |  Hi-yah! |\n| Tournament Combatant |  Work the Crowd  | Competitive Taunt |\n| Mixed Martial Artist  | Any Stance Shift option  | Constant Feint Stance |\n| Black Belt |  Blocking Counterattack  | Defensive Side Kick |\n| Grandmaster |  One-Millimeter Punch | Blazing Gate |\n\n**Blazing Gate** [##] (electricity) **Requirements** The grandmaster has a target grappled or restrained; **Effect** The grandmaster tosses their target upwards and electrocutes them with a qi-infused double palm strike as they land. The target becomes prone, loses the grappled or restrained condition, and takes 5d6 bludgeoning damage and 2d8 persistent electricity damage (DC 38 basic Fortitude save).  \n**Competitive Taunt** [#] (emotion, fear, mental) The tournament combatant attempts to Demoralize a target. On a success, the demoralized creature is off-guard until the end of their next turn. The tournament combatant gets a +2 circumstance bonus to their damage against a creature made off-guard in this way.  \n**Constant Feint Stance** This stance option replaces a different Stance Shift option (usually Secure Grapple Stance). +2 to attempts to Feint. If the mixed martial artist rolls a critical failure to Feint, they get a failure instead. If they successfully Feint, they can use Stance Shift as a free action. Unlike other stances, in this stance the mixed martial artist can't make Strikes.  \n**Defensive Side Kick** [@] **Trigger** A creature within the black belt's reach uses a move action; **Effect** The black belt makes a fist Strike designed to intercept and create distance. This Strike does not count towards the black belt's multiple attack penalty, and the black belt's multiple attack penalty doesn't apply to this Strike. On a successful hit, the target is pushed 5 feet away. **Kiai!** [-] **Frequency** once per turn; **Requirements** The martial student attempts a Strike; **Effect** The martial student shouts to startle their adversary. If the Strike is successful, the target becomes frightened 1.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "bleed",
+              "formula": "1d6",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "effect": "Tiny spikes in the martial artist's gloves or footwear deal an additional 1d6 persistent bleed damage.",
+          "links": [
+            {
+              "alt": "persistent bleed damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent bleed damage",
+              "type": "link"
+            }
+          ],
+          "name": "Concealed Spikes",
+          "subtype": "ability",
+          "trigger": "The martial artist critically succeeds on an unarmed Strike",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "juggernaut mutagen",
+              "aonid": 3318,
+              "game-obj": "Equipment",
+              "name": "juggernaut mutagen",
+              "type": "link"
+            },
+            {
+              "alt": "quicksilver mutagen",
+              "aonid": 3319,
+              "game-obj": "Equipment",
+              "name": "quicksilver mutagen",
+              "type": "link"
+            }
+          ],
+          "name": "Contraband Substance",
+          "subtype": "ability",
+          "text": "The martial artist pulls out a concealed alchemical vial of mutagen and drinks it to improve their combat prowess. The item is usually a juggernaut mutagen, or quicksilver mutagen. This ability can't be used again until the martial artist has time to acquire and hide a new mutagen. Some martial artists use concealed small vials, but others hide a syringe or soak the alchemical liquid into a garment they can put in their mouth.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "piercing",
+              "formula": "2d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "Athletics",
+              "aonid": 36,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            }
+          ],
+          "name": "Illegal Bite",
+          "subtype": "ability",
+          "text": "The martial artist makes an Athletics check against a target's Fortitude DC to bite them in a vulnerable area. On a success, the martial artist deals 2d6 piercing damage (or double on a critical success).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "Feints",
+              "aonid": 2390,
+              "game-obj": "Actions",
+              "name": "Feints",
+              "type": "link"
+            },
+            {
+              "alt": "blinding",
+              "aonid": 59,
+              "game-obj": "Conditions",
+              "name": "blinding",
+              "type": "link"
+            }
+          ],
+          "name": "Sand In Your Eye",
+          "subtype": "ability",
+          "text": "The martial artist Feints. On a success, the martial artist tosses sand into the face of one target, blinding them for 1 round or until the target Interacts to remove the blinded condition.",
+          "traits": [
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "persistent bleed damage",
+          "aonid": 29,
+          "game-obj": "Conditions",
+          "name": "persistent bleed damage",
+          "type": "link"
+        },
+        {
+          "alt": "juggernaut mutagen",
+          "aonid": 3318,
+          "game-obj": "Equipment",
+          "name": "juggernaut mutagen",
+          "type": "link"
+        },
+        {
+          "alt": "quicksilver mutagen",
+          "aonid": 3319,
+          "game-obj": "Equipment",
+          "name": "quicksilver mutagen",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 36,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "Feints",
+          "aonid": 2390,
+          "game-obj": "Actions",
+          "name": "Feints",
+          "type": "link"
+        },
+        {
+          "alt": "blinding",
+          "aonid": 59,
+          "game-obj": "Conditions",
+          "name": "blinding",
+          "type": "link"
+        }
+      ],
+      "name": "Dirty Fighting",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 72",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 72",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 72,
+          "type": "source"
+        }
+      ],
+      "text": "Sometimes it doesn't pay to fight fair. You can give one of these dirty fighting tactics to any martial artist NPC. While tournament combatants are especially likely to look for an edge that will let them win, most black belts and grandmasters are unlikely to stoop to such chicanery.  \n**Concealed Spikes** [@] **Trigger** The martial artist critically succeeds on an unarmed Strike; **Effect** Tiny spikes in the martial artist's gloves or footwear deal an additional 1d6 persistent bleed damage.  \n**Contraband Substance** [#] The martial artist pulls out a concealed alchemical vial of mutagen and drinks it to improve their combat prowess. The item is usually a juggernaut mutagen, or quicksilver mutagen. This ability can't be used again until the martial artist has time to acquire and hide a new mutagen. Some martial artists use concealed small vials, but others hide a syringe or soak the alchemical liquid into a garment they can put in their mouth.  \n**Illegal Bite** [#] The martial artist makes an Athletics check against a target's Fortitude DC to bite them in a vulnerable area. On a success, the martial artist deals 2d6 piercing damage (or double on a critical success).  \n**Sand In Your Eye** [#] (visual) The martial artist Feints. On a success, the martial artist tosses sand into the face of one target, blinding them for 1 round or until the target Interacts to remove the blinded condition.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "force",
+              "formula": "3d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "doomed 1",
+              "aonid": 67,
+              "game-obj": "Conditions",
+              "name": "doomed 1",
+              "type": "link"
+            }
+          ],
+          "name": "Life Burn Aura",
+          "subtype": "ability",
+          "text": "The grandmaster transmutes their lifespan into an expulsion of qi. For the next minute, the grandmaster is surrounded by a 30-foot emanation that deals 3d6 force damage to all creatures who start their turn within the emanation, including the grandmaster themself. While Life Burn Aura is active, the grandmaster's fist Strikes deal 2 additional die of weapon damage. When the aura disappears, the grandmaster is permanently doomed 1. This condition is cumulative.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "force",
+                "aonid": 610,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              "name": "force",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Three Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 50,
+              "subtype": "area",
+              "text": "50-foot radius",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "name": "Solar Surge",
+          "saving_throw": [
+            {
+              "dc": 38,
+              "save_type": "Ref",
+              "subtype": "save_dc",
+              "text": "DC 38 Reflex save",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The grandmaster unleashes a qi wave as bright as the sun. All creatures within a 50-foot radius of the grandmaster who can see must attempt a DC 38 Reflex save, including the grandmaster themself.",
+          "traits": [
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "dazzled",
+              "aonid": 65,
+              "game-obj": "Conditions",
+              "name": "dazzled",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature is dazzled for 1 round.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "blinded",
+              "aonid": 59,
+              "game-obj": "Conditions",
+              "name": "blinded",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is blinded for 1 round.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature is blinded for 1 day.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "The creature is permanently blinded.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "qi blast",
+              "aonid": 2055,
+              "game-obj": "Spells",
+              "name": "qi blast",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            }
+          ],
+          "name": "Super Qi Blast",
+          "subtype": "ability",
+          "text": "The grandmaster's body expands as it prepares to exude an unfathomable amount of qi. If the grandmaster's next action is to cast the two-action version of *qi blast*, the size of the cone increases to 120 feet and the damage increases to 16d6. The grandmaster also becomes one size category larger for the next minute, dealing an additional +9 damage with their melee Strikes. Additionally, the grandmaster is permanently drained 1. This drained condition is cumulative.",
+          "traits": [
+            {
+              "link": {
+                "alt": "force",
+                "aonid": 610,
+                "game-obj": "Traits",
+                "name": "force",
+                "type": "link"
+              },
+              "name": "force",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "spellshape",
+                "aonid": 513,
+                "game-obj": "Traits",
+                "name": "spellshape",
+                "type": "link"
+              },
+              "name": "spellshape",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "polymorph",
+                "aonid": 670,
+                "game-obj": "Traits",
+                "name": "polymorph",
+                "type": "link"
+              },
+              "name": "polymorph",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "force",
+          "aonid": 610,
+          "game-obj": "Traits",
+          "name": "force",
+          "type": "link"
+        },
+        {
+          "alt": "doomed 1",
+          "aonid": 67,
+          "game-obj": "Conditions",
+          "name": "doomed 1",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "dazzled",
+          "aonid": 65,
+          "game-obj": "Conditions",
+          "name": "dazzled",
+          "type": "link"
+        },
+        {
+          "alt": "blinded",
+          "aonid": 59,
+          "game-obj": "Conditions",
+          "name": "blinded",
+          "type": "link"
+        },
+        {
+          "alt": "force",
+          "aonid": 610,
+          "game-obj": "Traits",
+          "name": "force",
+          "type": "link"
+        },
+        {
+          "alt": "spellshape",
+          "aonid": 513,
+          "game-obj": "Traits",
+          "name": "spellshape",
+          "type": "link"
+        },
+        {
+          "alt": "polymorph",
+          "aonid": 670,
+          "game-obj": "Traits",
+          "name": "polymorph",
+          "type": "link"
+        },
+        {
+          "alt": "qi blast",
+          "aonid": 2055,
+          "game-obj": "Spells",
+          "name": "qi blast",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        }
+      ],
+      "name": "Grandmaster Forbidden Knowledge",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "Orc veteran master",
+              "aonid": 3666,
+              "game-obj": "NPCs",
+              "name": "Orc veteran master",
+              "type": "link"
+            }
+          ],
+          "name": "Crossover Ancestry NPCs",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 72",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 72",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 72,
+              "type": "source"
+            }
+          ],
+          "text": "Several of the NPCs elsewhere in NPC Core can fit well in this group: Orc veteran master (level 10)",
+          "type": "section"
+        },
+        {
+          "name": "Fists Of The Ruby Phoenix",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 72",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 72",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 72,
+              "type": "source"
+            }
+          ],
+          "text": "Of all the fighting contests across Golarion, the most notable is the Ruby Phoenix Tournament, held once every decade off the coast of Goka. The tournament is orchestrated by the legendary mage Hao Jin and attracts innumerable athletes, with the winners awarded powerful relics beyond imagination. The story of the most recent tournament can be found in the Fists of the Ruby Phoenix Adventure Path.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Qi Zhong",
+              "aonid": 314,
+              "game-obj": "Deities",
+              "name": "Qi Zhong",
+              "type": "link"
+            }
+          ],
+          "name": "Life's Energy",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 72",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 72",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 72,
+              "type": "source"
+            }
+          ],
+          "text": "Qi is far more than a means of supplementing attacks\u2014it is an energy possessed by all living entities, and martial artists are merely experienced at manifesting qi in offensive ways. Aside from combat, qi is widely used in Tian Xia medicine, particularly among healers who worship the deity Qi Zhong.",
+          "type": "section"
+        },
+        {
+          "name": "Versus A Gauntlet",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 72",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 72",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 72,
+              "type": "source"
+            }
+          ],
+          "text": "For a fight against an entire dojo or monastic order, reserve martial artist stat blocks of similar levels to the PCs for the strongest antagonists. Pepper the scene with weaker combatants with low AC and saving throws, very few Hit Points, and a Speed of 25 feet. Each of these foes uses their actions to flank the PCs and attempt fist Strikes with a low hit modifier that deal low damage. When their numbers begin to dwindle, they flee.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 72",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 72",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 72,
+          "type": "source"
+        }
+      ],
+      "text": "Grandmasters study techniques outlawed for their tendency to maim both the user and the victim. If the Forbidden Palm doesn't suit your grandmaster's style, swap it for one of the following moves\u2014if you dare.   \n  \n**Life Burn Aura** [###] (aura, force) The grandmaster transmutes their lifespan into an expulsion of qi. For the next minute, the grandmaster is surrounded by a 30-foot emanation that deals 3d6 force damage to all creatures who start their turn within the emanation, including the grandmaster themself. While Life Burn Aura is active, the grandmaster's fist Strikes deal 2 additional die of weapon damage. When the aura disappears, the grandmaster is permanently doomed 1. This condition is cumulative.  \n**Solar Surge** [###] (visual) The grandmaster unleashes a qi wave as bright as the sun. All creatures within a 50-foot radius of the grandmaster who can see must attempt a DC 38 Reflex save, including the grandmaster themself.  \n**Critical Success** The creature is dazzled for 1 round.  \n**Success** The creature is blinded for 1 round.  \n**Failure** The creature is blinded for 1 day.  \n**Critical Failure** The creature is permanently blinded.   \n  \n**Super Qi Blast** [#] (force, spellshape, polymorph); The grandmaster's body expands as it prepares to exude an unfathomable amount of qi. If the grandmaster's next action is to cast the two-action version of *qi blast*, the size of the cone increases to 120 feet and the damage increases to 16d6. The grandmaster also becomes one size category larger for the next minute, dealing an additional +9 damage with their melee Strikes. Additionally, the grandmaster is permanently drained 1. This drained condition is cumulative.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/npc_core/mercenary.json
+++ b/monster_families/npc_core/mercenary.json
@@ -59,77 +59,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Crackster",
-                "subtype": "ability",
-                "text": ": Someone adept at breaking locks or safes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Diving",
-                "subtype": "ability",
-                "text": ": Theft or smuggling below ground, often through tunnels.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Foxing",
-                "subtype": "ability",
-                "text": ": To play at being asleep, usually for an ambush.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Medic",
-                "subtype": "ability",
-                "text": ": A healer.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Ram",
-                "subtype": "ability",
-                "text": ": A hard-hitting warrior.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Slinger",
-                "subtype": "ability",
-                "text": ": A spellcaster.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Sway of Coin",
-                "subtype": "ability",
-                "text": ": Swearing allegiance to whoever pays the most.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Waterline",
-                "subtype": "ability",
-                "text": ": A mercenary company's money: \u201cTake time in town while the waterline's high, everyone.\u201d",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Whisperer",
-                "subtype": "ability",
-                "text": ": Anyone who can move stealthily.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Mercenary Banter')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -140,7 +74,6 @@
         ],
         "name": "Mercenary Banter",
         "subtype": "monster_family",
-        "text": "Here's some parlance commonly used by mercenaries.",
         "type": "stat_block_section"
       }
     ],
@@ -241,6 +174,91 @@
         }
       ],
       "text": "Different mercenary bands have different requirements for prospective members. Being able to fight is just the start. Bands with more honorable reputations require rigorous interviews, blood oaths, and even background checks, while bands with more dubious reputations will take on a skilled fighter with no questions asked. On occasion, bands tend to form along ancestry lines. Orcs, hobgoblins, and dwarves all have storied mercenary bands wandering the Inner Sea region, but almost all of them will take one recruit who's not of their ancestry if their skills are valuable enough.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Crackster",
+          "subtype": "ability",
+          "text": ": Someone adept at breaking locks or safes.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Diving",
+          "subtype": "ability",
+          "text": ": Theft or smuggling below ground, often through tunnels.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Foxing",
+          "subtype": "ability",
+          "text": ": To play at being asleep, usually for an ambush.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Medic",
+          "subtype": "ability",
+          "text": ": A healer.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Ram",
+          "subtype": "ability",
+          "text": ": A hard-hitting warrior.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Slinger",
+          "subtype": "ability",
+          "text": ": A spellcaster.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Sway of Coin",
+          "subtype": "ability",
+          "text": ": Swearing allegiance to whoever pays the most.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Waterline",
+          "subtype": "ability",
+          "text": ": A mercenary company's money: \u201cTake time in town while the waterline's high, everyone.\u201d",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Whisperer",
+          "subtype": "ability",
+          "text": ": Anyone who can move stealthily.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Mercenary Banter",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 82",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 82",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 82,
+          "type": "source"
+        }
+      ],
+      "text": "Here's some parlance commonly used by mercenaries.  \n  \n**Crackster**: Someone adept at breaking locks or safes.  \n**Diving**: Theft or smuggling below ground, often through tunnels.  \n**Foxing**: To play at being asleep, usually for an ambush.  \n**Medic**: A healer.  \n**Ram**: A hard-hitting warrior.  \n**Slinger**: A spellcaster.  \n**Sway of Coin**: Swearing allegiance to whoever pays the most.  \n**Waterline**: A mercenary company's money: \u201cTake time in town while the waterline's high, everyone.\u201d  \n**Whisperer**: Anyone who can move stealthily.",
       "type": "section"
     }
   ],

--- a/monster_families/npc_core/military.json
+++ b/monster_families/npc_core/military.json
@@ -151,36 +151,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "hidden",
-                    "aonid": 79,
-                    "game-obj": "Conditions",
-                    "name": "hidden",
-                    "type": "link"
-                  }
-                ],
-                "name": "Pounce",
-                "subtype": "ability",
-                "text": "The creature Strides and makes a Strike at the end of that movement. If the creature began this action hidden, they remain hidden until after this ability's Strike.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Guerrilla Adjustments')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "hidden",
+                "aonid": 79,
+                "game-obj": "Conditions",
+                "name": "hidden",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -190,88 +175,16 @@
         ],
         "name": "Guerrilla Adjustments",
         "subtype": "monster_family",
-        "text": "Most military engagements take place in large areas, such as plains or cities, where there is the most territory or resources to be gained. However, guerrilla units fight in forests, swamps, and other tough locations, where they set up traps, ambushes, and use other surprise tactics. You can use these adjustments to turn a military NPC or troop into a guerrilla. These can also be useful for mercenaries or other non-military NPCs.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "splash",
-                    "aonid": 699,
-                    "game-obj": "Traits",
-                    "name": "splash",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "off-guard",
-                    "aonid": 58,
-                    "game-obj": "Conditions",
-                    "name": "off-guard",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "troop",
-                    "aonid": 367,
-                    "game-obj": "Traits",
-                    "name": "troop",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "slowed 1",
-                    "aonid": 92,
-                    "game-obj": "Conditions",
-                    "name": "slowed 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Change Formation",
-                "subtype": "ability",
-                "text": "The troop reconfigures to assume one of the formations below they know. Using this action again ends any previous formation, and the troop can also use this action to revert to its default formation, ending any benefits and drawbacks. \n* **Loose** Members of the troop fan out to cover more ground. **Benefit** Any weaknesses the troop has to area and splash damage are suppressed. **Drawback** Enemies' saving throws against the troop's damaging effects are one degree of success better than they roll.\n* **Marching Column** This formation traverses long distances more rapidly. **Benefit** The troop gains a +10 foot circumstance bonus to all its Speeds. **Drawback** The troop is off-guard and takes a \u20132 penalty to Reflex saves.\n* **Turtle Shell** The troop interlocks their shields. Only a group with shields can use this formation. **Benefit** The troop gains a +2 circumstance bonus to AC against ranged attacks and to Reflex saves. **Drawback** The troop takes a \u201310-foot penalty to all its Speeds.\n* **Wedge** The troop aligns itself behind a powerful commander. **Benefit** The troop chooses an adjacent allied creature without the troop trait to fall in behind. Each time the chosen creature Strides, the troop follows as a free action, Striding to keep the chosen creature adjacent. **Drawback** The troop loses some of their autonomy. They're slowed 1 and can't voluntarily move away from their leader.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "move",
-                      "aonid": 658,
-                      "game-obj": "Traits",
-                      "name": "move",
-                      "type": "link"
-                    },
-                    "name": "move",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Troop Formations')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -282,6 +195,48 @@
                 "game-obj": "Traits",
                 "name": "animal",
                 "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "move",
+                "aonid": 658,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
+              },
+              {
+                "alt": "splash",
+                "aonid": 699,
+                "game-obj": "Traits",
+                "name": "splash",
+                "type": "link"
+              },
+              {
+                "alt": "off-guard",
+                "aonid": 58,
+                "game-obj": "Conditions",
+                "name": "off-guard",
+                "type": "link"
+              },
+              {
+                "alt": "troop",
+                "aonid": 367,
+                "game-obj": "Traits",
+                "name": "troop",
+                "type": "link"
+              },
+              {
+                "alt": "slowed 1",
+                "aonid": 92,
+                "game-obj": "Conditions",
+                "name": "slowed 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -291,7 +246,6 @@
         ],
         "name": "Troop Formations",
         "subtype": "monster_family",
-        "text": "Battle can be a complicated affair. Different situations call for varied arrangement of soldiers. You can add the Change Formation ability to a troop to give it more options, typically choosing two or three of the possible formations listed here. Troops with animal Intelligence (\u20134 or lower) or that aren't battle trained are typically unable to change formation without an outside force commanding them.",
         "type": "stat_block_section"
       }
     ],
@@ -299,6 +253,416 @@
   },
   "name": "Military",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "hidden",
+              "aonid": 79,
+              "game-obj": "Conditions",
+              "name": "hidden",
+              "type": "link"
+            }
+          ],
+          "name": "Pounce",
+          "subtype": "ability",
+          "text": "The creature Strides and makes a Strike at the end of that movement. If the creature began this action hidden, they remain hidden until after this ability's Strike.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "hidden",
+          "aonid": 79,
+          "game-obj": "Conditions",
+          "name": "hidden",
+          "type": "link"
+        }
+      ],
+      "name": "Guerrilla Adjustments",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 88",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 88",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 88,
+          "type": "source"
+        }
+      ],
+      "text": "Most military engagements take place in large areas, such as plains or cities, where there is the most territory or resources to be gained. However, guerrilla units fight in forests, swamps, and other tough locations, where they set up traps, ambushes, and use other surprise tactics. You can use these adjustments to turn a military NPC or troop into a guerrilla. These can also be useful for mercenaries or other non-military NPCs. **Pounce** [#] The creature Strides and makes a Strike at the end of that movement. If the creature began this action hidden, they remain hidden until after this ability's Strike.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "splash",
+              "aonid": 699,
+              "game-obj": "Traits",
+              "name": "splash",
+              "type": "link"
+            },
+            {
+              "alt": "off-guard",
+              "aonid": 58,
+              "game-obj": "Conditions",
+              "name": "off-guard",
+              "type": "link"
+            },
+            {
+              "alt": "troop",
+              "aonid": 367,
+              "game-obj": "Traits",
+              "name": "troop",
+              "type": "link"
+            },
+            {
+              "alt": "slowed 1",
+              "aonid": 92,
+              "game-obj": "Conditions",
+              "name": "slowed 1",
+              "type": "link"
+            }
+          ],
+          "name": "Change Formation",
+          "subtype": "ability",
+          "text": "The troop reconfigures to assume one of the formations below they know. Using this action again ends any previous formation, and the troop can also use this action to revert to its default formation, ending any benefits and drawbacks. \n* **Loose** Members of the troop fan out to cover more ground. **Benefit** Any weaknesses the troop has to area and splash damage are suppressed. **Drawback** Enemies' saving throws against the troop's damaging effects are one degree of success better than they roll.\n* **Marching Column** This formation traverses long distances more rapidly. **Benefit** The troop gains a +10 foot circumstance bonus to all its Speeds. **Drawback** The troop is off-guard and takes a \u20132 penalty to Reflex saves.\n* **Turtle Shell** The troop interlocks their shields. Only a group with shields can use this formation. **Benefit** The troop gains a +2 circumstance bonus to AC against ranged attacks and to Reflex saves. **Drawback** The troop takes a \u201310-foot penalty to all its Speeds.\n* **Wedge** The troop aligns itself behind a powerful commander. **Benefit** The troop chooses an adjacent allied creature without the troop trait to fall in behind. Each time the chosen creature Strides, the troop follows as a free action, Striding to keep the chosen creature adjacent. **Drawback** The troop loses some of their autonomy. They're slowed 1 and can't voluntarily move away from their leader.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "move",
+                "aonid": 658,
+                "game-obj": "Traits",
+                "name": "move",
+                "type": "link"
+              },
+              "name": "move",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "animal",
+          "aonid": 531,
+          "game-obj": "Traits",
+          "name": "animal",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "move",
+          "aonid": 658,
+          "game-obj": "Traits",
+          "name": "move",
+          "type": "link"
+        },
+        {
+          "alt": "splash",
+          "aonid": 699,
+          "game-obj": "Traits",
+          "name": "splash",
+          "type": "link"
+        },
+        {
+          "alt": "off-guard",
+          "aonid": 58,
+          "game-obj": "Conditions",
+          "name": "off-guard",
+          "type": "link"
+        },
+        {
+          "alt": "troop",
+          "aonid": 367,
+          "game-obj": "Traits",
+          "name": "troop",
+          "type": "link"
+        },
+        {
+          "alt": "slowed 1",
+          "aonid": 92,
+          "game-obj": "Conditions",
+          "name": "slowed 1",
+          "type": "link"
+        }
+      ],
+      "name": "Troop Formations",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "Corn leshy throng",
+              "aonid": 3658,
+              "game-obj": "NPCs",
+              "name": "Corn leshy throng",
+              "type": "link"
+            },
+            {
+              "alt": "demonbane warrior",
+              "aonid": 3632,
+              "game-obj": "NPCs",
+              "name": "demonbane warrior",
+              "type": "link"
+            },
+            {
+              "alt": "dwarf battalion",
+              "aonid": 3628,
+              "game-obj": "NPCs",
+              "name": "dwarf battalion",
+              "type": "link"
+            },
+            {
+              "alt": "dwarf general",
+              "aonid": 3629,
+              "game-obj": "NPCs",
+              "name": "dwarf general",
+              "type": "link"
+            },
+            {
+              "alt": "hobgoblin battalion",
+              "aonid": 3649,
+              "game-obj": "NPCs",
+              "name": "hobgoblin battalion",
+              "type": "link"
+            },
+            {
+              "alt": "hobgoblin spellbreaker",
+              "aonid": 3648,
+              "game-obj": "NPCs",
+              "name": "hobgoblin spellbreaker",
+              "type": "link"
+            },
+            {
+              "alt": "hobgoblin vanguard",
+              "aonid": 3650,
+              "game-obj": "NPCs",
+              "name": "hobgoblin vanguard",
+              "type": "link"
+            },
+            {
+              "alt": "orc skullcrushers",
+              "aonid": 3665,
+              "game-obj": "NPCs",
+              "name": "orc skullcrushers",
+              "type": "link"
+            }
+          ],
+          "name": "Crossover Ancestry NPCs",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 88",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 88",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "Several of the NPCs elsewhere in NPC Core can fit well in this group: Corn leshy throng (level 4), demonbane warrior (level 5), dwarf battalion (level 6), dwarf general (level 8), hobgoblin battalion (level 5), hobgoblin spellbreaker (level 3), hobgoblin vanguard (level 8), orc skullcrushers (level 7)",
+          "type": "section"
+        },
+        {
+          "name": "Military Nomenclature",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 88",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 88",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "Various cultures see war differently. Some see it as a game to be won, some as an art, and still others as the ultimate form of glory. These different perspectives can be reflected in the names used to describe military units and formations. Some militaries go to elaborate lengths to mislead their foes by bestowing ever-changing code names on various divisions and strategies. Others may borrow the names of beautiful animals or simply name units after favored weapons.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "war horse",
+              "aonid": 3060,
+              "game-obj": "Monsters",
+              "name": "war horse",
+              "type": "link"
+            }
+          ],
+          "name": "Mounted Warfare",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 88",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 88",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "Individual military NPCs who find themselves in open terrain might need to close the distance to their opponents. Consider giving an NPC like standard bearer or sniper a war horse, or having a drill sergeant or mage knight ride a veteran war horse.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "spear",
+              "aonid": 365,
+              "game-obj": "Weapons",
+              "name": "spear",
+              "type": "link"
+            },
+            {
+              "alt": "Gozreh",
+              "aonid": 284,
+              "game-obj": "Deities",
+              "name": "Gozreh",
+              "type": "link"
+            },
+            {
+              "alt": "tridents",
+              "aonid": 401,
+              "game-obj": "Weapons",
+              "name": "tridents",
+              "type": "link"
+            }
+          ],
+          "name": "Signature Weapons",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 88",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 88",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "Phalanx formations are classically seen using a spear as their weapon of choice. However, feel free to swap out this weapon for something more appropriate to the local culture. For example, a phalanx comprised of worshippers of Gozreh might wield tridents instead of spears.",
+          "type": "section"
+        },
+        {
+          "name": "Spoils Of War",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 88",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 88",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "War is rarely a profitable venture for either side. Each battle wins little more than a better strategic position and, potentially, glory. Occasionally, a particularly potent enemy may have some magical gear, but most soldiers do not. An adventuring party should seek to leverage the army they fight for, as that is where they will often find the highest rewards, both in terms of gold and favors.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "Hellknight plate",
+              "aonid": 25,
+              "game-obj": "Armor",
+              "name": "Hellknight plate",
+              "type": "link"
+            }
+          ],
+          "name": "Troop Gear",
+          "sources": [
+            {
+              "link": {
+                "alt": "NPC Core pg. 88",
+                "aonid": 236,
+                "game-obj": "Sources",
+                "name": "NPC Core pg. 88",
+                "type": "link"
+              },
+              "name": "NPC Core",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "Since the component members of a troop are individually much less powerful than the troop as a whole, a troop's gear is typically of negligible utility or value. However, the Hellknight cavalry brigade wear valuable Hellknight plate (worth 35 gp), and a party might be able to salvage a suit or two from their defeated foes\u2014if they're willing to risk the wrath of the Order of the Nail!",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 88",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 88",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 88,
+          "type": "source"
+        }
+      ],
+      "text": "Battle can be a complicated affair. Different situations call for varied arrangement of soldiers. You can add the Change Formation ability to a troop to give it more options, typically choosing two or three of the possible formations listed here. Troops with animal Intelligence (\u20134 or lower) or that aren't battle trained are typically unable to change formation without an outside force commanding them.  \n  \n**Change Formation** [##] (concentrate, move) The troop reconfigures to assume one of the formations below they know. Using this action again ends any previous formation, and the troop can also use this action to revert to its default formation, ending any benefits and drawbacks. \n* **Loose** Members of the troop fan out to cover more ground. **Benefit** Any weaknesses the troop has to area and splash damage are suppressed. **Drawback** Enemies' saving throws against the troop's damaging effects are one degree of success better than they roll.\n* **Marching Column** This formation traverses long distances more rapidly. **Benefit** The troop gains a +10 foot circumstance bonus to all its Speeds. **Drawback** The troop is off-guard and takes a \u20132 penalty to Reflex saves.\n* **Turtle Shell** The troop interlocks their shields. Only a group with shields can use this formation. **Benefit** The troop gains a +2 circumstance bonus to AC against ranged attacks and to Reflex saves. **Drawback** The troop takes a \u201310-foot penalty to all its Speeds.\n* **Wedge** The troop aligns itself behind a powerful commander. **Benefit** The troop chooses an adjacent allied creature without the troop trait to fall in behind. Each time the chosen creature Strides, the troop follows as a free action, Striding to keep the chosen creature adjacent. **Drawback** The troop loses some of their autonomy. They're slowed 1 and can't voluntarily move away from their leader.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/npc_core/performer.json
+++ b/monster_families/npc_core/performer.json
@@ -59,61 +59,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Circus",
-                "subtype": "ability",
-                "text": "1 sp;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Dance",
-                "subtype": "ability",
-                "text": "2 cp social, 6 cp stage performance, 1 gp high-society ball;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Opera",
-                "subtype": "ability",
-                "text": "5 gp general admission, 20 gp box seats;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Music",
-                "subtype": "ability",
-                "text": "5 cp troubadours, 2 sp orchestra;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Stage Play",
-                "subtype": "ability",
-                "text": "6 cp small theater, 1 sp major theater;",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Street Performance",
-                "subtype": "ability",
-                "text": "tips of 1\u20132 cp.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Let\\'s See A Show')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -124,40 +74,16 @@
         ],
         "name": "Let's See A Show",
         "subtype": "monster_family",
-        "text": "Prices for a night's entertainment are per head and can be far higher for world-class performers.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Camilia Drannoch, Revolutionary",
-                "subtype": "ability",
-                "text": ": Camilia uses her powerful words to put an end to the Red Revolution, rid Galt of its *final blades*, and reestablish relations abroad.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "The Circus of Wayward Wonders",
-                "subtype": "ability",
-                "text": ": Perhaps the most spectacular traveling show in the Inner Sea, the Circus of Wayward Wonders and its Sideshow of Everyday Marvels offers truly outstanding acts for their audiences.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Janatimo, Speaker of the World's Tales",
-                "subtype": "ability",
-                "text": ": Janatimo, an aiuvarin bard at the Magaambya, leads the Uzunjati, scholars and teachers tasked with spreading knowledge to improve the world.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Performers Across Golarion')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -168,7 +94,6 @@
         ],
         "name": "Performers Across Golarion",
         "subtype": "monster_family",
-        "text": "Some of Golarion's brightest stars are as much storymakers as storytellers.",
         "type": "stat_block_section"
       }
     ],
@@ -236,6 +161,117 @@
         }
       ],
       "text": "Musical instruments range in size and function. For inspiration on what an NPC musician might play, choose from the following list: accordion, bagpipe, bodhr\u00e1n, bongo drum, cabasa, castanet, charango, chimes, claves, cu\u00edca, dan moi, didgeridoo, fiddle, flute, gemshorn, gittern, guan, hand bell, harmonica, hurdy-gurdy, kalimba, kazoo, lute, lyre, mandolin, maracas, ocarina, pan flute, piccolo, psaltery, recorder sackbut, shawm, slide whistle, spoons, tambourine, trumpet, triangle, ukulele, vielle, or zills.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Circus",
+          "subtype": "ability",
+          "text": "1 sp;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Dance",
+          "subtype": "ability",
+          "text": "2 cp social, 6 cp stage performance, 1 gp high-society ball;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Opera",
+          "subtype": "ability",
+          "text": "5 gp general admission, 20 gp box seats;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Music",
+          "subtype": "ability",
+          "text": "5 cp troubadours, 2 sp orchestra;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Stage Play",
+          "subtype": "ability",
+          "text": "6 cp small theater, 1 sp major theater;",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Street Performance",
+          "subtype": "ability",
+          "text": "tips of 1\u20132 cp.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Let's See A Show",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 124",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 124",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 124,
+          "type": "source"
+        }
+      ],
+      "text": "Prices for a night's entertainment are per head and can be far higher for world-class performers.  \n  \n**Circus** 1 sp; **Dance** 2 cp social, 6 cp stage performance, 1 gp high-society ball; **Opera** 5 gp general admission, 20 gp box seats; **Music** 5 cp troubadours, 2 sp orchestra; **Stage Play** 6 cp small theater, 1 sp major theater; **Street Performance** tips of 1\u20132 cp.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Camilia Drannoch, Revolutionary",
+          "subtype": "ability",
+          "text": ": Camilia uses her powerful words to put an end to the Red Revolution, rid Galt of its *final blades*, and reestablish relations abroad.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "The Circus of Wayward Wonders",
+          "subtype": "ability",
+          "text": ": Perhaps the most spectacular traveling show in the Inner Sea, the Circus of Wayward Wonders and its Sideshow of Everyday Marvels offers truly outstanding acts for their audiences.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Janatimo, Speaker of the World's Tales",
+          "subtype": "ability",
+          "text": ": Janatimo, an aiuvarin bard at the Magaambya, leads the Uzunjati, scholars and teachers tasked with spreading knowledge to improve the world.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Performers Across Golarion",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 124",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 124",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 124,
+          "type": "source"
+        }
+      ],
+      "text": "Some of Golarion's brightest stars are as much storymakers as storytellers.  \n  \n**Camilia Drannoch, Revolutionary**: Camilia uses her powerful words to put an end to the Red Revolution, rid Galt of its *final blades*, and reestablish relations abroad.  \n**The Circus of Wayward Wonders**: Perhaps the most spectacular traveling show in the Inner Sea, the Circus of Wayward Wonders and its Sideshow of Everyday Marvels offers truly outstanding acts for their audiences.  \n**Janatimo, Speaker of the World's Tales**: Janatimo, an aiuvarin bard at the Magaambya, leads the Uzunjati, scholars and teachers tasked with spreading knowledge to improve the world.",
       "type": "section"
     },
     {

--- a/monster_families/npc_core/scholar.json
+++ b/monster_families/npc_core/scholar.json
@@ -59,48 +59,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "The Acadaemae (Varisia)",
-                "subtype": "ability",
-                "text": ": Premiere wizard's college specializing in the summoning of otherworldly creatures.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Almas University (Andoran)",
-                "subtype": "ability",
-                "text": ": School primarily focusing on law, politics, modern philosophy, and zoology.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Kitharodian Academy (Taldor)",
-                "subtype": "ability",
-                "text": ": Famed bardic college teaching students of all social classes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Magaambya (Nantambu)",
-                "subtype": "ability",
-                "text": ": Ancient school with some of the world's greatest stores of arcane knowledge.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "University of Lepidstadt (Ustalav)",
-                "subtype": "ability",
-                "text": ": School primarily focusing on alchemy, medicine, and scientific study.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Centers Of Learning')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -136,6 +99,62 @@
         }
       ],
       "text": "It is a fond tradition at most universities in the Inner Sea for young scholars to pull strange and off-kilter pranks, all the more so when those young scholars have magic\u2014the more difficult, bizarre, or inexplicable the prank, the better. The wizards of the Arcanamirium still reminisce over the time they transported an entire galleon into a city park in the middle of the night. Similarly, the students at Dacilane Academy have recently started what they have called the First Great Prank War.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "The Acadaemae (Varisia)",
+          "subtype": "ability",
+          "text": ": Premiere wizard's college specializing in the summoning of otherworldly creatures.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Almas University (Andoran)",
+          "subtype": "ability",
+          "text": ": School primarily focusing on law, politics, modern philosophy, and zoology.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Kitharodian Academy (Taldor)",
+          "subtype": "ability",
+          "text": ": Famed bardic college teaching students of all social classes.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Magaambya (Nantambu)",
+          "subtype": "ability",
+          "text": ": Ancient school with some of the world's greatest stores of arcane knowledge.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "University of Lepidstadt (Ustalav)",
+          "subtype": "ability",
+          "text": ": School primarily focusing on alchemy, medicine, and scientific study.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Centers Of Learning",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 138",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 138",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 138,
+          "type": "source"
+        }
+      ],
+      "text": "**The Acadaemae (Varisia)**: Premiere wizard's college specializing in the summoning of otherworldly creatures.  \n**Almas University (Andoran)**: School primarily focusing on law, politics, modern philosophy, and zoology.  \n**Kitharodian Academy (Taldor)**: Famed bardic college teaching students of all social classes.  \n**Magaambya (Nantambu)**: Ancient school with some of the world's greatest stores of arcane knowledge.  \n**University of Lepidstadt (Ustalav)**: School primarily focusing on alchemy, medicine, and scientific study.",
       "type": "section"
     },
     {

--- a/monster_families/npc_core/villain.json
+++ b/monster_families/npc_core/villain.json
@@ -59,34 +59,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Queen Abrogail II",
-                "subtype": "ability",
-                "text": ": The ruler of Cheliax devotes herself to Asmodeus, and tyrannically rules her diabolic nation completely confident of the supremacy of herself and her country.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Tar-Baphon",
-                "subtype": "ability",
-                "text": ": The ancient lich called the Whispering Tyrant invaded nation after nation with his undead hordes, slayed a divine herald, and even now has arisen again and regrouped in the Gravelands.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "The Runelords",
-                "subtype": "ability",
-                "text": ": The seven rulers of ancient Thassilon mastered powers of magical runes, letting them rule in ancient times and return again and again in centuries since to try to take back the power they once had.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Golarion\\'s Most Wanted')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -97,7 +74,6 @@
         ],
         "name": "Golarion's Most Wanted",
         "subtype": "monster_family",
-        "text": "Here are a few of the most notorious villains in the history of Golarion.",
         "type": "stat_block_section"
       }
     ],
@@ -106,6 +82,48 @@
   "name": "Villain",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Queen Abrogail II",
+          "subtype": "ability",
+          "text": ": The ruler of Cheliax devotes herself to Asmodeus, and tyrannically rules her diabolic nation completely confident of the supremacy of herself and her country.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Tar-Baphon",
+          "subtype": "ability",
+          "text": ": The ancient lich called the Whispering Tyrant invaded nation after nation with his undead hordes, slayed a divine herald, and even now has arisen again and regrouped in the Gravelands.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "The Runelords",
+          "subtype": "ability",
+          "text": ": The seven rulers of ancient Thassilon mastered powers of magical runes, letting them rule in ancient times and return again and again in centuries since to try to take back the power they once had.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Golarion's Most Wanted",
+      "sources": [
+        {
+          "link": {
+            "alt": "NPC Core pg. 152",
+            "aonid": 236,
+            "game-obj": "Sources",
+            "name": "NPC Core pg. 152",
+            "type": "link"
+          },
+          "name": "NPC Core",
+          "page": 152,
+          "type": "source"
+        }
+      ],
+      "text": "Here are a few of the most notorious villains in the history of Golarion.  \n  \n**Queen Abrogail II**: The ruler of Cheliax devotes herself to Asmodeus, and tyrannically rules her diabolic nation completely confident of the supremacy of herself and her country.  \n**Tar-Baphon**: The ancient lich called the Whispering Tyrant invaded nation after nation with his undead hordes, slayed a divine herald, and even now has arisen again and regrouped in the Gravelands.  \n**The Runelords**: The seven rulers of ancient Thassilon mastered powers of magical runes, letting them rule in ancient times and return again and again in centuries since to try to take back the power they once had.",
+      "type": "section"
+    },
     {
       "name": "Manipulative Evil",
       "sources": [

--- a/monster_families/pathfinder_149_against_the_scarlet_triad/aluum.json
+++ b/monster_families/pathfinder_149_against_the_scarlet_triad/aluum.json
@@ -33,27 +33,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Daemon of Dogtown",
-                "subtype": "ability",
-                "text": ": Following the Silk Riots of 4303 AR, the Pactmasters dispatched this aluum to eliminate straggling instigators. It succeeded, but not before gaining sentience and enacting a 3-day string of murders. Although officials claim it was destroyed, the so-called Daemon of Dogtown\u2019s body was never actually recovered, leading to rumors that it still haunts the outskirts of Katapesh.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Queen Halkuar",
-                "subtype": "ability",
-                "text": ": Assigned to protect a gnoll emissary from the Spotted Hide pack, this aluum failed to protect its charge from assassins. Instinctively, it bound the gnoll\u2019s soul, assumed the fabricated persona of \u201cQueen Halkuar,\u201d and fled into the hinterlands. The queen is said to still wander the wastes in search of additional \u201cpackmates.\u201d",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Rogue Aluums')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -64,7 +48,6 @@
         ],
         "name": "Rogue Aluums",
         "subtype": "monster_family",
-        "text": "Although members of the Zephyr Guard stop at nothing to detain and destroy rogue aluums, several such renegade spiritbound aluums remain at large.",
         "type": "stat_block_section"
       }
     ],
@@ -90,6 +73,41 @@
         }
       ],
       "text": "Retired Zephyr Guards are the most common soul donors bound within an aluum\u2019s crystalline focus, typically agreeing to it early in their career in exchange for a higher salary.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Daemon of Dogtown",
+          "subtype": "ability",
+          "text": ": Following the Silk Riots of 4303 AR, the Pactmasters dispatched this aluum to eliminate straggling instigators. It succeeded, but not before gaining sentience and enacting a 3-day string of murders. Although officials claim it was destroyed, the so-called Daemon of Dogtown\u2019s body was never actually recovered, leading to rumors that it still haunts the outskirts of Katapesh.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Queen Halkuar",
+          "subtype": "ability",
+          "text": ": Assigned to protect a gnoll emissary from the Spotted Hide pack, this aluum failed to protect its charge from assassins. Instinctively, it bound the gnoll\u2019s soul, assumed the fabricated persona of \u201cQueen Halkuar,\u201d and fled into the hinterlands. The queen is said to still wander the wastes in search of additional \u201cpackmates.\u201d",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Rogue Aluums",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #149: Against the Scarlet Triad pg. 82",
+            "aonid": 14,
+            "game-obj": "Sources",
+            "name": "Pathfinder #149: Against the Scarlet Triad pg. 82",
+            "type": "link"
+          },
+          "name": "Pathfinder #149: Against the Scarlet Triad",
+          "page": 82,
+          "type": "source"
+        }
+      ],
+      "text": "Although members of the Zephyr Guard stop at nothing to detain and destroy rogue aluums, several such renegade spiritbound aluums remain at large.  \n  \n**Daemon of Dogtown**: Following the Silk Riots of 4303 AR, the Pactmasters dispatched this aluum to eliminate straggling instigators. It succeeded, but not before gaining sentience and enacting a 3-day string of murders. Although officials claim it was destroyed, the so-called Daemon of Dogtown\u2019s body was never actually recovered, leading to rumors that it still haunts the outskirts of Katapesh.  \n  \n**Queen Halkuar**: Assigned to protect a gnoll emissary from the Spotted Hide pack, this aluum failed to protect its charge from assassins. Instinctively, it bound the gnoll\u2019s soul, assumed the fabricated persona of \u201cQueen Halkuar,\u201d and fled into the hinterlands. The queen is said to still wander the wastes in search of additional \u201cpackmates.\u201d",
       "type": "section"
     }
   ],

--- a/monster_families/pathfinder_152_legacy_of_the_lost_god/visitant.json
+++ b/monster_families/pathfinder_152_legacy_of_the_lost_god/visitant.json
@@ -24,257 +24,91 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 15,
-                    "subtype": "area",
-                    "text": "15-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "name": "Noxious Breath",
-                "subtype": "ability",
-                "text": "The visitant exhales sharply, releasing pungent fumes from its lungs in a 15-foot cone. Each creature in the area must succeed at a Fortitude save or become sickened 1 (sickened 2 on a critical failure).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Roar",
-                "range": {
-                  "range": 100,
-                  "subtype": "range",
-                  "text": "within 100 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The visitant lets out a loud and horrifying roar. Each creature within 100 feet must attempt at a Will save. No matter the result, affected creatures are then temporarily immune to the effect for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "auditory",
-                      "aonid": 16,
-                      "game-obj": "Traits",
-                      "name": "auditory",
-                      "type": "link"
-                    },
-                    "name": "auditory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 134,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is frightened 1.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature is frightened 2.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "The creature is frightened 3.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "mental",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Vengeful Presence",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "A creature that starts its turn within the visitant\u2019s aura must succeed at a Will save or be overcome with a thirst for vengeance. For 1d4 rounds (1 minute on a critical failure), if the affected creature was attacked within the last round (whether or not the attack hit), the creature must use at least 1 action per round to Strike or use a hostile action toward its last attacker as long as the attacker is still alive. Failure to do so deals the affected creature 1d6 mental damage, plus 1d6 for every 5 levels the visitant has.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Wrestle",
-                "subtype": "ability",
-                "text": "The visitant makes a claw Strike against a creature it has grabbed. If the attack hits, that creature is knocked prone.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Visitant Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "auditory",
+                "aonid": 16,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -284,91 +118,40 @@
         ],
         "name": "Visitant Abilities",
         "subtype": "monster_family",
-        "text": "You can modify visitants by applying the following abilities. Most visitants have one of these abilities, but more powerful visitants might have more, in which you might consider increasing the visitant\u2019s level and statistics.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Occult Innate Spells",
-                "saving_throw": {
-                  "dc_text": "varies",
-                  "subtype": "save_dc",
-                  "text": "DC varies",
-                  "type": "stat_block_section"
-                },
-                "spell_attack_text": "varies",
-                "spell_list": [
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 110,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ray of enfeeblement",
-                            "aonid": 244,
-                            "game-obj": "Spells",
-                            "name": "ray of enfeeblement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ray of enfeeblement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "constant": true,
-                    "level": 1,
-                    "level_text": "(1st)",
-                    "spells": [
-                      {
-                        "count_text": "evil only",
-                        "links": [
-                          {
-                            "alt": "detect alignment",
-                            "aonid": 65,
-                            "game-obj": "Spells",
-                            "name": "detect alignment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect alignment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_tradition": "Occult",
-                "spell_type": "Innate Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Visitant Spells')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "fear",
+                "aonid": 110,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "ray of enfeeblement",
+                "aonid": 244,
+                "game-obj": "Spells",
+                "name": "ray of enfeeblement",
+                "type": "link"
+              },
+              {
+                "alt": "detect alignment",
+                "aonid": 65,
+                "game-obj": "Spells",
+                "name": "detect alignment",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -378,7 +161,6 @@
         ],
         "name": "Visitant Spells",
         "subtype": "monster_family",
-        "text": "Some visitants can cast the following innate occult spells. If you give a visitant the following spells, consider removing one of its other special abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -387,6 +169,349 @@
   "name": "Visitant",
   "schema_version": 1.0,
   "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "cone",
+              "size": 15,
+              "subtype": "area",
+              "text": "15-foot cone",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "name": "Noxious Breath",
+          "subtype": "ability",
+          "text": "The visitant exhales sharply, releasing pungent fumes from its lungs in a 15-foot cone. Each creature in the area must succeed at a Fortitude save or become sickened 1 (sickened 2 on a critical failure).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Roar",
+          "range": {
+            "range": 100,
+            "subtype": "range",
+            "text": "within 100 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The visitant lets out a loud and horrifying roar. Each creature within 100 feet must attempt at a Will save. No matter the result, affected creatures are then temporarily immune to the effect for 1 minute.",
+          "traits": [
+            {
+              "link": {
+                "alt": "auditory",
+                "aonid": 16,
+                "game-obj": "Traits",
+                "name": "auditory",
+                "type": "link"
+              },
+              "name": "auditory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              "name": "enchantment",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 134,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is frightened 1.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature is frightened 2.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "The creature is frightened 3.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "damage_type": "mental",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Vengeful Presence",
+          "range": {
+            "range": 20,
+            "subtype": "range",
+            "text": "20 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "A creature that starts its turn within the visitant\u2019s aura must succeed at a Will save or be overcome with a thirst for vengeance. For 1d4 rounds (1 minute on a critical failure), if the affected creature was attacked within the last round (whether or not the attack hit), the creature must use at least 1 action per round to Strike or use a hostile action toward its last attacker as long as the attacker is still alive. Failure to do so deals the affected creature 1d6 mental damage, plus 1d6 for every 5 levels the visitant has.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              "name": "enchantment",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Wrestle",
+          "subtype": "ability",
+          "text": "The visitant makes a claw Strike against a creature it has grabbed. If the attack hits, that creature is knocked prone.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "auditory",
+          "aonid": 16,
+          "game-obj": "Traits",
+          "name": "auditory",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "enchantment",
+          "aonid": 61,
+          "game-obj": "Traits",
+          "name": "enchantment",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 68,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 134,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 206,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "enchantment",
+          "aonid": 61,
+          "game-obj": "Traits",
+          "name": "enchantment",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        }
+      ],
+      "name": "Visitant Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #152: Legacy of the Lost God pg. 82",
+            "aonid": 23,
+            "game-obj": "Sources",
+            "name": "Pathfinder #152: Legacy of the Lost God pg. 82",
+            "type": "link"
+          },
+          "name": "Pathfinder #152: Legacy of the Lost God",
+          "page": 82,
+          "type": "source"
+        }
+      ],
+      "text": "You can modify visitants by applying the following abilities. Most visitants have one of these abilities, but more powerful visitants might have more, in which you might consider increasing the visitant\u2019s level and statistics.  \n**Noxious Breath** [##] The visitant exhales sharply, releasing pungent fumes from its lungs in a 15-foot cone. Each creature in the area must succeed at a Fortitude save or become sickened 1 (sickened 2 on a critical failure).  \n**Roar** [#] (auditory, concentrate, emotion, enchantment, fear, mental, primal) The visitant lets out a loud and horrifying roar. Each creature within 100 feet must attempt at a Will save. No matter the result, affected creatures are then temporarily immune to the effect for 1 minute.  \n**Critical Success** The creature is unaffected.  \n**Success** The creature is frightened 1.  \n**Failure** The creature is frightened 2.  \n**Critical Failure** The creature is frightened 3.  \n**Vengeful Presence** (aura, emotion, enchantment, mental) 20 feet. A creature that starts its turn within the visitant\u2019s aura must succeed at a Will save or be overcome with a thirst for vengeance. For 1d4 rounds (1 minute on a critical failure), if the affected creature was attacked within the last round (whether or not the attack hit), the creature must use at least 1 action per round to Strike or use a hostile action toward its last attacker as long as the attacker is still alive. Failure to do so deals the affected creature 1d6 mental damage, plus 1d6 for every 5 levels the visitant has.  \n**Wrestle** [#] The visitant makes a claw Strike against a creature it has grabbed. If the attack hits, that creature is knocked prone.",
+      "type": "section"
+    },
     {
       "links": [
         {
@@ -413,6 +538,128 @@
         }
       ],
       "text": "To create a visitant animal, use one of the stat blocks on this page as a starting point. Adjust the size as necessary and give its Strikes reach if it\u2019s Huge or larger. Visitants can also be made using a zombie stat block as a base; in this case, adjust the creature\u2019s Intelligence to \u20134. All visitants have imprecise lifesense as an additional sense.",
+      "type": "section"
+    },
+    {
+      "links": [
+        {
+          "alt": "fear",
+          "aonid": 110,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "ray of enfeeblement",
+          "aonid": 244,
+          "game-obj": "Spells",
+          "name": "ray of enfeeblement",
+          "type": "link"
+        },
+        {
+          "alt": "detect alignment",
+          "aonid": 65,
+          "game-obj": "Spells",
+          "name": "detect alignment",
+          "type": "link"
+        }
+      ],
+      "name": "Visitant Spells",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #152: Legacy of the Lost God pg. 82",
+            "aonid": 23,
+            "game-obj": "Sources",
+            "name": "Pathfinder #152: Legacy of the Lost God pg. 82",
+            "type": "link"
+          },
+          "name": "Pathfinder #152: Legacy of the Lost God",
+          "page": 82,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Occult Innate Spells",
+          "saving_throw": {
+            "dc_text": "varies",
+            "subtype": "save_dc",
+            "text": "DC varies",
+            "type": "stat_block_section"
+          },
+          "spell_attack_text": "varies",
+          "spell_list": [
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 110,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ray of enfeeblement",
+                      "aonid": 244,
+                      "game-obj": "Spells",
+                      "name": "ray of enfeeblement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ray of enfeeblement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "constant": true,
+              "level": 1,
+              "level_text": "(1st)",
+              "spells": [
+                {
+                  "count_text": "evil only",
+                  "links": [
+                    {
+                      "alt": "detect alignment",
+                      "aonid": 65,
+                      "game-obj": "Spells",
+                      "name": "detect alignment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect alignment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_tradition": "Occult",
+          "spell_type": "Innate Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "Some visitants can cast the following innate occult spells. If you give a visitant the following spells, consider removing one of its other special abilities.  \n**Occult Innate Spells** DC varies, spell attack varies; **1st** *fear*, *ray of enfeeblement*; **Constant (1st)** *detect alignment* (evil only)",
       "type": "section"
     }
   ],

--- a/monster_families/pathfinder_166_despair_on_danger_island/hantu.json
+++ b/monster_families/pathfinder_166_despair_on_danger_island/hantu.json
@@ -33,41 +33,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "Hantu Batu",
-                "subtype": "ability",
-                "text": ": These playful stone spirits throw rocks and pebbles with alarming frequency.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Hantu Beruk",
-                "subtype": "ability",
-                "text": ": These monkey spirits possess people (especially those with a naturally stoic or sober demeanor) and use their bodies to perform great acrobatic feats or perform mesmerizing dances.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Hantu Hutan",
-                "subtype": "ability",
-                "text": ": These jungle spirits defends their homes by shapeshifting into animals and plants to keep eyes on those who dare enter their domain.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Hantu Tinggi",
-                "subtype": "ability",
-                "text": ": These giant tree spirits tower above forest canopies. They tend to defend a location by using their great height to pick up intruders and place them elsewhere.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Other Hantus')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -78,7 +48,6 @@
         ],
         "name": "Other Hantus",
         "subtype": "monster_family",
-        "text": "Hantus can manifest from any manner of object or being, so an endless variety of the spirits exist. The following are some of the best-known examples of hantu kind.",
         "type": "stat_block_section"
       }
     ],
@@ -104,6 +73,55 @@
         }
       ],
       "text": "The spiritual nature of a hantu allows divine spellcasters to draw them forth with complex rituals. These rituals typically require a piece of the entity that the hantu embodies, such as a cup of water from a river or a bit of fur from a tapir. A successful ritual tugs a hantu toward the site of the ritual. A hantu typically listens to the requests of those who summoned it; whether it agrees to these requests, on the other hand, is another story.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "Hantu Batu",
+          "subtype": "ability",
+          "text": ": These playful stone spirits throw rocks and pebbles with alarming frequency.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Hantu Beruk",
+          "subtype": "ability",
+          "text": ": These monkey spirits possess people (especially those with a naturally stoic or sober demeanor) and use their bodies to perform great acrobatic feats or perform mesmerizing dances.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Hantu Hutan",
+          "subtype": "ability",
+          "text": ": These jungle spirits defends their homes by shapeshifting into animals and plants to keep eyes on those who dare enter their domain.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Hantu Tinggi",
+          "subtype": "ability",
+          "text": ": These giant tree spirits tower above forest canopies. They tend to defend a location by using their great height to pick up intruders and place them elsewhere.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Other Hantus",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #166: Despair on Danger Island pg. 84",
+            "aonid": 85,
+            "game-obj": "Sources",
+            "name": "Pathfinder #166: Despair on Danger Island pg. 84",
+            "type": "link"
+          },
+          "name": "Pathfinder #166: Despair on Danger Island",
+          "page": 84,
+          "type": "source"
+        }
+      ],
+      "text": "Hantus can manifest from any manner of object or being, so an endless variety of the spirits exist. The following are some of the best-known examples of hantu kind.   \n  \n**Hantu Batu**: These playful stone spirits throw rocks and pebbles with alarming frequency.   \n  \n**Hantu Beruk**: These monkey spirits possess people (especially those with a naturally stoic or sober demeanor) and use their bodies to perform great acrobatic feats or perform mesmerizing dances.   \n  \n**Hantu Hutan**: These jungle spirits defends their homes by shapeshifting into animals and plants to keep eyes on those who dare enter their domain.   \n  \n**Hantu Tinggi**: These giant tree spirits tower above forest canopies. They tend to defend a location by using their great height to pick up intruders and place them elsewhere.",
       "type": "section"
     }
   ],

--- a/monster_families/pathfinder_172_secrets_of_the_temple_city/graveknight.json
+++ b/monster_families/pathfinder_172_secrets_of_the_temple_city/graveknight.json
@@ -85,490 +85,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 12,
-                  "game-id": "fbaadf5607a32287e723316e8772a2c6",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 59,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "link": {
-                        "alt": "Bestiary pg. 343",
-                        "aonid": 2,
-                        "game-obj": "Sources",
-                        "name": "Bestiary pg. 343",
-                        "type": "link"
-                      },
-                      "name": "Bestiary",
-                      "page": 343,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Rejuvenation",
-                "subtype": "ability",
-                "text": "When a graveknight is destroyed, its armor rebuilds its body over the course of 1d10 days\u2014or more quickly if the armor is worn by a living host (see Graveknight Armor, below). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating its armor (such as with disintegrate), transporting it to the Positive Energy Plane, or throwing it into the heart of a volcano.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, precision, unconscious, plus one energy type (the same chosen for ruinous weapons below).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "positive",
-                    "aonid": 128,
-                    "game-obj": "Traits",
-                    "name": "positive",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "counteract",
-                    "aonid": 371,
-                    "game-obj": "Rules",
-                    "name": "counteract",
-                    "type": "link"
-                  }
-                ],
-                "name": "Sacrilegious Aura",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "When a creature in the aura uses a positive spell or ability, the graveknight automatically attempts to counteract it, with the listed counteract modifier.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "abjuration",
-                      "aonid": 2,
-                      "game-obj": "Traits",
-                      "name": "abjuration",
-                      "type": "link"
-                    },
-                    "name": "abjuration",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evil",
-                      "aonid": 64,
-                      "game-obj": "Traits",
-                      "name": "evil",
-                      "type": "link"
-                    },
-                    "name": "evil",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "formula": "1d12",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Devastating Blast",
-                "subtype": "ability",
-                "text": "The graveknight unleashes a 30-foot cone of energy. Creatures in the area take 1d12 damage, plus an additional 1d12 damage for every two levels the graveknight has (basic Reflex save). The graveknight can use this ability once every 1d4 rounds. This energy damage is of the same type as that of its ruinous weapons (see below); Devastating Blast gains the associated energy trait.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Three Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "phantom steed",
-                    "aonid": 221,
-                    "game-obj": "Spells",
-                    "name": "phantom steed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Phantom Mount",
-                "subtype": "ability",
-                "text": "The graveknight summons a supernatural mount as per *phantom steed*, heightened to a level equal to half the graveknight's level. Unlike *phantom steed*, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down). If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "conjuration",
-                      "aonid": 33,
-                      "game-obj": "Traits",
-                      "name": "conjuration",
-                      "type": "link"
-                    },
-                    "name": "conjuration",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "summon",
-                      "aonid": 154,
-                      "game-obj": "Traits",
-                      "name": "summon",
-                      "type": "link"
-                    },
-                    "name": "summon",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "acid",
-                    "aonid": 3,
-                    "game-obj": "Traits",
-                    "name": "acid",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "cold",
-                    "aonid": 27,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "electricity",
-                    "aonid": 56,
-                    "game-obj": "Traits",
-                    "name": "electricity",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fire",
-                    "aonid": 72,
-                    "game-obj": "Traits",
-                    "name": "fire",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "corrosive",
-                    "aonid": 292,
-                    "game-obj": "Equipment",
-                    "name": "corrosive",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frost",
-                    "aonid": 296,
-                    "game-obj": "Equipment",
-                    "name": "frost",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "shock",
-                    "aonid": 303,
-                    "game-obj": "Equipment",
-                    "name": "shock",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "flaming",
-                    "aonid": 295,
-                    "game-obj": "Equipment",
-                    "name": "flaming",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "striking",
-                    "aonid": 280,
-                    "game-obj": "Equipment",
-                    "name": "striking",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ruinous Weapons",
-                "subtype": "ability",
-                "text": "At the time of its creation, a graveknight chooses one of the following energy types that was relevant to its life or death: acid, cold, electricity, or fire. Any weapon the graveknight wields gains the effects of the *corrosive*, *frost*, *shock*, or *flaming* weapon rune, respectively, in addition to a *+1 striking* weapon rune. If the graveknight is 14th level or higher, its weapons instead gain the effects of the greater versions of both of these runes.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Weapon Master",
-                "subtype": "ability",
-                "text": "The graveknight has access to the critical specialization effects of any weapons it wields.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Graveknights')].sections[?(@.name=='Graveknight Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -593,6 +114,223 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "abjuration",
+                "aonid": 2,
+                "game-obj": "Traits",
+                "name": "abjuration",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "evil",
+                "aonid": 64,
+                "game-obj": "Traits",
+                "name": "evil",
+                "type": "link"
+              },
+              {
+                "alt": "positive",
+                "aonid": 128,
+                "game-obj": "Traits",
+                "name": "positive",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "conjuration",
+                "aonid": 33,
+                "game-obj": "Traits",
+                "name": "conjuration",
+                "type": "link"
+              },
+              {
+                "alt": "summon",
+                "aonid": 154,
+                "game-obj": "Traits",
+                "name": "summon",
+                "type": "link"
+              },
+              {
+                "alt": "phantom steed",
+                "aonid": 221,
+                "game-obj": "Spells",
+                "name": "phantom steed",
+                "type": "link"
+              },
+              {
+                "alt": "acid",
+                "aonid": 3,
+                "game-obj": "Traits",
+                "name": "acid",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 27,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "electricity",
+                "aonid": 56,
+                "game-obj": "Traits",
+                "name": "electricity",
+                "type": "link"
+              },
+              {
+                "alt": "fire",
+                "aonid": 72,
+                "game-obj": "Traits",
+                "name": "fire",
+                "type": "link"
+              },
+              {
+                "alt": "corrosive",
+                "aonid": 292,
+                "game-obj": "Equipment",
+                "name": "corrosive",
+                "type": "link"
+              },
+              {
+                "alt": "frost",
+                "aonid": 296,
+                "game-obj": "Equipment",
+                "name": "frost",
+                "type": "link"
+              },
+              {
+                "alt": "shock",
+                "aonid": 303,
+                "game-obj": "Equipment",
+                "name": "shock",
+                "type": "link"
+              },
+              {
+                "alt": "flaming",
+                "aonid": 295,
+                "game-obj": "Equipment",
+                "name": "flaming",
+                "type": "link"
+              },
+              {
+                "alt": "striking",
+                "aonid": 280,
+                "game-obj": "Equipment",
+                "name": "striking",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -602,70 +340,33 @@
         ],
         "name": "Graveknight Abilities",
         "subtype": "monster_family",
-        "text": "A graveknight gains the undead and graveknight traits, and its alignment is usually adjusted to evil. It loses any abilities that come from it being a living creature and any traits that represent its life, such as human and humanoid.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "damage_type": "mental",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "mental",
-                    "aonid": 106,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Betrayed Revivification",
-                "subtype": "ability",
-                "text": "The graveknight died after being deeply betrayed. Instead of being immune to a type of energy damage, it is immune to mental damage, its weapons deal 1d6 additional mental damage, and its Devastating Blast deals mental damage with a Will saving throw instead of Reflex.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "communication",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "suggestion",
-                    "aonid": 315,
-                    "game-obj": "Spells",
-                    "name": "suggestion",
-                    "type": "link"
-                  }
-                ],
-                "name": "Create Grave Squire",
-                "subtype": "ability",
-                "text": "The graveknight can gift a piece of its armor to a willing ally, which becomes its grave squire. The graveknight can communicate telepathically with its squire at any distance, see through the squire's senses, and cast *suggestion* as a divine innate spell through the telepathic link at will; the squire treats its degree of success as one step worse. If the graveknight's main armor is destroyed, the squire's piece expands to cover the squire's body over 1d10 days, after which point it becomes the graveknight's new body. The graveknight can have only one squire at a time, and must recover the gifted piece of armor if it wishes to create a new squire.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Dark Deliverance",
-                "subtype": "ability",
-                "text": "The graveknight has positive resistance equal to its level.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Graveknights')].sections[?(@.name=='Bestiary')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "suggestion",
+                "aonid": 315,
+                "game-obj": "Spells",
+                "name": "suggestion",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -680,37 +381,21 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "unarmed",
-                    "aonid": 199,
-                    "game-obj": "Traits",
-                    "name": "unarmed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Channel Magic",
-                "subtype": "ability",
-                "text": "The graveknight redirects magical energies through its armor, allowing it to deliver magic through an attack. The graveknight Casts a Spell that takes 1 or 2 actions to cast and requires a spell attack roll. The effects of the spell don't occur immediately but are imbued into an attack instead. The graveknight then makes a melee Strike with a weapon or unarmed attack. The spell is coupled with the attack, using the attack roll result to determine the effects of both the Strike and the spell. This counts as two attacks for the graveknight's multiple attack penalty but doesn't apply the penalty until after it's completed Channeling Magic. The graveknight can't use Channel Magic again for 1d4 rounds.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Graveknights')].sections[?(@.name=='Pathfinder #172: Secrets of the Temple City')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "unarmed",
+                "aonid": 199,
+                "game-obj": "Traits",
+                "name": "unarmed",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -725,285 +410,154 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The graveknight's armor animates and attempts to Grab the triggering creature. It makes an Athletics check to Grapple using the graveknight's Athletics modifier \u2013 2. The armor can continue to Grapple the creature normally. Since the armor is grappling the creature, the graveknight doesn't need a free hand to do so.",
-                "links": [
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Grapple",
-                    "aonid": 35,
-                    "game-obj": "Actions",
-                    "name": "Grapple",
-                    "type": "link"
-                  }
-                ],
-                "name": "Clutching Armor",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "A creature attempts to move away from the graveknight",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "quickened",
-                    "aonid": 32,
-                    "game-obj": "Conditions",
-                    "name": "quickened",
-                    "type": "link"
-                  }
-                ],
-                "name": "Eager for Battle",
-                "subtype": "ability",
-                "text": "When the graveknight rolls initiative, they roll twice and take the better result. They're quickened during their first round after rolling initiative and can use this extra action to Step, Stride, or Strike.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "fortune",
-                      "aonid": 76,
-                      "game-obj": "Traits",
-                      "name": "fortune",
-                      "type": "link"
-                    },
-                    "name": "fortune",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Empty Save for Dust",
-                "subtype": "ability",
-                "text": "The graveknight's armor contains nothing more than swirling dust that puffs out from joints in their armor. A living creature that touches or is touched by the graveknight (including one hit by the graveknight's fist Strike) must succeed at a Reflex saving throw or become contaminated with the dust. While contaminated, the targeted creature is stupefied 1 and gains weakness to the graveknight's energy damage equal to half the graveknight's level. The contamination ends after 1 minute or when the creature is doused with water, whichever occurs first.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sturdy shield",
-                    "aonid": 327,
-                    "game-obj": "Equipment",
-                    "name": "sturdy shield",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Shield Block",
-                    "aonid": 32,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Shield Block",
-                    "type": "link"
-                  }
-                ],
-                "name": "Graveknight's Shield",
-                "subtype": "ability",
-                "text": "The graveknight's curse extends to their shield, or the graveknight's armor uses a portion of itself to produce a shield. The graveknight has a shield that uses the statistics of a *sturdy shield* of a level no higher than the graveknight's level \u2013 1. The shield is quasi-independent of the graveknight and automatically protects the graveknight from harm. When the shield is raised, it automatically uses Shield Block to reduce the damage of the first attack against the graveknight each round without the graveknight needing to spend their reaction to do so. The shield automatically rejuvenates with the rest of the graveknight and must be destroyed in the same manner as the graveknight's armor.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "doomed 1",
-                    "aonid": 9,
-                    "game-obj": "Conditions",
-                    "name": "doomed 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened 2",
-                    "aonid": 19,
-                    "game-obj": "Conditions",
-                    "name": "frightened 2",
-                    "type": "link"
-                  }
-                ],
-                "name": "Portentous Glare",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The graveknight's visage is one of overwhelming menace. When a creature ends its turn in the aura, it must attempt a Will saving throw. A creature that fails is doomed 1 (or doomed 1 and frightened 2 on a critical failure). The graveknight can activate or deactivate the aura by using an Interact action to open or close their helmet visor.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Graveknights')].sections[?(@.name=='Book Of The Dead')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "Grapple",
+                "aonid": 35,
+                "game-obj": "Actions",
+                "name": "Grapple",
+                "type": "link"
+              },
+              {
+                "alt": "fortune",
+                "aonid": 76,
+                "game-obj": "Traits",
+                "name": "fortune",
+                "type": "link"
+              },
+              {
+                "alt": "quickened",
+                "aonid": 32,
+                "game-obj": "Conditions",
+                "name": "quickened",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 1",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
+              },
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "sturdy shield",
+                "aonid": 327,
+                "game-obj": "Equipment",
+                "name": "sturdy shield",
+                "type": "link"
+              },
+              {
+                "alt": "Shield Block",
+                "aonid": 32,
+                "game-obj": "MonsterAbilities",
+                "name": "Shield Block",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "doomed 1",
+                "aonid": 9,
+                "game-obj": "Conditions",
+                "name": "doomed 1",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 2",
+                "aonid": 19,
+                "game-obj": "Conditions",
+                "name": "frightened 2",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1018,89 +572,35 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "affliction",
-                "name": "Graveknight's Curse",
-                "onset": "1 hour",
-                "saving_throw": [
-                  {
-                    "save_type": "Will",
-                    "subtype": "save_dc",
-                    "text": "Will save",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "stages": [
-                  {
-                    "name": "Stage 1",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 1 and cannot remove the armor (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 2",
-                    "subtype": "affliction_stage",
-                    "text": "doomed 2, hampered 10, and cannot remove the armor (1 day)",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "name": "Stage 3",
-                    "subtype": "affliction_stage",
-                    "text": "dies and transforms into the armor's graveknight.",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "This curse affects anyone who wears a graveknight's armor for at least 1 hour.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "arcane",
-                      "aonid": 11,
-                      "game-obj": "Traits",
-                      "name": "arcane",
-                      "type": "link"
-                    },
-                    "name": "arcane",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 38,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Graveknight Armor')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1114,29 +614,11 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "name": "Lictor Shokneir:",
-                    "subtype": "ability",
-                    "text": "Once the Hellknight leader of the notorious Order of the Crux, Lictor Shokneir was disgraced when he refused a royal order to disband his army of butchers. The other Hellknights surrounded him and razed his castle, Citadel Gheisteno, to the ground. However, Shokneir's determination sustains his now-undead form, and he and his undead legions have rebuilt the citadel in all its haunting glory.",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "name": "The Black Prince:",
-                    "subtype": "ability",
-                    "text": "Although the graveknight known simply as the Black Prince was redeemed centuries ago as part of Iomedae's 11 Acts, it is said that the prince's armor remains intact\u2014and that vile forces conspire to reclaim it. If the armor is donned by one of the Black Prince's descendants, the Inner Sea will be beset by a terrible villain indeed.",
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Graveknight Armor')].sections[?(@.name=='Infamous Graveknights')].abilities",
                     "target": "$.defense.automatic_abilities"
                   }
                 ],
@@ -1147,11 +629,9 @@
             ],
             "name": "Infamous Graveknights",
             "subtype": "monster_family",
-            "text": "Several of Golarion's most notorious villains are graveknights. The following examples are among the world's most infamous graveknights at large, and may inspire or serve as villains in your own games.",
             "type": "stat_block_section"
           }
         ],
-        "text": "Wearing graveknight armor is very risky, for the graveknight's essence rapidly parasitizes the new wearer, accelerating the graveknight's rejuvenation. This agonizing transformation inevitably kills the host, transforming their flesh into the graveknight's new body. Removing the curse allows a character to remove the armor, but if it ever wears the armor again, the curse returns. If the wearer dies from another cause while wearing the armor, or if the graveknight's rejuvenation completes before the wearer dies from the curse, the wearer immediately progresses to stage 3.",
         "type": "stat_block_section"
       }
     ],
@@ -1163,6 +643,744 @@
     {
       "name": "Creating Graveknights",
       "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              "name": "Darkvision",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 12,
+                "game-id": "fbaadf5607a32287e723316e8772a2c6",
+                "game-obj": "MonsterAbilities",
+                "links": [
+                  {
+                    "alt": "darkvision",
+                    "aonid": 415,
+                    "game-obj": "Rules",
+                    "name": "darkvision",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 409,
+                    "game-obj": "Rules",
+                    "name": "darkness",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "dim light",
+                    "aonid": 408,
+                    "game-obj": "Rules",
+                    "name": "dim light",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "darkness",
+                    "aonid": 59,
+                    "game-obj": "Spells",
+                    "name": "darkness",
+                    "type": "link"
+                  }
+                ],
+                "name": "Darkvision",
+                "sources": [
+                  {
+                    "link": {
+                      "alt": "Bestiary pg. 343",
+                      "aonid": 2,
+                      "game-obj": "Sources",
+                      "name": "Bestiary pg. 343",
+                      "type": "link"
+                    },
+                    "name": "Bestiary",
+                    "page": 343,
+                    "type": "source"
+                  }
+                ],
+                "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "link": {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              "name": "Negative Healing",
+              "subtype": "ability",
+              "type": "stat_block_section",
+              "universal_monster_ability": {
+                "ability_type": "universal_monster_ability",
+                "aonid": 42,
+                "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "sources": [
+                  {
+                    "errata": {
+                      "alt": "2.0",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "2.0",
+                      "type": "link"
+                    },
+                    "link": {
+                      "alt": "Bestiary 2 pg. 305",
+                      "aonid": 32,
+                      "game-obj": "Sources",
+                      "name": "Bestiary 2 pg. 305",
+                      "type": "link"
+                    },
+                    "name": "Bestiary 2",
+                    "page": 305,
+                    "type": "source"
+                  }
+                ],
+                "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+                "type": "ability"
+              }
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Rejuvenation",
+              "subtype": "ability",
+              "text": "When a graveknight is destroyed, its armor rebuilds its body over the course of 1d10 days\u2014or more quickly if the armor is worn by a living host (see Graveknight Armor, below). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating its armor (such as with disintegrate), transporting it to the Positive Energy Plane, or throwing it into the heart of a volcano.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "death",
+                  "aonid": 40,
+                  "game-obj": "Traits",
+                  "name": "death",
+                  "type": "link"
+                },
+                {
+                  "alt": "disease",
+                  "aonid": 46,
+                  "game-obj": "Traits",
+                  "name": "disease",
+                  "type": "link"
+                },
+                {
+                  "alt": "paralyzed",
+                  "aonid": 28,
+                  "game-obj": "Conditions",
+                  "name": "paralyzed",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                },
+                {
+                  "alt": "unconscious",
+                  "aonid": 38,
+                  "game-obj": "Conditions",
+                  "name": "unconscious",
+                  "type": "link"
+                }
+              ],
+              "name": "Immunities",
+              "subtype": "ability",
+              "text": "death effects, disease, paralyzed, poison, precision, unconscious, plus one energy type (the same chosen for ruinous weapons below).",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "positive",
+                  "aonid": 128,
+                  "game-obj": "Traits",
+                  "name": "positive",
+                  "type": "link"
+                },
+                {
+                  "alt": "counteract",
+                  "aonid": 371,
+                  "game-obj": "Rules",
+                  "name": "counteract",
+                  "type": "link"
+                }
+              ],
+              "name": "Sacrilegious Aura",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "When a creature in the aura uses a positive spell or ability, the graveknight automatically attempts to counteract it, with the listed counteract modifier.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "abjuration",
+                    "aonid": 2,
+                    "game-obj": "Traits",
+                    "name": "abjuration",
+                    "type": "link"
+                  },
+                  "name": "abjuration",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "evil",
+                    "aonid": 64,
+                    "game-obj": "Traits",
+                    "name": "evil",
+                    "type": "link"
+                  },
+                  "name": "evil",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "area": [
+                {
+                  "shape": "cone",
+                  "size": 30,
+                  "subtype": "area",
+                  "text": "30-foot cone",
+                  "type": "stat_block_section",
+                  "unit": "feet"
+                }
+              ],
+              "damage": [
+                {
+                  "formula": "1d12",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "basic",
+                  "aonid": 329,
+                  "game-obj": "Rules",
+                  "name": "basic",
+                  "type": "link"
+                }
+              ],
+              "name": "Devastating Blast",
+              "subtype": "ability",
+              "text": "The graveknight unleashes a 30-foot cone of energy. Creatures in the area take 1d12 damage, plus an additional 1d12 damage for every two levels the graveknight has (basic Reflex save). The graveknight can use this ability once every 1d4 rounds. This energy damage is of the same type as that of its ruinous weapons (see below); Devastating Blast gains the associated energy trait.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "evocation",
+                    "aonid": 65,
+                    "game-obj": "Traits",
+                    "name": "evocation",
+                    "type": "link"
+                  },
+                  "name": "evocation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Three Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "links": [
+                {
+                  "alt": "phantom steed",
+                  "aonid": 221,
+                  "game-obj": "Spells",
+                  "name": "phantom steed",
+                  "type": "link"
+                }
+              ],
+              "name": "Phantom Mount",
+              "subtype": "ability",
+              "text": "The graveknight summons a supernatural mount as per *phantom steed*, heightened to a level equal to half the graveknight's level. Unlike *phantom steed*, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down). If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "conjuration",
+                    "aonid": 33,
+                    "game-obj": "Traits",
+                    "name": "conjuration",
+                    "type": "link"
+                  },
+                  "name": "conjuration",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "summon",
+                    "aonid": 154,
+                    "game-obj": "Traits",
+                    "name": "summon",
+                    "type": "link"
+                  },
+                  "name": "summon",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "acid",
+                  "aonid": 3,
+                  "game-obj": "Traits",
+                  "name": "acid",
+                  "type": "link"
+                },
+                {
+                  "alt": "cold",
+                  "aonid": 27,
+                  "game-obj": "Traits",
+                  "name": "cold",
+                  "type": "link"
+                },
+                {
+                  "alt": "electricity",
+                  "aonid": 56,
+                  "game-obj": "Traits",
+                  "name": "electricity",
+                  "type": "link"
+                },
+                {
+                  "alt": "fire",
+                  "aonid": 72,
+                  "game-obj": "Traits",
+                  "name": "fire",
+                  "type": "link"
+                },
+                {
+                  "alt": "corrosive",
+                  "aonid": 292,
+                  "game-obj": "Equipment",
+                  "name": "corrosive",
+                  "type": "link"
+                },
+                {
+                  "alt": "frost",
+                  "aonid": 296,
+                  "game-obj": "Equipment",
+                  "name": "frost",
+                  "type": "link"
+                },
+                {
+                  "alt": "shock",
+                  "aonid": 303,
+                  "game-obj": "Equipment",
+                  "name": "shock",
+                  "type": "link"
+                },
+                {
+                  "alt": "flaming",
+                  "aonid": 295,
+                  "game-obj": "Equipment",
+                  "name": "flaming",
+                  "type": "link"
+                },
+                {
+                  "alt": "striking",
+                  "aonid": 280,
+                  "game-obj": "Equipment",
+                  "name": "striking",
+                  "type": "link"
+                }
+              ],
+              "name": "Ruinous Weapons",
+              "subtype": "ability",
+              "text": "At the time of its creation, a graveknight chooses one of the following energy types that was relevant to its life or death: acid, cold, electricity, or fire. Any weapon the graveknight wields gains the effects of the *corrosive*, *frost*, *shock*, or *flaming* weapon rune, respectively, in addition to a *+1 striking* weapon rune. If the graveknight is 14th level or higher, its weapons instead gain the effects of the greater versions of both of these runes.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "name": "Weapon Master",
+              "subtype": "ability",
+              "text": "The graveknight has access to the critical specialization effects of any weapons it wields.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "undead",
+              "aonid": 160,
+              "game-obj": "Traits",
+              "name": "undead",
+              "type": "link"
+            },
+            {
+              "alt": "human",
+              "aonid": 90,
+              "game-obj": "Traits",
+              "name": "human",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 91,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            },
+            {
+              "alt": "Darkvision",
+              "aonid": 12,
+              "game-obj": "MonsterAbilities",
+              "name": "Darkvision",
+              "type": "link"
+            },
+            {
+              "alt": "Negative Healing",
+              "aonid": 42,
+              "game-obj": "MonsterAbilities",
+              "name": "Negative Healing",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "abjuration",
+              "aonid": 2,
+              "game-obj": "Traits",
+              "name": "abjuration",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "evil",
+              "aonid": 64,
+              "game-obj": "Traits",
+              "name": "evil",
+              "type": "link"
+            },
+            {
+              "alt": "positive",
+              "aonid": 128,
+              "game-obj": "Traits",
+              "name": "positive",
+              "type": "link"
+            },
+            {
+              "alt": "counteract",
+              "aonid": 371,
+              "game-obj": "Rules",
+              "name": "counteract",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "evocation",
+              "aonid": 65,
+              "game-obj": "Traits",
+              "name": "evocation",
+              "type": "link"
+            },
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "conjuration",
+              "aonid": 33,
+              "game-obj": "Traits",
+              "name": "conjuration",
+              "type": "link"
+            },
+            {
+              "alt": "summon",
+              "aonid": 154,
+              "game-obj": "Traits",
+              "name": "summon",
+              "type": "link"
+            },
+            {
+              "alt": "phantom steed",
+              "aonid": 221,
+              "game-obj": "Spells",
+              "name": "phantom steed",
+              "type": "link"
+            },
+            {
+              "alt": "acid",
+              "aonid": 3,
+              "game-obj": "Traits",
+              "name": "acid",
+              "type": "link"
+            },
+            {
+              "alt": "cold",
+              "aonid": 27,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "electricity",
+              "aonid": 56,
+              "game-obj": "Traits",
+              "name": "electricity",
+              "type": "link"
+            },
+            {
+              "alt": "fire",
+              "aonid": 72,
+              "game-obj": "Traits",
+              "name": "fire",
+              "type": "link"
+            },
+            {
+              "alt": "corrosive",
+              "aonid": 292,
+              "game-obj": "Equipment",
+              "name": "corrosive",
+              "type": "link"
+            },
+            {
+              "alt": "frost",
+              "aonid": 296,
+              "game-obj": "Equipment",
+              "name": "frost",
+              "type": "link"
+            },
+            {
+              "alt": "shock",
+              "aonid": 303,
+              "game-obj": "Equipment",
+              "name": "shock",
+              "type": "link"
+            },
+            {
+              "alt": "flaming",
+              "aonid": 295,
+              "game-obj": "Equipment",
+              "name": "flaming",
+              "type": "link"
+            },
+            {
+              "alt": "striking",
+              "aonid": 280,
+              "game-obj": "Equipment",
+              "name": "striking",
+              "type": "link"
+            }
+          ],
+          "name": "Graveknight Abilities",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "A graveknight gains the undead and graveknight traits, and its alignment is usually adjusted to evil. It loses any abilities that come from it being a living creature and any traits that represent its life, such as human and humanoid.  \n**Darkvision**  \n**Negative Healing**  \n**Rejuvenation** (divine, necromancy) When a graveknight is destroyed, its armor rebuilds its body over the course of 1d10 days\u2014or more quickly if the armor is worn by a living host (see Graveknight Armor, below). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating its armor (such as with disintegrate), transporting it to the Positive Energy Plane, or throwing it into the heart of a volcano.  \n**Immunities** death effects, disease, paralyzed, poison, precision, unconscious, plus one energy type (the same chosen for ruinous weapons below).  \n**Sacrilegious Aura** (abjuration, aura, divine, evil) 30 feet. When a creature in the aura uses a positive spell or ability, the graveknight automatically attempts to counteract it, with the listed counteract modifier.  \n**Devastating Blast** [##] (arcane, evocation) The graveknight unleashes a 30-foot cone of energy. Creatures in the area take 1d12 damage, plus an additional 1d12 damage for every two levels the graveknight has (basic Reflex save). The graveknight can use this ability once every 1d4 rounds. This energy damage is of the same type as that of its ruinous weapons (see below); Devastating Blast gains the associated energy trait.  \n**Phantom Mount** [###] (arcane, conjuration, summon) The graveknight summons a supernatural mount as per *phantom steed*, heightened to a level equal to half the graveknight's level. Unlike *phantom steed*, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down). If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.  \n**Ruinous Weapons** At the time of its creation, a graveknight chooses one of the following energy types that was relevant to its life or death: acid, cold, electricity, or fire. Any weapon the graveknight wields gains the effects of the *corrosive*, *frost*, *shock*, or *flaming* weapon rune, respectively, in addition to a *+1 striking* weapon rune. If the graveknight is 14th level or higher, its weapons instead gain the effects of the greater versions of both of these runes.  \n**Weapon Master** The graveknight has access to the critical specialization effects of any weapons it wields.",
+          "type": "section"
+        },
         {
           "name": "Alternate Graveknight Abilities",
           "sources": [
@@ -1181,6 +1399,580 @@
           ],
           "text": "You can create a more unusual graveknight by substituting one of their abilities (except for darkvision, negative healing, rejuvenation, or immunities) with one of the following.",
           "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "mental",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "links": [
+                {
+                  "alt": "mental",
+                  "aonid": 106,
+                  "game-obj": "Traits",
+                  "name": "mental",
+                  "type": "link"
+                }
+              ],
+              "name": "Betrayed Revivification",
+              "subtype": "ability",
+              "text": "The graveknight died after being deeply betrayed. Instead of being immune to a type of energy damage, it is immune to mental damage, its weapons deal 1d6 additional mental damage, and its Devastating Blast deals mental damage with a Will saving throw instead of Reflex.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "communication",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "suggestion",
+                  "aonid": 315,
+                  "game-obj": "Spells",
+                  "name": "suggestion",
+                  "type": "link"
+                }
+              ],
+              "name": "Create Grave Squire",
+              "subtype": "ability",
+              "text": "The graveknight can gift a piece of its armor to a willing ally, which becomes its grave squire. The graveknight can communicate telepathically with its squire at any distance, see through the squire's senses, and cast *suggestion* as a divine innate spell through the telepathic link at will; the squire treats its degree of success as one step worse. If the graveknight's main armor is destroyed, the squire's piece expands to cover the squire's body over 1d10 days, after which point it becomes the graveknight's new body. The graveknight can have only one squire at a time, and must recover the gifted piece of armor if it wishes to create a new squire.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Dark Deliverance",
+              "subtype": "ability",
+              "text": "The graveknight has positive resistance equal to its level.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "suggestion",
+              "aonid": 315,
+              "game-obj": "Spells",
+              "name": "suggestion",
+              "type": "link"
+            }
+          ],
+          "name": "Bestiary",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "**Betrayed Revivification** The graveknight died after being deeply betrayed. Instead of being immune to a type of energy damage, it is immune to mental damage, its weapons deal 1d6 additional mental damage, and its Devastating Blast deals mental damage with a Will saving throw instead of Reflex.  \n**Create Grave Squire** The graveknight can gift a piece of its armor to a willing ally, which becomes its grave squire. The graveknight can communicate telepathically with its squire at any distance, see through the squire's senses, and cast *suggestion* as a divine innate spell through the telepathic link at will; the squire treats its degree of success as one step worse. If the graveknight's main armor is destroyed, the squire's piece expands to cover the squire's body over 1d10 days, after which point it becomes the graveknight's new body. The graveknight can have only one squire at a time, and must recover the gifted piece of armor if it wishes to create a new squire.  \n**Dark Deliverance** The graveknight has positive resistance equal to its level.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "offensive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Two Actions",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "frequency": "1d4 rounds",
+              "links": [
+                {
+                  "alt": "unarmed",
+                  "aonid": 199,
+                  "game-obj": "Traits",
+                  "name": "unarmed",
+                  "type": "link"
+                }
+              ],
+              "name": "Channel Magic",
+              "subtype": "ability",
+              "text": "The graveknight redirects magical energies through its armor, allowing it to deliver magic through an attack. The graveknight Casts a Spell that takes 1 or 2 actions to cast and requires a spell attack roll. The effects of the spell don't occur immediately but are imbued into an attack instead. The graveknight then makes a melee Strike with a weapon or unarmed attack. The spell is coupled with the attack, using the attack roll result to determine the effects of both the Strike and the spell. This counts as two attacks for the graveknight's multiple attack penalty but doesn't apply the penalty until after it's completed Channeling Magic. The graveknight can't use Channel Magic again for 1d4 rounds.",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "unarmed",
+              "aonid": 199,
+              "game-obj": "Traits",
+              "name": "unarmed",
+              "type": "link"
+            }
+          ],
+          "name": "Pathfinder #172: Secrets of the Temple City",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "**Channel Magic** [##] The graveknight redirects magical energies through its armor, allowing it to deliver magic through an attack. The graveknight Casts a Spell that takes 1 or 2 actions to cast and requires a spell attack roll. The effects of the spell don't occur immediately but are imbued into an attack instead. The graveknight then makes a melee Strike with a weapon or unarmed attack. The spell is coupled with the attack, using the attack roll result to determine the effects of both the Strike and the spell. This counts as two attacks for the graveknight's multiple attack penalty but doesn't apply the penalty until after it's completed Channeling Magic. The graveknight can't use Channel Magic again for 1d4 rounds.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "reactive",
+              "ability_type": "ability",
+              "action_type": {
+                "name": "Reaction",
+                "subtype": "action_type",
+                "type": "stat_block_section"
+              },
+              "effect": "The graveknight's armor animates and attempts to Grab the triggering creature. It makes an Athletics check to Grapple using the graveknight's Athletics modifier \u2013 2. The armor can continue to Grapple the creature normally. Since the armor is grappling the creature, the graveknight doesn't need a free hand to do so.",
+              "links": [
+                {
+                  "alt": "Athletics",
+                  "aonid": 3,
+                  "game-obj": "Skills",
+                  "name": "Athletics",
+                  "type": "link"
+                },
+                {
+                  "alt": "Grapple",
+                  "aonid": 35,
+                  "game-obj": "Actions",
+                  "name": "Grapple",
+                  "type": "link"
+                }
+              ],
+              "name": "Clutching Armor",
+              "subtype": "ability",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "transmutation",
+                    "aonid": 157,
+                    "game-obj": "Traits",
+                    "name": "transmutation",
+                    "type": "link"
+                  },
+                  "name": "transmutation",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "trigger": "A creature attempts to move away from the graveknight",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "quickened",
+                  "aonid": 32,
+                  "game-obj": "Conditions",
+                  "name": "quickened",
+                  "type": "link"
+                }
+              ],
+              "name": "Eager for Battle",
+              "subtype": "ability",
+              "text": "When the graveknight rolls initiative, they roll twice and take the better result. They're quickened during their first round after rolling initiative and can use this extra action to Step, Stride, or Strike.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "fortune",
+                    "aonid": 76,
+                    "game-obj": "Traits",
+                    "name": "fortune",
+                    "type": "link"
+                  },
+                  "name": "fortune",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "stupefied 1",
+                  "aonid": 37,
+                  "game-obj": "Conditions",
+                  "name": "stupefied 1",
+                  "type": "link"
+                }
+              ],
+              "name": "Empty Save for Dust",
+              "subtype": "ability",
+              "text": "The graveknight's armor contains nothing more than swirling dust that puffs out from joints in their armor. A living creature that touches or is touched by the graveknight (including one hit by the graveknight's fist Strike) must succeed at a Reflex saving throw or become contaminated with the dust. While contaminated, the targeted creature is stupefied 1 and gains weakness to the graveknight's energy damage equal to half the graveknight's level. The contamination ends after 1 minute or when the creature is doused with water, whichever occurs first.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "sturdy shield",
+                  "aonid": 327,
+                  "game-obj": "Equipment",
+                  "name": "sturdy shield",
+                  "type": "link"
+                },
+                {
+                  "alt": "Shield Block",
+                  "aonid": 32,
+                  "game-obj": "MonsterAbilities",
+                  "name": "Shield Block",
+                  "type": "link"
+                }
+              ],
+              "name": "Graveknight's Shield",
+              "subtype": "ability",
+              "text": "The graveknight's curse extends to their shield, or the graveknight's armor uses a portion of itself to produce a shield. The graveknight has a shield that uses the statistics of a *sturdy shield* of a level no higher than the graveknight's level \u2013 1. The shield is quasi-independent of the graveknight and automatically protects the graveknight from harm. When the shield is raised, it automatically uses Shield Block to reduce the damage of the first attack against the graveknight each round without the graveknight needing to spend their reaction to do so. The shield automatically rejuvenates with the rest of the graveknight and must be destroyed in the same manner as the graveknight's armor.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "arcane",
+                    "aonid": 11,
+                    "game-obj": "Traits",
+                    "name": "arcane",
+                    "type": "link"
+                  },
+                  "name": "arcane",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "necromancy",
+                    "aonid": 117,
+                    "game-obj": "Traits",
+                    "name": "necromancy",
+                    "type": "link"
+                  },
+                  "name": "necromancy",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "doomed 1",
+                  "aonid": 9,
+                  "game-obj": "Conditions",
+                  "name": "doomed 1",
+                  "type": "link"
+                },
+                {
+                  "alt": "frightened 2",
+                  "aonid": 19,
+                  "game-obj": "Conditions",
+                  "name": "frightened 2",
+                  "type": "link"
+                }
+              ],
+              "name": "Portentous Glare",
+              "range": {
+                "range": 30,
+                "subtype": "range",
+                "text": "30 feet",
+                "type": "stat_block_section",
+                "unit": "feet"
+              },
+              "subtype": "ability",
+              "text": "The graveknight's visage is one of overwhelming menace. When a creature ends its turn in the aura, it must attempt a Will saving throw. A creature that fails is doomed 1 (or doomed 1 and frightened 2 on a critical failure). The graveknight can activate or deactivate the aura by using an Interact action to open or close their helmet visor.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "aura",
+                    "aonid": 206,
+                    "game-obj": "Traits",
+                    "name": "aura",
+                    "type": "link"
+                  },
+                  "name": "aura",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "divine",
+                    "aonid": 48,
+                    "game-obj": "Traits",
+                    "name": "divine",
+                    "type": "link"
+                  },
+                  "name": "divine",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "emotion",
+                    "aonid": 60,
+                    "game-obj": "Traits",
+                    "name": "emotion",
+                    "type": "link"
+                  },
+                  "name": "emotion",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "enchantment",
+                    "aonid": 61,
+                    "game-obj": "Traits",
+                    "name": "enchantment",
+                    "type": "link"
+                  },
+                  "name": "enchantment",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fear",
+                    "aonid": 68,
+                    "game-obj": "Traits",
+                    "name": "fear",
+                    "type": "link"
+                  },
+                  "name": "fear",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "mental",
+                    "aonid": 106,
+                    "game-obj": "Traits",
+                    "name": "mental",
+                    "type": "link"
+                  },
+                  "name": "mental",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "visual",
+                    "aonid": 163,
+                    "game-obj": "Traits",
+                    "name": "visual",
+                    "type": "link"
+                  },
+                  "name": "visual",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "transmutation",
+              "aonid": 157,
+              "game-obj": "Traits",
+              "name": "transmutation",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "Grapple",
+              "aonid": 35,
+              "game-obj": "Actions",
+              "name": "Grapple",
+              "type": "link"
+            },
+            {
+              "alt": "fortune",
+              "aonid": 76,
+              "game-obj": "Traits",
+              "name": "fortune",
+              "type": "link"
+            },
+            {
+              "alt": "quickened",
+              "aonid": 32,
+              "game-obj": "Conditions",
+              "name": "quickened",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied 1",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            },
+            {
+              "alt": "arcane",
+              "aonid": 11,
+              "game-obj": "Traits",
+              "name": "arcane",
+              "type": "link"
+            },
+            {
+              "alt": "necromancy",
+              "aonid": 117,
+              "game-obj": "Traits",
+              "name": "necromancy",
+              "type": "link"
+            },
+            {
+              "alt": "sturdy shield",
+              "aonid": 327,
+              "game-obj": "Equipment",
+              "name": "sturdy shield",
+              "type": "link"
+            },
+            {
+              "alt": "Shield Block",
+              "aonid": 32,
+              "game-obj": "MonsterAbilities",
+              "name": "Shield Block",
+              "type": "link"
+            },
+            {
+              "alt": "aura",
+              "aonid": 206,
+              "game-obj": "Traits",
+              "name": "aura",
+              "type": "link"
+            },
+            {
+              "alt": "divine",
+              "aonid": 48,
+              "game-obj": "Traits",
+              "name": "divine",
+              "type": "link"
+            },
+            {
+              "alt": "emotion",
+              "aonid": 60,
+              "game-obj": "Traits",
+              "name": "emotion",
+              "type": "link"
+            },
+            {
+              "alt": "enchantment",
+              "aonid": 61,
+              "game-obj": "Traits",
+              "name": "enchantment",
+              "type": "link"
+            },
+            {
+              "alt": "fear",
+              "aonid": 68,
+              "game-obj": "Traits",
+              "name": "fear",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 106,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            },
+            {
+              "alt": "doomed 1",
+              "aonid": 9,
+              "game-obj": "Conditions",
+              "name": "doomed 1",
+              "type": "link"
+            },
+            {
+              "alt": "frightened 2",
+              "aonid": 19,
+              "game-obj": "Conditions",
+              "name": "frightened 2",
+              "type": "link"
+            }
+          ],
+          "name": "Book Of The Dead",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "**Clutching Armor** [@] (arcane, transmutation) **Trigger** A creature attempts to move away from the graveknight; **Effect** The graveknight's armor animates and attempts to Grab the triggering creature. It makes an Athletics check to Grapple using the graveknight's Athletics modifier \u2013 2. The armor can continue to Grapple the creature normally. Since the armor is grappling the creature, the graveknight doesn't need a free hand to do so.  \n**Eager for Battle** (fortune) When the graveknight rolls initiative, they roll twice and take the better result. They're quickened during their first round after rolling initiative and can use this extra action to Step, Stride, or Strike.  \n**Empty Save for Dust** The graveknight's armor contains nothing more than swirling dust that puffs out from joints in their armor. A living creature that touches or is touched by the graveknight (including one hit by the graveknight's fist Strike) must succeed at a Reflex saving throw or become contaminated with the dust. While contaminated, the targeted creature is stupefied 1 and gains weakness to the graveknight's energy damage equal to half the graveknight's level. The contamination ends after 1 minute or when the creature is doused with water, whichever occurs first.   \n**Graveknight's Shield** (arcane, necromancy) The graveknight's curse extends to their shield, or the graveknight's armor uses a portion of itself to produce a shield. The graveknight has a shield that uses the statistics of a *sturdy shield* of a level no higher than the graveknight's level \u2013 1. The shield is quasi-independent of the graveknight and automatically protects the graveknight from harm. When the shield is raised, it automatically uses Shield Block to reduce the damage of the first attack against the graveknight each round without the graveknight needing to spend their reaction to do so. The shield automatically rejuvenates with the rest of the graveknight and must be destroyed in the same manner as the graveknight's armor.  \n**Portentous Glare** (aura, divine, emotion, enchantment, fear, mental, visual) 30 feet. The graveknight's visage is one of overwhelming menace. When a creature ends its turn in the aura, it must attempt a Will saving throw. A creature that fails is doomed 1 (or doomed 1 and frightened 2 on a critical failure). The graveknight can activate or deactivate the aura by using an Interact action to open or close their helmet visor.",
+          "type": "section"
         }
       ],
       "sources": [
@@ -1198,6 +1990,263 @@
         }
       ],
       "text": "You can turn an existing, living creature into a graveknight by completing the following steps. It's best to build a graveknight from scratch, but if you don't have the time, simply apply the template. A creature should be at least level 5 before being converted to a graveknight.  \n Increase the creature's level by 1 and change its statistics as follows.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "affliction",
+          "name": "Graveknight's Curse",
+          "onset": "1 hour",
+          "saving_throw": [
+            {
+              "save_type": "Will",
+              "subtype": "save_dc",
+              "text": "Will save",
+              "type": "stat_block_section"
+            }
+          ],
+          "stages": [
+            {
+              "name": "Stage 1",
+              "subtype": "affliction_stage",
+              "text": "doomed 1 and cannot remove the armor (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 2",
+              "subtype": "affliction_stage",
+              "text": "doomed 2, hampered 10, and cannot remove the armor (1 day)",
+              "type": "stat_block_section"
+            },
+            {
+              "name": "Stage 3",
+              "subtype": "affliction_stage",
+              "text": "dies and transforms into the armor's graveknight.",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "This curse affects anyone who wears a graveknight's armor for at least 1 hour.",
+          "traits": [
+            {
+              "link": {
+                "alt": "arcane",
+                "aonid": 11,
+                "game-obj": "Traits",
+                "name": "arcane",
+                "type": "link"
+              },
+              "name": "arcane",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "curse",
+                "aonid": 38,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              "name": "curse",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "arcane",
+          "aonid": 11,
+          "game-obj": "Traits",
+          "name": "arcane",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 38,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        }
+      ],
+      "name": "Graveknight Armor",
+      "sections": [
+        {
+          "name": "Arts of War",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "Graveknights don't arise from mere soldiers but from great tacticians who've won countless engagements. Often, they were once their land's mightiest general or most decorated war hero. This means graveknights don't just rush into a toe-to-toe melee. They've studied the land (often with the experienced and unrelenting gaze only the undead can bring to bear) and engineered troop movements, earthworks, and traps to ensure victory. They usually have reinforcements ready to deploy and redundant contingencies in place. Just as great strategists opine that an engagement is decided before the first blow is landed, a combat against a graveknight often feels like a desperate fight in a rapidly closing vise.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Lictor Shokneir:",
+              "subtype": "ability",
+              "text": "Once the Hellknight leader of the notorious Order of the Crux, Lictor Shokneir was disgraced when he refused a royal order to disband his army of butchers. The other Hellknights surrounded him and razed his castle, Citadel Gheisteno, to the ground. However, Shokneir's determination sustains his now-undead form, and he and his undead legions have rebuilt the citadel in all its haunting glory.",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "The Black Prince:",
+              "subtype": "ability",
+              "text": "Although the graveknight known simply as the Black Prince was redeemed centuries ago as part of Iomedae's 11 Acts, it is said that the prince's armor remains intact\u2014and that vile forces conspire to reclaim it. If the armor is donned by one of the Black Prince's descendants, the Inner Sea will be beset by a terrible villain indeed.",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Infamous Graveknights",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "Several of Golarion's most notorious villains are graveknights. The following examples are among the world's most infamous graveknights at large, and may inspire or serve as villains in your own games.  \n  \n**Lictor Shokneir:** Once the Hellknight leader of the notorious Order of the Crux, Lictor Shokneir was disgraced when he refused a royal order to disband his army of butchers. The other Hellknights surrounded him and razed his castle, Citadel Gheisteno, to the ground. However, Shokneir's determination sustains his now-undead form, and he and his undead legions have rebuilt the citadel in all its haunting glory.  \n  \n**The Black Prince:** Although the graveknight known simply as the Black Prince was redeemed centuries ago as part of Iomedae's 11 Acts, it is said that the prince's armor remains intact\u2014and that vile forces conspire to reclaim it. If the armor is donned by one of the Black Prince's descendants, the Inner Sea will be beset by a terrible villain indeed.",
+          "type": "section"
+        },
+        {
+          "name": "Other Powers",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "You can use the alternate abilities as examples to create new powers reflecting a graveknight's personality or history, or even swap out more than one power. Graveknights should be unique and memorable foes.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "phantom steed",
+              "aonid": 221,
+              "game-obj": "Spells",
+              "name": "phantom steed",
+              "type": "link"
+            },
+            {
+              "alt": "nightmare's",
+              "aonid": 308,
+              "game-obj": "Monsters",
+              "name": "nightmare's",
+              "type": "link"
+            },
+            {
+              "alt": "pegasus's",
+              "aonid": 329,
+              "game-obj": "Monsters",
+              "name": "pegasus's",
+              "type": "link"
+            }
+          ],
+          "name": "Steed Adaptations",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "For some graveknights, their mount is more than a projection of their desire to move quickly around a battlefield. A graveknight's *phantom steed* might have the appearance, resistances, or movement of a favored mount the knight rode as a mortal, such as a nightmare's resistance to fire or a pegasus's Fly Speed.",
+          "type": "section"
+        },
+        {
+          "name": "Unique Destruction",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "aonid": 102,
+                "game-obj": "Sources",
+                "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #172: Secrets of the Temple City",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "While most graveknight armors can be destroyed with the standard means of destruction, particularly powerful graveknights might have more durable armor that requires additional steps to destroy. These are usually the armors of high-level graveknights, and their destruction steps are tied to the creation of the graveknight. For example, a specific graveknight armor can't be destroyed until it's struck by a descendant of the person that originally felled the graveknight in battle before their transformation.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #172: Secrets of the Temple City pg. 82",
+            "aonid": 102,
+            "game-obj": "Sources",
+            "name": "Pathfinder #172: Secrets of the Temple City pg. 82",
+            "type": "link"
+          },
+          "name": "Pathfinder #172: Secrets of the Temple City",
+          "page": 82,
+          "type": "source"
+        }
+      ],
+      "text": "Wearing graveknight armor is very risky, for the graveknight's essence rapidly parasitizes the new wearer, accelerating the graveknight's rejuvenation. This agonizing transformation inevitably kills the host, transforming their flesh into the graveknight's new body. Removing the curse allows a character to remove the armor, but if it ever wears the armor again, the curse returns. If the wearer dies from another cause while wearing the armor, or if the graveknight's rejuvenation completes before the wearer dies from the curse, the wearer immediately progresses to stage 3.  \n**Graveknight's Curse** (arcane, curse, necromancy) This curse affects anyone who wears a graveknight's armor for at least 1 hour. **Saving Throw** Will save; **Onset** 1 hour; **Stage 1** doomed 1 and cannot remove the armor (1 day); **Stage 2** doomed 2, hampered 10, and cannot remove the armor (1 day); **Stage 3** dies and transforms into the armor's graveknight.",
       "type": "section"
     }
   ],

--- a/monster_families/pathfinder_177_burning_tundra/zombie_tar.json
+++ b/monster_families/pathfinder_177_burning_tundra/zombie_tar.json
@@ -40,177 +40,70 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Disgusting Pustules",
-                "subtype": "ability",
-                "text": "The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. In either case, adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Feast",
-                "subtype": "ability",
-                "text": "If the zombie is adjacent to a helpless or unconscious creature, or a deceased creature that died in the past hour, the zombie can feast upon its flesh to heal itself. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, flst, or claw damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "manipulate",
-                      "aonid": 104,
-                      "game-obj": "Traits",
-                      "name": "manipulate",
-                      "type": "link"
-                    },
-                    "name": "manipulate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Plague-Ridden",
-                "subtype": "ability",
-                "text": "The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "damage": [
-                  {
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "name": "Rotting Aura",
-                "range": {
-                  "range": 10,
-                  "subtype": "range",
-                  "text": "within 10 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 damage as its wounds fester. This damage increases by 1d6 for every 6 levels the zombie has. Creatures that take a critical hit from the zombie also take this damage immediately.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "disease",
-                      "aonid": 46,
-                      "game-obj": "Traits",
-                      "name": "disease",
-                      "type": "link"
-                    },
-                    "name": "disease",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Unkillable",
-                "subtype": "ability",
-                "text": "This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Zombie Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "manipulate",
+                "aonid": 104,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -220,131 +113,75 @@
         ],
         "name": "Zombie Abilities",
         "subtype": "monster_family",
-        "text": "You can modify zombies with the following zombie abilities. Most zombies have one of these abilities; If you give a zombie more, you might want to increase its level and adjust its statistics.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "prone",
-                    "aonid": 31,
-                    "game-obj": "Conditions",
-                    "name": "prone",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "flat-footed",
-                    "aonid": 16,
-                    "game-obj": "Conditions",
-                    "name": "flat-footed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Trip",
-                    "aonid": 40,
-                    "game-obj": "Actions",
-                    "name": "Trip",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Crawls",
-                    "aonid": 76,
-                    "game-obj": "Actions",
-                    "name": "Crawls",
-                    "type": "link"
-                  }
-                ],
-                "name": "Ankle Biter",
-                "subtype": "ability",
-                "text": "This zombie fights just as well on the ground as it does standing. While prone, the zombie isn't flat-footed, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "name": "Persistent Limbs",
-                "subtype": "ability",
-                "text": "The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "sickened 1",
-                    "aonid": 34,
-                    "game-obj": "Conditions",
-                    "name": "sickened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Putrid Stench",
-                "range": {
-                  "range": 15,
-                  "subtype": "range",
-                  "text": "15 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The zombie's rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies' putrid stenches for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 206,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "olfactory",
-                      "aonid": 246,
-                      "game-obj": "Traits",
-                      "name": "olfactory",
-                      "type": "link"
-                    },
-                    "name": "olfactory",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Unholy Speed",
-                "subtype": "ability",
-                "text": "The zombie gains a +10 status bonus to all its Speeds",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Additional Monster Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "prone",
+                "aonid": 31,
+                "game-obj": "Conditions",
+                "name": "prone",
+                "type": "link"
+              },
+              {
+                "alt": "flat-footed",
+                "aonid": 16,
+                "game-obj": "Conditions",
+                "name": "flat-footed",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "Trip",
+                "aonid": 40,
+                "game-obj": "Actions",
+                "name": "Trip",
+                "type": "link"
+              },
+              {
+                "alt": "Crawls",
+                "aonid": 76,
+                "game-obj": "Actions",
+                "name": "Crawls",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "olfactory",
+                "aonid": 246,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              {
+                "alt": "sickened 1",
+                "aonid": 34,
+                "game-obj": "Conditions",
+                "name": "sickened 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -354,7 +191,6 @@
         ],
         "name": "Additional Monster Abilities",
         "subtype": "monster_family",
-        "text": "You can modify zombies with the following zombie abilities, in addition to those found on page 340 of the *Bestiary*. Most zombies have one of these abilities; if you give a zombie more, you might want to increase its level and adjust its statistics.",
         "type": "stat_block_section"
       }
     ],
@@ -492,6 +328,448 @@
         }
       ],
       "text": "**Related Groups** *Zombie*  \nA zombie's only desire is to consume the living. Unthinking and ever-shambling harbingers of death, zombies stop only when they're destroyed.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Disgusting Pustules",
+          "subtype": "ability",
+          "text": "The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. In either case, adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save.",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Feast",
+          "subtype": "ability",
+          "text": "If the zombie is adjacent to a helpless or unconscious creature, or a deceased creature that died in the past hour, the zombie can feast upon its flesh to heal itself. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, flst, or claw damage.",
+          "traits": [
+            {
+              "link": {
+                "alt": "manipulate",
+                "aonid": 104,
+                "game-obj": "Traits",
+                "name": "manipulate",
+                "type": "link"
+              },
+              "name": "manipulate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Plague-Ridden",
+          "subtype": "ability",
+          "text": "The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie.",
+          "traits": [
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "damage": [
+            {
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "name": "Rotting Aura",
+          "range": {
+            "range": 10,
+            "subtype": "range",
+            "text": "within 10 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 damage as its wounds fester. This damage increases by 1d6 for every 6 levels the zombie has. Creatures that take a critical hit from the zombie also take this damage immediately.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              "name": "disease",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Unkillable",
+          "subtype": "ability",
+          "text": "This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "manipulate",
+          "aonid": 104,
+          "game-obj": "Traits",
+          "name": "manipulate",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 206,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        }
+      ],
+      "name": "Zombie Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #177: Burning Tundra pg. 84",
+            "aonid": 116,
+            "game-obj": "Sources",
+            "name": "Pathfinder #177: Burning Tundra pg. 84",
+            "type": "link"
+          },
+          "name": "Pathfinder #177: Burning Tundra",
+          "page": 84,
+          "type": "source"
+        },
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 302",
+            "href": "https://paizo.com/products/btq024xj",
+            "name": "Bestiary 3 pg. 302",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 302,
+          "type": "source"
+        }
+      ],
+      "text": "You can modify zombies with the following zombie abilities. Most zombies have one of these abilities; If you give a zombie more, you might want to increase its level and adjust its statistics.  \n**Disgusting Pustules** (disease, necromancy) The zombie is covered in pustules that rupture when it takes any piercing damage or any critical hit. In either case, adjacent creatures are hit with vile fluid, causing them to become sickened 1 unless they succeed at a Fortitude save.  \n**Feast** [##] (manipulate) If the zombie is adjacent to a helpless or unconscious creature, or a deceased creature that died in the past hour, the zombie can feast upon its flesh to heal itself. This restores an amount of Hit Points equal to the zombie's level. If the creature is alive, the zombie deals damage equal to its jaws, flst, or claw damage.  \n**Plague-Ridden** (disease, necromancy) The zombie carries a plague that can create more of its own kind. This functions as the plague zombie's zombie rot, except at stage 5, the victim rises as another of the zombie's type, rather than a plague zombie.  \n**Rotting Aura** (aura, disease, necromancy) The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes 1d6 damage as its wounds fester. This damage increases by 1d6 for every 6 levels the zombie has. Creatures that take a critical hit from the zombie also take this damage immediately.  \n**Unkillable** This zombie is nigh unkillable. The zombie loses its weakness to slashing and gains resistance against all damage equal to its level (minimum 3), and it gains weakness equal to twice its level (minimum 6) to critical hits. Increase the zombie's level by 1 if you give it this ability.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "prone",
+              "aonid": 31,
+              "game-obj": "Conditions",
+              "name": "prone",
+              "type": "link"
+            },
+            {
+              "alt": "flat-footed",
+              "aonid": 16,
+              "game-obj": "Conditions",
+              "name": "flat-footed",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "Trip",
+              "aonid": 40,
+              "game-obj": "Actions",
+              "name": "Trip",
+              "type": "link"
+            },
+            {
+              "alt": "Crawls",
+              "aonid": 76,
+              "game-obj": "Actions",
+              "name": "Crawls",
+              "type": "link"
+            }
+          ],
+          "name": "Ankle Biter",
+          "subtype": "ability",
+          "text": "This zombie fights just as well on the ground as it does standing. While prone, the zombie isn't flat-footed, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "name": "Persistent Limbs",
+          "subtype": "ability",
+          "text": "The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "sickened 1",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Putrid Stench",
+          "range": {
+            "range": 15,
+            "subtype": "range",
+            "text": "15 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The zombie's rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies' putrid stenches for 1 minute.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 206,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "olfactory",
+                "aonid": 246,
+                "game-obj": "Traits",
+                "name": "olfactory",
+                "type": "link"
+              },
+              "name": "olfactory",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Unholy Speed",
+          "subtype": "ability",
+          "text": "The zombie gains a +10 status bonus to all its Speeds",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "prone",
+          "aonid": 31,
+          "game-obj": "Conditions",
+          "name": "prone",
+          "type": "link"
+        },
+        {
+          "alt": "flat-footed",
+          "aonid": 16,
+          "game-obj": "Conditions",
+          "name": "flat-footed",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 3,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "Trip",
+          "aonid": 40,
+          "game-obj": "Actions",
+          "name": "Trip",
+          "type": "link"
+        },
+        {
+          "alt": "Crawls",
+          "aonid": 76,
+          "game-obj": "Actions",
+          "name": "Crawls",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 206,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "olfactory",
+          "aonid": 246,
+          "game-obj": "Traits",
+          "name": "olfactory",
+          "type": "link"
+        },
+        {
+          "alt": "sickened 1",
+          "aonid": 34,
+          "game-obj": "Conditions",
+          "name": "sickened 1",
+          "type": "link"
+        }
+      ],
+      "name": "Additional Monster Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Bestiary 3 pg. 302",
+            "href": "https://paizo.com/products/btq024xj",
+            "name": "Bestiary 3 pg. 302",
+            "type": "link"
+          },
+          "name": "Bestiary 3",
+          "page": 302,
+          "type": "source"
+        }
+      ],
+      "text": "You can modify zombies with the following zombie abilities, in addition to those found on page 340 of the *Bestiary*. Most zombies have one of these abilities; if you give a zombie more, you might want to increase its level and adjust its statistics.   \n  \n**Ankle Biter** This zombie fights just as well on the ground as it does standing. While prone, the zombie isn't flat-footed, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to Trip. The zombie can also move up to half its Speed when it Crawls.   \n  \n**Persistent Limbs** The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.   \n  \n**Putrid Stench** (aura, olfactory) 15 feet. The zombie's rotting flesh is particularly malodorous. A creature that enters the area must attempt a Fortitude save. On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a \u20135-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a \u20132 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies' putrid stenches for 1 minute.   \n  \n**Unholy Speed** The zombie gains a +10 status bonus to all its Speeds",
       "type": "section"
     }
   ],

--- a/monster_families/pathfinder_182_graveclaw/virulak.json
+++ b/monster_families/pathfinder_182_graveclaw/virulak.json
@@ -33,314 +33,133 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Envenomed Weapons",
-                "subtype": "ability",
-                "text": "A virulak's poison is supernaturally channeled through their weapons. Any target hit by a melee weapon wielded by the virulak is exposed to the virulak's undead virulence.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 15,
-                    "subtype": "area",
-                    "text": "15-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "poison",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "high DC for their level",
-                    "aonid": 1020,
-                    "game-obj": "Rules",
-                    "name": "high DC for their level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fetid Breath",
-                "saving_throw": [
-                  {
-                    "dc": 20,
-                    "subtype": "save_dc",
-                    "text": "DC 20",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "subtype": "ability",
-                "text": "The virulak exhales a deadly poisonous cloud in a 15-foot cone. The cloud deals 1d6 poison damage plus 1d6 poison damage for each level of the virulak to all creatures in the area, which must attempt a basic Fortitude save (using a high DC for their level). The virulak can't use Fetid Breath again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "poison",
-                      "aonid": 126,
-                      "game-obj": "Traits",
-                      "name": "poison",
-                      "type": "link"
-                    },
-                    "name": "poison",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "virulent",
-                    "aonid": 162,
-                    "game-obj": "Traits",
-                    "name": "virulent",
-                    "type": "link"
-                  }
-                ],
-                "name": "Intensify Toxin",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The virulak targets a creature within 30 feet that's currently subject to a poison affliction. That affliction becomes virulent until it's cured.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "poison",
-                      "aonid": 126,
-                      "game-obj": "Traits",
-                      "name": "poison",
-                      "type": "link"
-                    },
-                    "name": "poison",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The virulak squirts a jet of poisonous ichor from the wound. The creature making the triggering Strike takes persistent poison damage equal to the virulak's level.",
-                "links": [
-                  {
-                    "alt": "persistent poison damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent poison damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Lingering Ichor",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "poison",
-                      "aonid": 126,
-                      "game-obj": "Traits",
-                      "name": "poison",
-                      "type": "link"
-                    },
-                    "name": "poison",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "The virulak takes piercing or slashing damage from a melee Strike",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Venomous Gaze",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "within 30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The virulak locks its gaze on a single creature within 30 feet. The target is exposed to the virulak's undead virulence.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "poison",
-                      "aonid": 126,
-                      "game-obj": "Traits",
-                      "name": "poison",
-                      "type": "link"
-                    },
-                    "name": "poison",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Virulak Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "high DC for their level",
+                "aonid": 1020,
+                "game-obj": "Rules",
+                "name": "high DC for their level",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "virulent",
+                "aonid": 162,
+                "game-obj": "Traits",
+                "name": "virulent",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "persistent poison damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent poison damage",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -350,7 +169,6 @@
         ],
         "name": "Virulak Abilities",
         "subtype": "monster_family",
-        "text": "All virulaks carry lethal poison in their bodies, described by their undead virulence ability. Virulaks usually have one of the following additional abilities (each stat block presented here already has one of these abilities included). You can give a virulak multiple abilities, but you should increase the virulak's level if you do.",
         "type": "stat_block_section"
       }
     ],
@@ -358,6 +176,450 @@
   },
   "name": "Virulak",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Envenomed Weapons",
+          "subtype": "ability",
+          "text": "A virulak's poison is supernaturally channeled through their weapons. Any target hit by a melee weapon wielded by the virulak is exposed to the virulak's undead virulence.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "cone",
+              "size": 15,
+              "subtype": "area",
+              "text": "15-foot cone",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "poison",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "frequency": "1d4 rounds",
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "high DC for their level",
+              "aonid": 1020,
+              "game-obj": "Rules",
+              "name": "high DC for their level",
+              "type": "link"
+            }
+          ],
+          "name": "Fetid Breath",
+          "saving_throw": [
+            {
+              "dc": 20,
+              "subtype": "save_dc",
+              "text": "DC 20",
+              "type": "stat_block_section"
+            }
+          ],
+          "subtype": "ability",
+          "text": "The virulak exhales a deadly poisonous cloud in a 15-foot cone. The cloud deals 1d6 poison damage plus 1d6 poison damage for each level of the virulak to all creatures in the area, which must attempt a basic Fortitude save (using a high DC for their level). The virulak can't use Fetid Breath again for 1d4 rounds.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              "name": "evocation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              "name": "poison",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "virulent",
+              "aonid": 162,
+              "game-obj": "Traits",
+              "name": "virulent",
+              "type": "link"
+            }
+          ],
+          "name": "Intensify Toxin",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "within 30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The virulak targets a creature within 30 feet that's currently subject to a poison affliction. That affliction becomes virulent until it's cured.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              "name": "poison",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The virulak squirts a jet of poisonous ichor from the wound. The creature making the triggering Strike takes persistent poison damage equal to the virulak's level.",
+          "links": [
+            {
+              "alt": "persistent poison damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent poison damage",
+              "type": "link"
+            }
+          ],
+          "name": "Lingering Ichor",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              "name": "poison",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "trigger": "The virulak takes piercing or slashing damage from a melee Strike",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Venomous Gaze",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "within 30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The virulak locks its gaze on a single creature within 30 feet. The target is exposed to the virulak's undead virulence.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              "name": "poison",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "evocation",
+          "aonid": 65,
+          "game-obj": "Traits",
+          "name": "evocation",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 126,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "high DC for their level",
+          "aonid": 1020,
+          "game-obj": "Rules",
+          "name": "high DC for their level",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 126,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        },
+        {
+          "alt": "virulent",
+          "aonid": 162,
+          "game-obj": "Traits",
+          "name": "virulent",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 126,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "persistent poison damage",
+          "aonid": 29,
+          "game-obj": "Conditions",
+          "name": "persistent poison damage",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 126,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 163,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        }
+      ],
+      "name": "Virulak Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #182: Graveclaw pg. 86",
+            "aonid": 143,
+            "game-obj": "Sources",
+            "name": "Pathfinder #182: Graveclaw pg. 86",
+            "type": "link"
+          },
+          "name": "Pathfinder #182: Graveclaw",
+          "page": 86,
+          "type": "source"
+        }
+      ],
+      "text": "All virulaks carry lethal poison in their bodies, described by their undead virulence ability. Virulaks usually have one of the following additional abilities (each stat block presented here already has one of these abilities included). You can give a virulak multiple abilities, but you should increase the virulak's level if you do.  \n  \n**Envenomed Weapons** A virulak's poison is supernaturally channeled through their weapons. Any target hit by a melee weapon wielded by the virulak is exposed to the virulak's undead virulence.  \n  \n**Fetid Breath** [##] (divine, evocation, poison) The virulak exhales a deadly poisonous cloud in a 15-foot cone. The cloud deals 1d6 poison damage plus 1d6 poison damage for each level of the virulak to all creatures in the area, which must attempt a basic Fortitude save (using a high DC for their level). The virulak can't use Fetid Breath again for 1d4 rounds.  \n  \n**Intensify Toxin** [##] (concentrate, divine, poison, transmutation) The virulak targets a creature within 30 feet that's currently subject to a poison affliction. That affliction becomes virulent until it's cured.  \n  \n**Lingering Ichor** [@] (poison) **Trigger** The virulak takes piercing or slashing damage from a melee Strike; **Effect** The virulak squirts a jet of poisonous ichor from the wound. The creature making the triggering Strike takes persistent poison damage equal to the virulak's level.  \n  \n**Venomous Gaze** [##] (concentrate, divine, necromancy, poison, visual) The virulak locks its gaze on a single creature within 30 feet. The target is exposed to the virulak's undead virulence.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/pathfinder_189_dreamers_of_the_nameless_spires/blackfrost_dead.json
+++ b/monster_families/pathfinder_189_dreamers_of_the_nameless_spires/blackfrost_dead.json
@@ -39,249 +39,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 5,
-                    "subtype": "area",
-                    "text": "5-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "frequency": "1d4 rounds",
-                "links": [
-                  {
-                    "alt": "concealed",
-                    "aonid": 4,
-                    "game-obj": "Conditions",
-                    "name": "concealed",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blackfrost Breath",
-                "subtype": "ability",
-                "text": "The blackfrost dead gasps sharply, then exhales a mist of dark-blue blackfrost particles in a 5-foot emanation. All creatures within the mist become concealed, and all creatures outside the mist become concealed to creatures within it. The mist persists for 1 minute. A creature that ends its turn in the mist is exposed to blackfrost. The blackfrost dead can't use Blackfrost Breath again for 1d4 rounds.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "conjuration",
-                      "aonid": 33,
-                      "game-obj": "Traits",
-                      "name": "conjuration",
-                      "type": "link"
-                    },
-                    "name": "conjuration",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Ice Climb",
-                "subtype": "ability",
-                "text": "The blackfrost dead can climb on ice as though it had the listed climb Speed. It ignores difficult terrain and greater difficult terrain from ice and snow and doesn't risk falling when crossing ice.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "mental",
-                    "formula": "1d4",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "frightened 1",
-                    "aonid": 19,
-                    "game-obj": "Conditions",
-                    "name": "frightened 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Mindburning Gaze",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "within 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The blackfrost dead fixes its terrifying gaze on a creature within 60 feet. The creature takes 1d4 mental damage per level of the blackfrost dead (minimum 2d4), with a basic Will save. On a critical failure, the creature is frightened 1.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "emotion",
-                      "aonid": 60,
-                      "game-obj": "Traits",
-                      "name": "emotion",
-                      "type": "link"
-                    },
-                    "name": "emotion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "fear",
-                      "aonid": 68,
-                      "game-obj": "Traits",
-                      "name": "fear",
-                      "type": "link"
-                    },
-                    "name": "fear",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 10,
-                    "subtype": "area",
-                    "text": "10-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "cold",
-                    "formula": "1d8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "damage_type": "bleed",
-                    "formula": "1d6",
-                    "persistent": true,
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "persistent bleed damage",
-                    "aonid": 29,
-                    "game-obj": "Conditions",
-                    "name": "persistent bleed damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "Shattering Death",
-                "subtype": "ability",
-                "text": "When the blackfrost dead is destroyed, its body shatters like brittle ice, filling the air around it with a cloud of frigid, razor-sharp ice shards. Creatures in a 10-foot emanation take 1d8 cold damage per level of the blackfrost dead (minimum 3d8), with a basic Reflex save. Creatures that critically fail this save also take 1d6 persistent bleed damage.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "cold",
-                      "aonid": 27,
-                      "game-obj": "Traits",
-                      "name": "cold",
-                      "type": "link"
-                    },
-                    "name": "cold",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Blackfrost Dead Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -299,6 +61,97 @@
                 "game-obj": "Traits",
                 "name": "rare",
                 "type": "link"
+              },
+              {
+                "alt": "conjuration",
+                "aonid": 33,
+                "game-obj": "Traits",
+                "name": "conjuration",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "concealed",
+                "aonid": 4,
+                "game-obj": "Conditions",
+                "name": "concealed",
+                "type": "link"
+              },
+              {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "frightened 1",
+                "aonid": 19,
+                "game-obj": "Conditions",
+                "name": "frightened 1",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 27,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "persistent bleed damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent bleed damage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -308,7 +161,6 @@
         ],
         "name": "Blackfrost Dead Abilities",
         "subtype": "monster_family",
-        "text": "You can modify an existing undead creature to become blackfrost dead using the following abilities. All blackfrost dead bear the curse of blackfrost and have some way to inflict it, usually using one of their existing Strikes. Most blackfrost dead have one other ability from this list as well. As blackfrost dead stem from blackfrost itself, all blackfrost dead have the rare trait.",
         "type": "stat_block_section"
       }
     ],
@@ -316,6 +168,435 @@
   },
   "name": "Blackfrost Dead",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 5,
+              "subtype": "area",
+              "text": "5-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "frequency": "1d4 rounds",
+          "links": [
+            {
+              "alt": "concealed",
+              "aonid": 4,
+              "game-obj": "Conditions",
+              "name": "concealed",
+              "type": "link"
+            }
+          ],
+          "name": "Blackfrost Breath",
+          "subtype": "ability",
+          "text": "The blackfrost dead gasps sharply, then exhales a mist of dark-blue blackfrost particles in a 5-foot emanation. All creatures within the mist become concealed, and all creatures outside the mist become concealed to creatures within it. The mist persists for 1 minute. A creature that ends its turn in the mist is exposed to blackfrost. The blackfrost dead can't use Blackfrost Breath again for 1d4 rounds.",
+          "traits": [
+            {
+              "link": {
+                "alt": "conjuration",
+                "aonid": 33,
+                "game-obj": "Traits",
+                "name": "conjuration",
+                "type": "link"
+              },
+              "name": "conjuration",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Ice Climb",
+          "subtype": "ability",
+          "text": "The blackfrost dead can climb on ice as though it had the listed climb Speed. It ignores difficult terrain and greater difficult terrain from ice and snow and doesn't risk falling when crossing ice.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "mental",
+              "formula": "1d4",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "frightened 1",
+              "aonid": 19,
+              "game-obj": "Conditions",
+              "name": "frightened 1",
+              "type": "link"
+            }
+          ],
+          "name": "Mindburning Gaze",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "within 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The blackfrost dead fixes its terrifying gaze on a creature within 60 feet. The creature takes 1d4 mental damage per level of the blackfrost dead (minimum 2d4), with a basic Will save. On a critical failure, the creature is frightened 1.",
+          "traits": [
+            {
+              "link": {
+                "alt": "emotion",
+                "aonid": 60,
+                "game-obj": "Traits",
+                "name": "emotion",
+                "type": "link"
+              },
+              "name": "emotion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "fear",
+                "aonid": 68,
+                "game-obj": "Traits",
+                "name": "fear",
+                "type": "link"
+              },
+              "name": "fear",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 10,
+              "subtype": "area",
+              "text": "10-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "cold",
+              "formula": "1d8",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            },
+            {
+              "damage_type": "bleed",
+              "formula": "1d6",
+              "persistent": true,
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "persistent bleed damage",
+              "aonid": 29,
+              "game-obj": "Conditions",
+              "name": "persistent bleed damage",
+              "type": "link"
+            }
+          ],
+          "name": "Shattering Death",
+          "subtype": "ability",
+          "text": "When the blackfrost dead is destroyed, its body shatters like brittle ice, filling the air around it with a cloud of frigid, razor-sharp ice shards. Creatures in a 10-foot emanation take 1d8 cold damage per level of the blackfrost dead (minimum 3d8), with a basic Reflex save. Creatures that critically fail this save also take 1d6 persistent bleed damage.",
+          "traits": [
+            {
+              "link": {
+                "alt": "cold",
+                "aonid": 27,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              "name": "cold",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "curse of blackfrost",
+          "aonid": 51,
+          "game-obj": "Curses",
+          "name": "curse of blackfrost",
+          "type": "link"
+        },
+        {
+          "alt": "rare",
+          "aonid": 137,
+          "game-obj": "Traits",
+          "name": "rare",
+          "type": "link"
+        },
+        {
+          "alt": "conjuration",
+          "aonid": 33,
+          "game-obj": "Traits",
+          "name": "conjuration",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 120,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "concealed",
+          "aonid": 4,
+          "game-obj": "Conditions",
+          "name": "concealed",
+          "type": "link"
+        },
+        {
+          "alt": "emotion",
+          "aonid": 60,
+          "game-obj": "Traits",
+          "name": "emotion",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 68,
+          "game-obj": "Traits",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 120,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 163,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "frightened 1",
+          "aonid": 19,
+          "game-obj": "Conditions",
+          "name": "frightened 1",
+          "type": "link"
+        },
+        {
+          "alt": "cold",
+          "aonid": 27,
+          "game-obj": "Traits",
+          "name": "cold",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "persistent bleed damage",
+          "aonid": 29,
+          "game-obj": "Conditions",
+          "name": "persistent bleed damage",
+          "type": "link"
+        }
+      ],
+      "name": "Blackfrost Dead Abilities",
+      "sections": [
+        {
+          "links": [
+            {
+              "alt": "zombie",
+              "aonid": 103,
+              "game-obj": "MonsterFamilies",
+              "name": "zombie",
+              "type": "link"
+            },
+            {
+              "alt": "mummy",
+              "aonid": 74,
+              "game-obj": "MonsterFamilies",
+              "name": "mummy",
+              "type": "link"
+            },
+            {
+              "alt": "blackfrost",
+              "aonid": 51,
+              "game-obj": "Curses",
+              "name": "blackfrost",
+              "type": "link"
+            }
+          ],
+          "name": "Creating Blackfrost Dead",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #189: Dreamers of the Nameless Spires pg. 80",
+                "aonid": 195,
+                "game-obj": "Sources",
+                "name": "Pathfinder #189: Dreamers of the Nameless Spires pg. 80",
+                "type": "link"
+              },
+              "name": "Pathfinder #189: Dreamers of the Nameless Spires",
+              "page": 80,
+              "type": "source"
+            }
+          ],
+          "text": "The simplest way to create a blackfrost dead is to use an existing undead, such as a zombie or a mummy, as your base creature. Replace the creature's abilities with abilities from the list on this page. All blackfrost dead gain the cold trait and have at least one way to inflict blackfrost, often using one of their Strikes.",
+          "type": "section"
+        },
+        {
+          "name": "Curse of the Crown",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #189: Dreamers of the Nameless Spires pg. 80",
+                "aonid": 195,
+                "game-obj": "Sources",
+                "name": "Pathfinder #189: Dreamers of the Nameless Spires pg. 80",
+                "type": "link"
+              },
+              "name": "Pathfinder #189: Dreamers of the Nameless Spires",
+              "page": 80,
+              "type": "source"
+            }
+          ],
+          "text": "Blackfrost dead are found only around the Nameless Spires, under which a massive alien being named Osoyo remains imprisoned. Only recently has this ancient being stirred from its slumber, causing blackfrost to foam out of fissures in the ice and afflict unfortunate explorers. The spread of the blackfrost curse has been mercifully slow thus far, but with each creature afflicted, Osoyo's reach expands ever outward.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #189: Dreamers of the Nameless Spires pg. 80",
+            "aonid": 195,
+            "game-obj": "Sources",
+            "name": "Pathfinder #189: Dreamers of the Nameless Spires pg. 80",
+            "type": "link"
+          },
+          "name": "Pathfinder #189: Dreamers of the Nameless Spires",
+          "page": 80,
+          "type": "source"
+        }
+      ],
+      "text": "You can modify an existing undead creature to become blackfrost dead using the following abilities. All blackfrost dead bear the curse of blackfrost and have some way to inflict it, usually using one of their existing Strikes. Most blackfrost dead have one other ability from this list as well. As blackfrost dead stem from blackfrost itself, all blackfrost dead have the rare trait.  \n  \n**Blackfrost Breath** [##] (conjuration, occult) The blackfrost dead gasps sharply, then exhales a mist of dark-blue blackfrost particles in a 5-foot emanation. All creatures within the mist become concealed, and all creatures outside the mist become concealed to creatures within it. The mist persists for 1 minute. A creature that ends its turn in the mist is exposed to blackfrost. The blackfrost dead can't use Blackfrost Breath again for 1d4 rounds.  \n  \n**Ice Climb** The blackfrost dead can climb on ice as though it had the listed climb Speed. It ignores difficult terrain and greater difficult terrain from ice and snow and doesn't risk falling when crossing ice.  \n  \n**Mindburning Gaze** [##] (emotion, fear, necromancy, occult, visual) The blackfrost dead fixes its terrifying gaze on a creature within 60 feet. The creature takes 1d4 mental damage per level of the blackfrost dead (minimum 2d4), with a basic Will save. On a critical failure, the creature is frightened 1.  \n  \n**Shattering Death** (cold) When the blackfrost dead is destroyed, its body shatters like brittle ice, filling the air around it with a cloud of frigid, razor-sharp ice shards. Creatures in a 10-foot emanation take 1d8 cold damage per level of the blackfrost dead (minimum 3d8), with a basic Reflex save. Creatures that critically fail this save also take 1d6 persistent bleed damage.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/pathfinder_192_worst_of_all_possible_worlds/harrowkin.json
+++ b/monster_families/pathfinder_192_worst_of_all_possible_worlds/harrowkin.json
@@ -84,103 +84,42 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Defensive Suit",
-                "subtype": "ability",
-                "text": "When the harrowkin attempts a saving throw connected to its suit\u2014that is, Fortitude (Hammers or Shields), Reflex (Keys or Books), or Will (Stars or Crowns)\u2014if they roll a success, they get a critical success instead.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The harrowkin attempts to rewrite destiny. Roll 1d6 to determine a suit. The harrowkin gains the effects of the suit for 1 minute. If the suit matches the harrowkin's suit, the value is doubled.",
-                "name": "Read the Cards",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divination",
-                      "aonid": 47,
-                      "game-obj": "Traits",
-                      "name": "divination",
-                      "type": "link"
-                    },
-                    "name": "divination",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "trigger": "The harrowkin is about to roll initiative",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "At the end of the current round, all creatures currently in initiative reroll their initiative, using the same modifiers as their original initiative roll, and use the new initiative values for all following rounds.",
-                "frequency": "once per day",
-                "name": "Shuffle the Deck",
-                "requirement": "The harrowkin has rolled initiative",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divination",
-                      "aonid": 47,
-                      "game-obj": "Traits",
-                      "name": "divination",
-                      "type": "link"
-                    },
-                    "name": "divination",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 120,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Harrowkin Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -190,7 +129,6 @@
         ],
         "name": "Harrowkin Abilities",
         "subtype": "monster_family",
-        "text": "Each harrowkin is connected one specific harrow suit and has the following shared abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -198,6 +136,188 @@
   },
   "name": "Harrowkin",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Defensive Suit",
+          "subtype": "ability",
+          "text": "When the harrowkin attempts a saving throw connected to its suit\u2014that is, Fortitude (Hammers or Shields), Reflex (Keys or Books), or Will (Stars or Crowns)\u2014if they roll a success, they get a critical success instead.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The harrowkin attempts to rewrite destiny. Roll 1d6 to determine a suit. The harrowkin gains the effects of the suit for 1 minute. If the suit matches the harrowkin's suit, the value is doubled.",
+          "name": "Read the Cards",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              "name": "divination",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "trigger": "The harrowkin is about to roll initiative",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "At the end of the current round, all creatures currently in initiative reroll their initiative, using the same modifiers as their original initiative roll, and use the new initiative values for all following rounds.",
+          "frequency": "once per day",
+          "name": "Shuffle the Deck",
+          "requirement": "The harrowkin has rolled initiative",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divination",
+                "aonid": 47,
+                "game-obj": "Traits",
+                "name": "divination",
+                "type": "link"
+              },
+              "name": "divination",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 120,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divination",
+          "aonid": 47,
+          "game-obj": "Traits",
+          "name": "divination",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 120,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "divination",
+          "aonid": 47,
+          "game-obj": "Traits",
+          "name": "divination",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 120,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        }
+      ],
+      "name": "Harrowkin Abilities",
+      "sections": [
+        {
+          "name": "Ancient Harrowkin",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #192: Worst of All Possible Worlds pg. 82",
+                "aonid": 203,
+                "game-obj": "Sources",
+                "name": "Pathfinder #192: Worst of All Possible Worlds pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #192: Worst of All Possible Worlds",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "Some harrowkin form from ancient decks, even originating from the days before Earthfall. These harrowkin are especially powerful as they've spent a long time\u2014sometimes millennia\u2014learning to control their own abilities and their magical influence over the power of fate. These harrowkin are known to keep weaker harrowkin as companions or servants, living secluded lives in their own courts of fate. Unlike other harrowkin, ancient harrowkin have souls, agency, free will, and can be of any alignment.",
+          "type": "section"
+        },
+        {
+          "name": "Harrowkin Agency",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #192: Worst of All Possible Worlds pg. 82",
+                "aonid": 203,
+                "game-obj": "Sources",
+                "name": "Pathfinder #192: Worst of All Possible Worlds pg. 82",
+                "type": "link"
+              },
+              "name": "Pathfinder #192: Worst of All Possible Worlds",
+              "page": 82,
+              "type": "source"
+            }
+          ],
+          "text": "Harrowkin lack free will, despite being sapient. All are neutral, even in the case of fabled harrowkin whose legacies force them into specific roles. They do not possess souls. When slain they revert back to the card from which they sprang.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #192: Worst of All Possible Worlds pg. 82",
+            "aonid": 203,
+            "game-obj": "Sources",
+            "name": "Pathfinder #192: Worst of All Possible Worlds pg. 82",
+            "type": "link"
+          },
+          "name": "Pathfinder #192: Worst of All Possible Worlds",
+          "page": 82,
+          "type": "source"
+        }
+      ],
+      "text": "Each harrowkin is connected one specific harrow suit and has the following shared abilities.  \n  \n**Defensive Suit** When the harrowkin attempts a saving throw connected to its suit\u2014that is, Fortitude (Hammers or Shields), Reflex (Keys or Books), or Will (Stars or Crowns)\u2014if they roll a success, they get a critical success instead.  \n  \n**Read the Cards** [-] (divination, occult) **Trigger** The harrowkin is about to roll initiative; **Effect** The harrowkin attempts to rewrite destiny. Roll 1d6 to determine a suit. The harrowkin gains the effects of the suit for 1 minute. If the suit matches the harrowkin's suit, the value is doubled.   \n  \n**Shuffle the Deck** [-] (divination, occult) **Frequency** once per day; **Requirements** The harrowkin has rolled initiative; **Effect** At the end of the current round, all creatures currently in initiative reroll their initiative, using the same modifiers as their original initiative roll, and use the new initiative values for all following rounds.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/pathfinder_193_mantle_of_gold/sporeborn.json
+++ b/monster_families/pathfinder_193_mantle_of_gold/sporeborn.json
@@ -53,48 +53,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_type": "ability",
-                "name": "1st Level or Higher:",
-                "subtype": "ability",
-                "text": "The sporeborn gains one sporeborn ability.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "4th Level or Higher:",
-                "subtype": "ability",
-                "text": "The sporeborn gains two sporeborn abilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "7th Level or Higher:",
-                "subtype": "ability",
-                "text": "The sporeborn gains three sporeborn abilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "12th Level or Higher:",
-                "subtype": "ability",
-                "text": "The sporeborn gains four sporeborn abilities.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "17th Level or Higher:",
-                "subtype": "ability",
-                "text": "The sporeborn gains five sporeborn abilities.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Creating Sporeborn')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -109,104 +72,49 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_category": "hp_automatic",
-                    "ability_type": "ability",
-                    "name": "Consume Biomatter",
-                    "subtype": "ability",
-                    "text": "If the sporeborn is adjacent to a helpless or unconscious creature, or a deceased creature who died in the past hour, the sporeborn can consume its flesh with mycelium tendrils to heal itself. This restores an amount of Hit Points equal to the sporeborn's level. If the creature is alive, the sporeborn deals damage equal to one of its unarmed attacks.",
-                    "traits": [
-                      {
-                        "link": {
-                          "alt": "manipulate",
-                          "aonid": 104,
-                          "game-obj": "Traits",
-                          "name": "manipulate",
-                          "type": "link"
-                        },
-                        "name": "manipulate",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "special_sense",
-                    "ability_type": "ability",
-                    "name": "Contagious Spores",
-                    "subtype": "ability",
-                    "text": "The sporeborn continues to infect creatures with sporeborn infestation, creating more of its own kind.",
-                    "traits": [
-                      {
-                        "link": {
-                          "alt": "disease",
-                          "aonid": 46,
-                          "game-obj": "Traits",
-                          "name": "disease",
-                          "type": "link"
-                        },
-                        "name": "disease",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "link": {
-                          "alt": "fungus",
-                          "aonid": 77,
-                          "game-obj": "Traits",
-                          "name": "fungus",
-                          "type": "link"
-                        },
-                        "name": "fungus",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "hp_automatic",
-                    "ability_type": "ability",
-                    "name": "Sporeborn Infestation",
-                    "subtype": "ability",
-                    "text": "An infected creature can't heal damage it takes from sporeborn infestation until it has been cured of the disease.",
-                    "traits": [
-                      {
-                        "link": {
-                          "alt": "disease",
-                          "aonid": 46,
-                          "game-obj": "Traits",
-                          "name": "disease",
-                          "type": "link"
-                        },
-                        "name": "disease",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "link": {
-                          "alt": "fungus",
-                          "aonid": 77,
-                          "game-obj": "Traits",
-                          "name": "fungus",
-                          "type": "link"
-                        },
-                        "name": "fungus",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Creating Sporeborn')].sections[?(@.name=='Sporeborn Abilities You can modify sporeborn with the following sporeborn abilities. Most sporeborn have one of these abilities, gaining more at higher levels.')].abilities",
                     "target": "$.defense.automatic_abilities"
+                  }
+                ],
+                "links": [
+                  {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -221,169 +129,11 @@
           {
             "changes": [
               {
-                "abilities": [
-                  {
-                    "ability_type": "affliction",
-                    "name": "Stage 1",
-                    "stages": [
-                      {
-                        "name": "Stage 2",
-                        "subtype": "affliction_stage",
-                        "text": "1d6 poison damage (1 day)",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "name": "Stage 3",
-                        "subtype": "affliction_stage",
-                        "text": "2d6 poison damage (1 day)",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "name": "Stage 4",
-                        "subtype": "affliction_stage",
-                        "text": "3d6 poison damage (1 day)",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "name": "Stage 5",
-                        "subtype": "affliction_stage",
-                        "text": "dead, rising as an uncontrolled sporeborn immediately",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "ability",
-                    "text": "carrier with no ill effect (1 day);",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "automatic",
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "fungus",
-                        "aonid": 77,
-                        "game-obj": "Traits",
-                        "name": "fungus",
-                        "type": "link"
-                      },
-                      {
-                        "alt": "poison",
-                        "aonid": 126,
-                        "game-obj": "Traits",
-                        "name": "poison",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Fungal Armor",
-                    "subtype": "ability",
-                    "text": "The sporeborn grows broad patches of dense fungus on the outside of the corpse. It gains resistance to bludgeoning damage equal to its level. Potent Poison (fungus, poison) The sporeborn fungus enhances the dead creature's natural toxins rather than diminishing them. Increase the DC of poison and spore abilities of the base creature by 2 rather than decreasing them.",
-                    "traits": [
-                      {
-                        "link": {
-                          "alt": "fungus",
-                          "aonid": 77,
-                          "game-obj": "Traits",
-                          "name": "fungus",
-                          "type": "link"
-                        },
-                        "name": "fungus",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "automatic",
-                    "ability_type": "ability",
-                    "links": [
-                      {
-                        "alt": "sickened",
-                        "aonid": 34,
-                        "game-obj": "Conditions",
-                        "name": "sickened",
-                        "type": "link"
-                      }
-                    ],
-                    "name": "Rancid Spore Pods",
-                    "subtype": "ability",
-                    "text": "The sporeborn is covered in spore pods that rupture when it takes any piercing damage or a critical hit. In either case, adjacent creatures are hit with spores, causing them to become sickened 1 unless they succeed at a Fortitude save.",
-                    "traits": [
-                      {
-                        "link": {
-                          "alt": "disease",
-                          "aonid": 46,
-                          "game-obj": "Traits",
-                          "name": "disease",
-                          "type": "link"
-                        },
-                        "name": "disease",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "link": {
-                          "alt": "fungus",
-                          "aonid": 77,
-                          "game-obj": "Traits",
-                          "name": "fungus",
-                          "type": "link"
-                        },
-                        "name": "fungus",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "ability_category": "automatic",
-                    "ability_type": "ability",
-                    "damage": [
-                      {
-                        "damage_type": "poison",
-                        "formula": "1d6",
-                        "subtype": "attack_damage",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "name": "Spore Explosion",
-                    "subtype": "ability",
-                    "text": "When the sporeborn is destroyed, its body explodes, releasing toxic fumes and spores. Adjacent creatures take 1d6 poison damage per 2 levels (minimum 1d6) with a basic Fortitude save.",
-                    "traits": [
-                      {
-                        "link": {
-                          "alt": "fungus",
-                          "aonid": 77,
-                          "game-obj": "Traits",
-                          "name": "fungus",
-                          "type": "link"
-                        },
-                        "name": "fungus",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "link": {
-                          "alt": "inhaled",
-                          "aonid": 96,
-                          "game-obj": "Traits",
-                          "name": "inhaled",
-                          "type": "link"
-                        },
-                        "name": "inhaled",
-                        "subtype": "trait",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "type": "stat_block_section"
-                  }
-                ],
                 "change_category": "abilities",
                 "effects": [
                   {
                     "operation": "add_items",
-                    "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                    "source": "$.sections[?(@.name=='Creating Sporeborn')].sections[?(@.name=='Saving Throw')].abilities",
                     "target": "$.defense.automatic_abilities"
                   }
                 ],
@@ -394,6 +144,62 @@
                     "game-obj": "Rules",
                     "name": "DCs by Level table",
                     "type": "link"
+                  },
+                  {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "poison",
+                    "aonid": 126,
+                    "game-obj": "Traits",
+                    "name": "poison",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "sickened",
+                    "aonid": 34,
+                    "game-obj": "Conditions",
+                    "name": "sickened",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  {
+                    "alt": "inhaled",
+                    "aonid": 96,
+                    "game-obj": "Traits",
+                    "name": "inhaled",
+                    "type": "link"
                   }
                 ],
                 "subtype": "change",
@@ -403,11 +209,9 @@
             ],
             "name": "Saving Throw",
             "subtype": "monster_family",
-            "text": "Use a Fortitude save for the creature's level using the DCs by Level table.",
             "type": "stat_block_section"
           }
         ],
-        "text": "A sporeborn gains the fungus, mindless, rare, and sporeborn traits, and its alignment is usually adjusted to true neutral.The DC of any creature abilities it had in life are reduced by 2. Remove any traits that represent its life, such as animal or humanoid, as well as all languages, including telepathy. The sporeborn has an Intelligence and Charisma modifier of \u20135.  \n All Creatures: The sporeborn gains darkvision and scent as an imprecise sense up to 30 feet.",
         "type": "stat_block_section"
       }
     ],
@@ -415,6 +219,522 @@
   },
   "name": "Sporeborn",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_type": "ability",
+          "name": "1st Level or Higher:",
+          "subtype": "ability",
+          "text": "The sporeborn gains one sporeborn ability.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "4th Level or Higher:",
+          "subtype": "ability",
+          "text": "The sporeborn gains two sporeborn abilities.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "7th Level or Higher:",
+          "subtype": "ability",
+          "text": "The sporeborn gains three sporeborn abilities.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "12th Level or Higher:",
+          "subtype": "ability",
+          "text": "The sporeborn gains four sporeborn abilities.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "17th Level or Higher:",
+          "subtype": "ability",
+          "text": "The sporeborn gains five sporeborn abilities.",
+          "type": "stat_block_section"
+        }
+      ],
+      "name": "Creating Sporeborn",
+      "sections": [
+        {
+          "abilities": [
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Consume Biomatter",
+              "subtype": "ability",
+              "text": "If the sporeborn is adjacent to a helpless or unconscious creature, or a deceased creature who died in the past hour, the sporeborn can consume its flesh with mycelium tendrils to heal itself. This restores an amount of Hit Points equal to the sporeborn's level. If the creature is alive, the sporeborn deals damage equal to one of its unarmed attacks.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "manipulate",
+                    "aonid": 104,
+                    "game-obj": "Traits",
+                    "name": "manipulate",
+                    "type": "link"
+                  },
+                  "name": "manipulate",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "special_sense",
+              "ability_type": "ability",
+              "name": "Contagious Spores",
+              "subtype": "ability",
+              "text": "The sporeborn continues to infect creatures with sporeborn infestation, creating more of its own kind.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  "name": "fungus",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "hp_automatic",
+              "ability_type": "ability",
+              "name": "Sporeborn Infestation",
+              "subtype": "ability",
+              "text": "An infected creature can't heal damage it takes from sporeborn infestation until it has been cured of the disease.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  "name": "fungus",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "manipulate",
+              "aonid": 104,
+              "game-obj": "Traits",
+              "name": "manipulate",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "fungus",
+              "aonid": 77,
+              "game-obj": "Traits",
+              "name": "fungus",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "fungus",
+              "aonid": 77,
+              "game-obj": "Traits",
+              "name": "fungus",
+              "type": "link"
+            }
+          ],
+          "name": "Sporeborn Abilities You can modify sporeborn with the following sporeborn abilities. Most sporeborn have one of these abilities, gaining more at higher levels.",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #193: Mantle of Gold pg. 88",
+                "aonid": 206,
+                "game-obj": "Sources",
+                "name": "Pathfinder #193: Mantle of Gold pg. 88",
+                "type": "link"
+              },
+              "name": "Pathfinder #193: Mantle of Gold",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "**Consume Biomatter** (manipulate) If the sporeborn is adjacent to a helpless or unconscious creature, or a deceased creature who died in the past hour, the sporeborn can consume its flesh with mycelium tendrils to heal itself. This restores an amount of Hit Points equal to the sporeborn's level. If the creature is alive, the sporeborn deals damage equal to one of its unarmed attacks.  \n**Contagious Spores** (disease, fungus) The sporeborn continues to infect creatures with sporeborn infestation, creating more of its own kind.  \n**Sporeborn Infestation** (disease, fungus); An infected creature can't heal damage it takes from sporeborn infestation until it has been cured of the disease.",
+          "type": "section"
+        },
+        {
+          "abilities": [
+            {
+              "ability_type": "affliction",
+              "name": "Stage 1",
+              "stages": [
+                {
+                  "name": "Stage 2",
+                  "subtype": "affliction_stage",
+                  "text": "1d6 poison damage (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 3",
+                  "subtype": "affliction_stage",
+                  "text": "2d6 poison damage (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 4",
+                  "subtype": "affliction_stage",
+                  "text": "3d6 poison damage (1 day)",
+                  "type": "stat_block_section"
+                },
+                {
+                  "name": "Stage 5",
+                  "subtype": "affliction_stage",
+                  "text": "dead, rising as an uncontrolled sporeborn immediately",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "ability",
+              "text": "carrier with no ill effect (1 day);",
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "fungus",
+                  "aonid": 77,
+                  "game-obj": "Traits",
+                  "name": "fungus",
+                  "type": "link"
+                },
+                {
+                  "alt": "poison",
+                  "aonid": 126,
+                  "game-obj": "Traits",
+                  "name": "poison",
+                  "type": "link"
+                }
+              ],
+              "name": "Fungal Armor",
+              "subtype": "ability",
+              "text": "The sporeborn grows broad patches of dense fungus on the outside of the corpse. It gains resistance to bludgeoning damage equal to its level. Potent Poison (fungus, poison) The sporeborn fungus enhances the dead creature's natural toxins rather than diminishing them. Increase the DC of poison and spore abilities of the base creature by 2 rather than decreasing them.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  "name": "fungus",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "links": [
+                {
+                  "alt": "sickened",
+                  "aonid": 34,
+                  "game-obj": "Conditions",
+                  "name": "sickened",
+                  "type": "link"
+                }
+              ],
+              "name": "Rancid Spore Pods",
+              "subtype": "ability",
+              "text": "The sporeborn is covered in spore pods that rupture when it takes any piercing damage or a critical hit. In either case, adjacent creatures are hit with spores, causing them to become sickened 1 unless they succeed at a Fortitude save.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "disease",
+                    "aonid": 46,
+                    "game-obj": "Traits",
+                    "name": "disease",
+                    "type": "link"
+                  },
+                  "name": "disease",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  "name": "fungus",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            },
+            {
+              "ability_category": "automatic",
+              "ability_type": "ability",
+              "damage": [
+                {
+                  "damage_type": "poison",
+                  "formula": "1d6",
+                  "subtype": "attack_damage",
+                  "type": "stat_block_section"
+                }
+              ],
+              "name": "Spore Explosion",
+              "subtype": "ability",
+              "text": "When the sporeborn is destroyed, its body explodes, releasing toxic fumes and spores. Adjacent creatures take 1d6 poison damage per 2 levels (minimum 1d6) with a basic Fortitude save.",
+              "traits": [
+                {
+                  "link": {
+                    "alt": "fungus",
+                    "aonid": 77,
+                    "game-obj": "Traits",
+                    "name": "fungus",
+                    "type": "link"
+                  },
+                  "name": "fungus",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                },
+                {
+                  "link": {
+                    "alt": "inhaled",
+                    "aonid": 96,
+                    "game-obj": "Traits",
+                    "name": "inhaled",
+                    "type": "link"
+                  },
+                  "name": "inhaled",
+                  "subtype": "trait",
+                  "type": "stat_block_section"
+                }
+              ],
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "DCs by Level table",
+              "aonid": 554,
+              "game-obj": "Rules",
+              "name": "DCs by Level table",
+              "type": "link"
+            },
+            {
+              "alt": "fungus",
+              "aonid": 77,
+              "game-obj": "Traits",
+              "name": "fungus",
+              "type": "link"
+            },
+            {
+              "alt": "fungus",
+              "aonid": 77,
+              "game-obj": "Traits",
+              "name": "fungus",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "fungus",
+              "aonid": 77,
+              "game-obj": "Traits",
+              "name": "fungus",
+              "type": "link"
+            },
+            {
+              "alt": "sickened",
+              "aonid": 34,
+              "game-obj": "Conditions",
+              "name": "sickened",
+              "type": "link"
+            },
+            {
+              "alt": "fungus",
+              "aonid": 77,
+              "game-obj": "Traits",
+              "name": "fungus",
+              "type": "link"
+            },
+            {
+              "alt": "inhaled",
+              "aonid": 96,
+              "game-obj": "Traits",
+              "name": "inhaled",
+              "type": "link"
+            }
+          ],
+          "name": "Saving Throw",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #193: Mantle of Gold pg. 88",
+                "aonid": 206,
+                "game-obj": "Sources",
+                "name": "Pathfinder #193: Mantle of Gold pg. 88",
+                "type": "link"
+              },
+              "name": "Pathfinder #193: Mantle of Gold",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "Use a Fortitude save for the creature's level using the DCs by Level table.  \n**Stage 1** carrier with no ill effect (1 day);  \n**Stage 2** 1d6 poison damage (1 day);  \n**Stage 3** 2d6 poison damage (1 day);  \n**Stage 4** 3d6 poison damage (1 day);  \n**Stage 5** dead, rising as an uncontrolled sporeborn immediately  \n**Fungal Armor** (fungus) The sporeborn grows broad patches of dense fungus on the outside of the corpse. It gains resistance to bludgeoning damage equal to its level. Potent Poison (fungus, poison) The sporeborn fungus enhances the dead creature's natural toxins rather than diminishing them. Increase the DC of poison and spore abilities of the base creature by 2 rather than decreasing them.  \n**Rancid Spore Pods** (disease, fungus) The sporeborn is covered in spore pods that rupture when it takes any piercing damage or a critical hit. In either case, adjacent creatures are hit with spores, causing them to become sickened 1 unless they succeed at a Fortitude save.  \n**Spore Explosion** (fungus, inhaled) When the sporeborn is destroyed, its body explodes, releasing toxic fumes and spores. Adjacent creatures take 1d6 poison damage per 2 levels (minimum 1d6) with a basic Fortitude save.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "create undead",
+              "aonid": 10,
+              "game-obj": "Rituals",
+              "name": "create undead",
+              "type": "link"
+            }
+          ],
+          "name": "Creating Mycoguardians",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #193: Mantle of Gold pg. 88",
+                "aonid": 206,
+                "game-obj": "Sources",
+                "name": "Pathfinder #193: Mantle of Gold pg. 88",
+                "type": "link"
+              },
+              "name": "Pathfinder #193: Mantle of Gold",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "To create a mycoguardian, such as a sporeborn, a ritualist can perform a ritual similar to *create undead* called *create mycoguardian*, but providing valuable parasitic fungal spores instead of black onyx. This ritual uses Fungus Lore (trained) or Nature (expert) for both the Primary Check and Secondary Checks, and lacks the Evil trait.",
+          "type": "section"
+        },
+        {
+          "name": "Different Mycoguardians",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #193: Mantle of Gold pg. 88",
+                "aonid": 206,
+                "game-obj": "Sources",
+                "name": "Pathfinder #193: Mantle of Gold pg. 88",
+                "type": "link"
+              },
+              "name": "Pathfinder #193: Mantle of Gold",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "In addition to the sporeborn presented here, there are many versions of the create mycoguardian ritual for making mycoguardians other than sporeborn, such as for aquatic chytridions and so on. Some forms of mycoguardians, such as mycelial mindbores, come to be using their own unique methods and can't be created with a version of *create mycoguardian*.",
+          "type": "section"
+        },
+        {
+          "name": "Fungal Ritualists",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #193: Mantle of Gold pg. 88",
+                "aonid": 206,
+                "game-obj": "Sources",
+                "name": "Pathfinder #193: Mantle of Gold pg. 88",
+                "type": "link"
+              },
+              "name": "Pathfinder #193: Mantle of Gold",
+              "page": 88,
+              "type": "source"
+            }
+          ],
+          "text": "While mycoguardians are rare, several different types of primal spellcasters might create a mycoguardian. Druids might turn the bodies of a poacher's victim against the poacher, seeking to avenge the wrongful death and rebalance the scales of life. Leshy spellcasters create mycoguardians to protect their hidden communities and sacred groves.  \n The fey of Northern Fangwood transform fallen or rotted trees into crustoreal mycoguardians, massive arboreal-looking creatures covered in parasitic lichen. These lumbering sentinels patrol their borders, crushing all non-fey who dare approach. There are rumors of crustoreals being imbued with negative energy from the Gravelands and going berserk.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #193: Mantle of Gold pg. 88",
+            "aonid": 206,
+            "game-obj": "Sources",
+            "name": "Pathfinder #193: Mantle of Gold pg. 88",
+            "type": "link"
+          },
+          "name": "Pathfinder #193: Mantle of Gold",
+          "page": 88,
+          "type": "source"
+        }
+      ],
+      "text": "A sporeborn gains the fungus, mindless, rare, and sporeborn traits, and its alignment is usually adjusted to true neutral.The DC of any creature abilities it had in life are reduced by 2. Remove any traits that represent its life, such as animal or humanoid, as well as all languages, including telepathy. The sporeborn has an Intelligence and Charisma modifier of \u20135.  \n All Creatures: The sporeborn gains darkvision and scent as an imprecise sense up to 30 feet.  \n**1st Level or Higher:** The sporeborn gains one sporeborn ability.  \n**4th Level or Higher:** The sporeborn gains two sporeborn abilities.  \n**7th Level or Higher:** The sporeborn gains three sporeborn abilities.  \n**12th Level or Higher:** The sporeborn gains four sporeborn abilities.  \n**17th Level or Higher:** The sporeborn gains five sporeborn abilities.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/pathfinder_202_severed_at_the_root/woodblessed.json
+++ b/monster_families/pathfinder_202_severed_at_the_root/woodblessed.json
@@ -185,202 +185,84 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 20,
-                    "subtype": "area",
-                    "text": "20-foot burst",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Explosive End",
-                "subtype": "ability",
-                "text": "When the woodblessed dies, the planar portal inside of them collapses, causing them to explode in a 20-foot burst of vines that deal 1d6 bludgeoning damage per level to all creatures with a basic Reflex save against the woodblessed's spell DC. The woodblessed's body is completely consumed, though their root network and gear remain behind.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "wood",
-                      "aonid": 508,
-                      "game-obj": "Traits",
-                      "name": "wood",
-                      "type": "link"
-                    },
-                    "name": "wood",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Luminant Aura",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The volatile planar energy coursing through a woodblessed's veins fills the area with dim light.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "light",
-                      "aonid": 640,
-                      "game-obj": "Traits",
-                      "name": "light",
-                      "type": "link"
-                    },
-                    "name": "light",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "timber",
-                    "aonid": 1412,
-                    "game-obj": "Spells",
-                    "name": "timber",
-                    "type": "link"
-                  }
-                ],
-                "name": "Primal Innate Spells",
-                "subtype": "ability",
-                "text": "A woodblessed can cast *timber* as an innate primal cantrip.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Reaction",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "damage": [
-                  {
-                    "damage_type": "piercing",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "effect": "Distracted by the pain, the woodblessed's concentration slips and splinters erupt from their body as they temporarily lose control of the planar energy within them. Both the triggering creature and the woodblessed take 1d6 piercing damage + 1d6 per 2 levels the woodblessed has, with a basic Reflex save against the woodblessed's spell DC.",
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Reactive Flare",
-                "subtype": "ability",
-                "trigger": "The woodblessed is damaged by a creature within their reach",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Tap Planar Gate",
-                "subtype": "ability",
-                "text": "The woodblessed empowers themself or their next attack.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Woodblessed Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "wood",
+                "aonid": 508,
+                "game-obj": "Traits",
+                "name": "wood",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 640,
+                "game-obj": "Traits",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "timber",
+                "aonid": 1412,
+                "game-obj": "Spells",
+                "name": "timber",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "persistent bleed damage",
+                "aonid": 29,
+                "game-obj": "Conditions",
+                "name": "persistent bleed damage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -390,7 +272,6 @@
         ],
         "name": "Woodblessed Abilities",
         "subtype": "monster_family",
-        "text": "All woodblessed gain the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -398,6 +279,310 @@
   },
   "name": "Woodblessed",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "burst",
+              "size": 20,
+              "subtype": "area",
+              "text": "20-foot burst",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "bludgeoning",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Explosive End",
+          "subtype": "ability",
+          "text": "When the woodblessed dies, the planar portal inside of them collapses, causing them to explode in a 20-foot burst of vines that deal 1d6 bludgeoning damage per level to all creatures with a basic Reflex save against the woodblessed's spell DC. The woodblessed's body is completely consumed, though their root network and gear remain behind.",
+          "traits": [
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "wood",
+                "aonid": 508,
+                "game-obj": "Traits",
+                "name": "wood",
+                "type": "link"
+              },
+              "name": "wood",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Luminant Aura",
+          "range": {
+            "range": 20,
+            "subtype": "range",
+            "text": "20 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The volatile planar energy coursing through a woodblessed's veins fills the area with dim light.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "light",
+                "aonid": 640,
+                "game-obj": "Traits",
+                "name": "light",
+                "type": "link"
+              },
+              "name": "light",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "timber",
+              "aonid": 1412,
+              "game-obj": "Spells",
+              "name": "timber",
+              "type": "link"
+            }
+          ],
+          "name": "Primal Innate Spells",
+          "subtype": "ability",
+          "text": "A woodblessed can cast *timber* as an innate primal cantrip.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Reaction",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "damage": [
+            {
+              "damage_type": "piercing",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "effect": "Distracted by the pain, the woodblessed's concentration slips and splinters erupt from their body as they temporarily lose control of the planar energy within them. Both the triggering creature and the woodblessed take 1d6 piercing damage + 1d6 per 2 levels the woodblessed has, with a basic Reflex save against the woodblessed's spell DC.",
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Reactive Flare",
+          "subtype": "ability",
+          "trigger": "The woodblessed is damaged by a creature within their reach",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Tap Planar Gate",
+          "subtype": "ability",
+          "text": "The woodblessed empowers themself or their next attack.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "wood",
+          "aonid": 508,
+          "game-obj": "Traits",
+          "name": "wood",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 640,
+          "game-obj": "Traits",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "timber",
+          "aonid": 1412,
+          "game-obj": "Spells",
+          "name": "timber",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "persistent bleed damage",
+          "aonid": 29,
+          "game-obj": "Conditions",
+          "name": "persistent bleed damage",
+          "type": "link"
+        }
+      ],
+      "name": "Woodblessed Abilities",
+      "sections": [
+        {
+          "name": "Creating Woodblessed",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #202: Severed at the Root pg. 85",
+                "aonid": 242,
+                "game-obj": "Sources",
+                "name": "Pathfinder #202: Severed at the Root pg. 85",
+                "type": "link"
+              },
+              "name": "Pathfinder #202: Severed at the Root",
+              "page": 85,
+              "type": "source"
+            }
+          ],
+          "text": "Apply the following to turn a living creature into a woodblessed.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #202: Severed at the Root pg. 85",
+            "aonid": 242,
+            "game-obj": "Sources",
+            "name": "Pathfinder #202: Severed at the Root pg. 85",
+            "type": "link"
+          },
+          "name": "Pathfinder #202: Severed at the Root",
+          "page": 85,
+          "type": "source"
+        }
+      ],
+      "text": "All woodblessed gain the following abilities.  \n  \n**Explosive End** (primal, wood) When the woodblessed dies, the planar portal inside of them collapses, causing them to explode in a 20-foot burst of vines that deal 1d6 bludgeoning damage per level to all creatures with a basic Reflex save against the woodblessed's spell DC. The woodblessed's body is completely consumed, though their root network and gear remain behind.  \n  \n**Luminant Aura** (aura, light) 20 feet. The volatile planar energy coursing through a woodblessed's veins fills the area with dim light.  \n  \n**Primal Innate Spells** A woodblessed can cast *timber* as an innate primal cantrip.  \n  \n**Reactive Flare** [@] **Trigger** The woodblessed is damaged by a creature within their reach; **Effect** Distracted by the pain, the woodblessed's concentration slips and splinters erupt from their body as they temporarily lose control of the planar energy within them. Both the triggering creature and the woodblessed take 1d6 piercing damage + 1d6 per 2 levels the woodblessed has, with a basic Reflex save against the woodblessed's spell DC.  \n  \n**Tap Planar Gate** [#] (concentrate, primal) The woodblessed empowers themself or their next attack.  \n If the woodblessed's next action is to Stride, is launched off the ground by a suddenly sprouting tree and propelled forward. During this Stride, they have a fly Speed equal to their Speed. If they don't end their movement on a solid surface that can support their weight, they fall.  \n If the woodblessed's next action is a Strike, the attack sprouts thorns that deal an additional 1d4 persistent bleed damage (1d6 for levels 6\u201312, 1d10 for levels 13+).",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/pathfinder_207_resurrection_flood/floodslain_creature.json
+++ b/monster_families/pathfinder_207_resurrection_flood/floodslain_creature.json
@@ -154,430 +154,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Darkvision",
-                  "aonid": 59,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Darkvision",
-                  "type": "link"
-                },
-                "name": "Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 59,
-                  "edition": "remastered",
-                  "game-id": "8ec277ab70576ba965a6c33f34a8773e",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "darkvision",
-                      "aonid": 415,
-                      "game-obj": "Rules",
-                      "name": "darkvision",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 409,
-                      "game-obj": "Rules",
-                      "name": "darkness",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "dim light",
-                      "aonid": 408,
-                      "game-obj": "Rules",
-                      "name": "dim light",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "darkness",
-                      "aonid": 1480,
-                      "game-obj": "Spells",
-                      "name": "darkness",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Darkvision",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 359",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 359",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 359,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 83,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 571,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 696,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyzed, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Drowning Touch",
-                "subtype": "ability",
-                "text": "When the floodslain creature damages a creature with a non-weapon melee  attack, the target's lungs begin to fill with water. The target must attempt a Fortitude save against the floodslain's Will DC. A target affected by Drowning Touch can spend a single action coughing in an attempt to recover, which immediately lets them attempt a new Fortitude save against the effect. A success improves the previous result by 1 step. A critical success improves the previous result by 2, and a critical failure decreases it by 1.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "slowed 1",
-                    "aonid": 92,
-                    "game-obj": "Conditions",
-                    "name": "slowed 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is slowed 1 for 1 round.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature is slowed 2 for 1 round.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "drowning",
-                    "aonid": 2439,
-                    "game-obj": "Rules",
-                    "name": "drowning",
-                    "type": "link"
-                  }
-                ],
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "The creature is slowed 2 and drowning.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "animal",
-                    "aonid": 531,
-                    "game-obj": "Traits",
-                    "name": "animal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "humanoid",
-                    "aonid": 628,
-                    "game-obj": "Traits",
-                    "name": "humanoid",
-                    "type": "link"
-                  }
-                ],
-                "name": "Floodslain Spawn",
-                "subtype": "ability",
-                "text": "A living animal or humanoid killed by a floodslain creature will rise as a floodslain if their corpse is left in water for 24 hours. The new floodslain isn't under the control of the floodslain creature that killed it.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Hard to Burn",
-                "subtype": "ability",
-                "text": "The creature gains resistance to fire damage equal to its level (minimum 1).",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Sodden Ground",
-                "range": {
-                  "range": 20,
-                  "subtype": "range",
-                  "text": "20 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "Water flows endlessly from a floodslain creature, making the area around it slippery. The ground in the aura is difficult terrain for all non-floodslain creatures.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "water",
-                      "aonid": 732,
-                      "game-obj": "Traits",
-                      "name": "water",
-                      "type": "link"
-                    },
-                    "name": "water",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "name": "Swimmer",
-                "subtype": "ability",
-                "text": "Despite their ungainly appearance, floodslain are excellent swimmers. The creature gains a swim Speed equal to its base Speed.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "cone",
-                    "size": 15,
-                    "subtype": "area",
-                    "text": "15-foot cone",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "bludgeoning",
-                    "formula": "1d8",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  }
-                ],
-                "name": "Vomit Flotsam",
-                "subtype": "ability",
-                "text": "A floodslain creature's body is filled with debris from their horrific death, which they can spew at their enemies. The floodslain vomits flotsam in a 15-foot cone. Any creature in the area takes 1d8 bludgeoning damage per level of the floodslain creature (minimum 1d8) with a basic Reflex save against the floodslain's Fortitude DC.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "occult",
-                      "aonid": 662,
-                      "game-obj": "Traits",
-                      "name": "occult",
-                      "type": "link"
-                    },
-                    "name": "occult",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Floodslain Creature Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -595,6 +176,132 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Darkvision",
+                "aonid": 59,
+                "game-obj": "MonsterAbilities",
+                "name": "Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 83,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 571,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 696,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "slowed 1",
+                "aonid": 92,
+                "game-obj": "Conditions",
+                "name": "slowed 1",
+                "type": "link"
+              },
+              {
+                "alt": "drowning",
+                "aonid": 2439,
+                "game-obj": "Rules",
+                "name": "drowning",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "animal",
+                "aonid": 531,
+                "game-obj": "Traits",
+                "name": "animal",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid",
+                "aonid": 628,
+                "game-obj": "Traits",
+                "name": "humanoid",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "water",
+                "aonid": 732,
+                "game-obj": "Traits",
+                "name": "water",
+                "type": "link"
+              },
+              {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -604,7 +311,6 @@
         ],
         "name": "Floodslain Creature Abilities",
         "subtype": "monster_family",
-        "text": "A floodslain creature gains the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might need to adjust or remove other abilities that conflict with the floodslain's theme as an undead creature.",
         "type": "stat_block_section"
       }
     ],
@@ -646,6 +352,626 @@
         }
       ],
       "text": "You can build a floodslain creature from the ground up using the standard rules for monster creation (which is how the floodslain orc and floodslain wolf were built), or you can turn an existing creature into a floodslain creature by completing the following steps. In either case, the specific floodslain creature abilities listed below work the same.  \n  \n Select a creature that has the animal or humanoid trait; this is the base creature. Increase the creature's level by 1 and change its statistics as follows. \n\n|  |  |\n| --- | --- |\n| **Starting Level** | **HP Increase** |\n| 1 or lower  | +10 |\n| 2\u20134  | +15 |\n| 5\u201319  | +20 |\n| 20+  | +30 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Darkvision",
+            "aonid": 59,
+            "game-obj": "MonsterAbilities",
+            "name": "Darkvision",
+            "type": "link"
+          },
+          "name": "Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 59,
+            "edition": "remastered",
+            "game-id": "8ec277ab70576ba965a6c33f34a8773e",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "darkvision",
+                "aonid": 415,
+                "game-obj": "Rules",
+                "name": "darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 409,
+                "game-obj": "Rules",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "dim light",
+                "aonid": 408,
+                "game-obj": "Rules",
+                "name": "dim light",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              }
+            ],
+            "name": "Darkvision",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 359",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 359",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 359,
+                "type": "source"
+              }
+            ],
+            "text": "A monster with darkvision can see perfectly well in areas of darkness and dim light, though such vision is in black and white only. Some forms of magical darkness, such as a 4th-level *darkness* spell, block normal darkvision. A monster with greater darkvision, however, can see through even these forms of magical darkness.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 83,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 571,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 696,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "death effects, disease, paralyzed, poison, sleep",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Drowning Touch",
+          "subtype": "ability",
+          "text": "When the floodslain creature damages a creature with a non-weapon melee  attack, the target's lungs begin to fill with water. The target must attempt a Fortitude save against the floodslain's Will DC. A target affected by Drowning Touch can spend a single action coughing in an attempt to recover, which immediately lets them attempt a new Fortitude save against the effect. A success improves the previous result by 1 step. A critical success improves the previous result by 2, and a critical failure decreases it by 1.",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "slowed 1",
+              "aonid": 92,
+              "game-obj": "Conditions",
+              "name": "slowed 1",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is slowed 1 for 1 round.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature is slowed 2 for 1 round.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "drowning",
+              "aonid": 2439,
+              "game-obj": "Rules",
+              "name": "drowning",
+              "type": "link"
+            }
+          ],
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "The creature is slowed 2 and drowning.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "animal",
+              "aonid": 531,
+              "game-obj": "Traits",
+              "name": "animal",
+              "type": "link"
+            },
+            {
+              "alt": "humanoid",
+              "aonid": 628,
+              "game-obj": "Traits",
+              "name": "humanoid",
+              "type": "link"
+            }
+          ],
+          "name": "Floodslain Spawn",
+          "subtype": "ability",
+          "text": "A living animal or humanoid killed by a floodslain creature will rise as a floodslain if their corpse is left in water for 24 hours. The new floodslain isn't under the control of the floodslain creature that killed it.",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Hard to Burn",
+          "subtype": "ability",
+          "text": "The creature gains resistance to fire damage equal to its level (minimum 1).",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Sodden Ground",
+          "range": {
+            "range": 20,
+            "subtype": "range",
+            "text": "20 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "Water flows endlessly from a floodslain creature, making the area around it slippery. The ground in the aura is difficult terrain for all non-floodslain creatures.",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "water",
+                "aonid": 732,
+                "game-obj": "Traits",
+                "name": "water",
+                "type": "link"
+              },
+              "name": "water",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "name": "Swimmer",
+          "subtype": "ability",
+          "text": "Despite their ungainly appearance, floodslain are excellent swimmers. The creature gains a swim Speed equal to its base Speed.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "cone",
+              "size": 15,
+              "subtype": "area",
+              "text": "15-foot cone",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "bludgeoning",
+              "formula": "1d8",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            }
+          ],
+          "name": "Vomit Flotsam",
+          "subtype": "ability",
+          "text": "A floodslain creature's body is filled with debris from their horrific death, which they can spew at their enemies. The floodslain vomits flotsam in a 15-foot cone. Any creature in the area takes 1d8 bludgeoning damage per level of the floodslain creature (minimum 1d8) with a basic Reflex save against the floodslain's Fortitude DC.",
+          "traits": [
+            {
+              "link": {
+                "alt": "occult",
+                "aonid": 662,
+                "game-obj": "Traits",
+                "name": "occult",
+                "type": "link"
+              },
+              "name": "occult",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "human",
+          "aonid": 627,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Darkvision",
+          "aonid": 59,
+          "game-obj": "MonsterAbilities",
+          "name": "Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 571,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 696,
+          "game-obj": "Traits",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "slowed 1",
+          "aonid": 92,
+          "game-obj": "Conditions",
+          "name": "slowed 1",
+          "type": "link"
+        },
+        {
+          "alt": "drowning",
+          "aonid": 2439,
+          "game-obj": "Rules",
+          "name": "drowning",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "animal",
+          "aonid": 531,
+          "game-obj": "Traits",
+          "name": "animal",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "water",
+          "aonid": 732,
+          "game-obj": "Traits",
+          "name": "water",
+          "type": "link"
+        },
+        {
+          "alt": "occult",
+          "aonid": 662,
+          "game-obj": "Traits",
+          "name": "occult",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        }
+      ],
+      "name": "Floodslain Creature Abilities",
+      "sections": [
+        {
+          "name": "In Search of Water",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #207: Resurrection Flood pg. 84",
+                "aonid": 249,
+                "game-obj": "Sources",
+                "name": "Pathfinder #207: Resurrection Flood pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #207: Resurrection Flood",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "Floodslain tend to move toward lower ground, instinctively seeking water. Belkzen's flat floodplains, however, mean that the creatures wander in unpredictable ways. A common saying among old orc crafters is \u201cbuild on high, keep dry,\u201d but many add \u201cbuild low, the dead flow.\u201d",
+          "type": "section"
+        },
+        {
+          "name": "Panicked Eyes",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #207: Resurrection Flood pg. 84",
+                "aonid": 249,
+                "game-obj": "Sources",
+                "name": "Pathfinder #207: Resurrection Flood pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #207: Resurrection Flood",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "One distinctive feature all floodslain share are their wide, panicstricken eyes. A floodslain's gaze is permanently frozen in the expression of terror the creature felt moments before its death. Some floodslain are rumored to have the ability to spread this fear to others with a mere glance.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #207: Resurrection Flood pg. 84",
+            "aonid": 249,
+            "game-obj": "Sources",
+            "name": "Pathfinder #207: Resurrection Flood pg. 84",
+            "type": "link"
+          },
+          "name": "Pathfinder #207: Resurrection Flood",
+          "page": 84,
+          "type": "source"
+        }
+      ],
+      "text": "A floodslain creature gains the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might need to adjust or remove other abilities that conflict with the floodslain's theme as an undead creature.  \n  \n**Darkvision**  \n**Void Healing**  \n**Immunities** death effects, disease, paralyzed, poison, sleep  \n**Drowning Touch** (occult) When the floodslain creature damages a creature with a non-weapon melee attack, the target's lungs begin to fill with water. The target must attempt a Fortitude save against the floodslain's Will DC. A target affected by Drowning Touch can spend a single action coughing in an attempt to recover, which immediately lets them attempt a new Fortitude save against the effect. A success improves the previous result by 1 step. A critical success improves the previous result by 2, and a critical failure decreases it by 1.  \n**Critical Success** The creature is unaffected.  \n**Success** The creature is slowed 1 for 1 round.  \n**Failure** The creature is slowed 2 for 1 round.  \n**Critical Failure** The creature is slowed 2 and drowning.  \n**Floodslain Spawn** (occult) A living animal or humanoid killed by a floodslain creature will rise as a floodslain if their corpse is left in water for 24 hours. The new floodslain isn't under the control of the floodslain creature that killed it.  \n**Hard to Burn** The creature gains resistance to fire damage equal to its level (minimum 1).  \n**Sodden Ground** (aura, occult, water) 20 feet. Water flows endlessly from a floodslain creature, making the area around it slippery. The ground in the aura is difficult terrain for all non-floodslain creatures.  \n**Swimmer** Despite their ungainly appearance, floodslain are excellent swimmers. The creature gains a swim Speed equal to its base Speed.  \n**Vomit Flotsam** [##] (occult) A floodslain creature's body is filled with debris from their horrific death, which they can spew at their enemies. The floodslain vomits flotsam in a 15-foot cone. Any creature in the area takes 1d8 bludgeoning damage per level of the floodslain creature (minimum 1d8) with a basic Reflex save against the floodslain's Fortitude DC.",
       "type": "section"
     }
   ],

--- a/monster_families/pathfinder_212_a_voice_in_the_blight/blight.json
+++ b/monster_families/pathfinder_212_a_voice_in_the_blight/blight.json
@@ -53,198 +53,154 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 1501,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "animals",
-                    "aonid": 531,
-                    "game-obj": "Traits",
-                    "name": "animals",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "beasts",
-                    "aonid": 547,
-                    "game-obj": "Traits",
-                    "name": "beasts",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fungi",
-                    "aonid": 614,
-                    "game-obj": "Traits",
-                    "name": "fungi",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "oozes",
-                    "aonid": 665,
-                    "game-obj": "Traits",
-                    "name": "oozes",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "plants",
-                    "aonid": 668,
-                    "game-obj": "Traits",
-                    "name": "plants",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "mental",
-                    "aonid": 647,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Blight Domination",
-                "subtype": "ability",
-                "text": "All blights can cast *dominate* as an innate primal spell but can target only animals, beasts, fungi, oozes, or plants that are located inside their cursed domain. If a creature dominated by this spell leaves the cursed domain, the effects of dominate immediately end, but as long as the dominated creature remains in the cursed domain, the duration is unlimited. When a blight targets a mindless fungi, ooze, or plant, its *dominate* spell loses the mental trait.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 5,
-                    "subtype": "area",
-                    "text": "5-mile radius",
-                    "type": "stat_block_section",
-                    "unit": "miles"
-                  }
-                ],
-                "frequency": "Once per year",
-                "name": "Cursed Domain",
-                "subtype": "ability",
-                "text": "Once per year, when in a terrain that is compatible with its type (such as a swamp for a swamp blight), the blight can infuse the land around it with its corrupted essence by performing a rite that takes one day. The region in a 5-mile radius becomes its cursed domain; this effect does not extend into incompatible terrain and does not move with the blight. The point at which the blight cursed the domain becomes its epicenter.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "curse",
-                      "aonid": 566,
-                      "game-obj": "Traits",
-                      "name": "curse",
-                      "type": "link"
-                    },
-                    "name": "curse",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "burst",
-                    "size": 500,
-                    "subtype": "area",
-                    "text": "500-foot radius",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 1501,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  }
-                ],
-                "name": "Oversee Domain",
-                "subtype": "ability",
-                "text": "The blight projects its senses to any point in its cursed domain, gaining a precise sense of its surroundings with a 500-foot radius until the end of its next turn. A blight can cast *dominate* through this sensory link. A blight can Sustain this ability, but cannot use it to extend its senses beyond the edges of its domain.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Rejuvenation",
-                "subtype": "ability",
-                "text": "If a blight is slain within its cursed domain, its body melts into the surrounding environment and a new blight of the same type spontaneously forms in 1d10 days at the cursed domain's epicenter unless the curse is removed before then. The new blight retains all the memories of the previous blight.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "primal",
-                      "aonid": 676,
-                      "game-obj": "Traits",
-                      "name": "primal",
-                      "type": "link"
-                    },
-                    "name": "primal",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Blight Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "animals",
+                "aonid": 531,
+                "game-obj": "Traits",
+                "name": "animals",
+                "type": "link"
+              },
+              {
+                "alt": "beasts",
+                "aonid": 547,
+                "game-obj": "Traits",
+                "name": "beasts",
+                "type": "link"
+              },
+              {
+                "alt": "fungi",
+                "aonid": 614,
+                "game-obj": "Traits",
+                "name": "fungi",
+                "type": "link"
+              },
+              {
+                "alt": "oozes",
+                "aonid": 665,
+                "game-obj": "Traits",
+                "name": "oozes",
+                "type": "link"
+              },
+              {
+                "alt": "plants",
+                "aonid": 668,
+                "game-obj": "Traits",
+                "name": "plants",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "difficult terrain",
+                "aonid": 453,
+                "game-obj": "Rules",
+                "name": "difficult terrain",
+                "type": "link"
+              },
+              {
+                "alt": "Cover Tracks",
+                "aonid": 2407,
+                "game-obj": "Actions",
+                "name": "Cover Tracks",
+                "type": "link"
+              },
+              {
+                "alt": "imprecise",
+                "aonid": 412,
+                "game-obj": "Rules",
+                "name": "imprecise",
+                "type": "link"
+              },
+              {
+                "alt": "telepathy",
+                "aonid": 79,
+                "game-obj": "MonsterAbilities",
+                "name": "telepathy",
+                "type": "link"
+              },
+              {
+                "alt": "slowed 1",
+                "aonid": 92,
+                "game-obj": "Conditions",
+                "name": "slowed 1",
+                "type": "link"
+              },
+              {
+                "alt": "Break Curse",
+                "aonid": 5128,
+                "game-obj": "Feats",
+                "name": "Break Curse",
+                "type": "link"
+              },
+              {
+                "alt": "counteract",
+                "aonid": 371,
+                "game-obj": "Rules",
+                "name": "counteract",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -254,7 +210,6 @@
         ],
         "name": "Blight Abilities",
         "subtype": "monster_family",
-        "text": "All blights possess the following abilities.",
         "type": "stat_block_section"
       }
     ],
@@ -262,6 +217,376 @@
   },
   "name": "Blight",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "dominate",
+              "aonid": 1501,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            },
+            {
+              "alt": "animals",
+              "aonid": 531,
+              "game-obj": "Traits",
+              "name": "animals",
+              "type": "link"
+            },
+            {
+              "alt": "beasts",
+              "aonid": 547,
+              "game-obj": "Traits",
+              "name": "beasts",
+              "type": "link"
+            },
+            {
+              "alt": "fungi",
+              "aonid": 614,
+              "game-obj": "Traits",
+              "name": "fungi",
+              "type": "link"
+            },
+            {
+              "alt": "oozes",
+              "aonid": 665,
+              "game-obj": "Traits",
+              "name": "oozes",
+              "type": "link"
+            },
+            {
+              "alt": "plants",
+              "aonid": 668,
+              "game-obj": "Traits",
+              "name": "plants",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            }
+          ],
+          "name": "Blight Domination",
+          "subtype": "ability",
+          "text": "All blights can cast *dominate* as an innate primal spell but can target only animals, beasts, fungi, oozes, or plants that are located inside their cursed domain. If a creature dominated by this spell leaves the cursed domain, the effects of dominate immediately end, but as long as the dominated creature remains in the cursed domain, the duration is unlimited. When a blight targets a mindless fungi, ooze, or plant, its *dominate* spell loses the mental trait.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "area": [
+            {
+              "shape": "burst",
+              "size": 5,
+              "subtype": "area",
+              "text": "5-mile radius",
+              "type": "stat_block_section",
+              "unit": "miles"
+            }
+          ],
+          "frequency": "Once per year",
+          "name": "Cursed Domain",
+          "subtype": "ability",
+          "text": "Once per year, when in a terrain that is compatible with its type (such as a swamp for a swamp blight), the blight can infuse the land around it with its corrupted essence by performing a rite that takes one day. The region in a 5-mile radius becomes its cursed domain; this effect does not extend into incompatible terrain and does not move with the blight. The point at which the blight cursed the domain becomes its epicenter.",
+          "traits": [
+            {
+              "link": {
+                "alt": "curse",
+                "aonid": 566,
+                "game-obj": "Traits",
+                "name": "curse",
+                "type": "link"
+              },
+              "name": "curse",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "burst",
+              "size": 500,
+              "subtype": "area",
+              "text": "500-foot radius",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "links": [
+            {
+              "alt": "dominate",
+              "aonid": 1501,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            }
+          ],
+          "name": "Oversee Domain",
+          "subtype": "ability",
+          "text": "The blight projects its senses to any point in its cursed domain, gaining a precise sense of its surroundings with a 500-foot radius until the end of its next turn. A blight can cast *dominate* through this sensory link. A blight can Sustain this ability, but cannot use it to extend its senses beyond the edges of its domain.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Rejuvenation",
+          "subtype": "ability",
+          "text": "If a blight is slain within its cursed domain, its body melts into the surrounding environment and a new blight of the same type spontaneously forms in 1d10 days at the cursed domain's epicenter unless the curse is removed before then. The new blight retains all the memories of the previous blight.",
+          "traits": [
+            {
+              "link": {
+                "alt": "primal",
+                "aonid": 676,
+                "game-obj": "Traits",
+                "name": "primal",
+                "type": "link"
+              },
+              "name": "primal",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "animals",
+          "aonid": 531,
+          "game-obj": "Traits",
+          "name": "animals",
+          "type": "link"
+        },
+        {
+          "alt": "beasts",
+          "aonid": 547,
+          "game-obj": "Traits",
+          "name": "beasts",
+          "type": "link"
+        },
+        {
+          "alt": "fungi",
+          "aonid": 614,
+          "game-obj": "Traits",
+          "name": "fungi",
+          "type": "link"
+        },
+        {
+          "alt": "oozes",
+          "aonid": 665,
+          "game-obj": "Traits",
+          "name": "oozes",
+          "type": "link"
+        },
+        {
+          "alt": "plants",
+          "aonid": 668,
+          "game-obj": "Traits",
+          "name": "plants",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "curse",
+          "aonid": 566,
+          "game-obj": "Traits",
+          "name": "curse",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "difficult terrain",
+          "aonid": 453,
+          "game-obj": "Rules",
+          "name": "difficult terrain",
+          "type": "link"
+        },
+        {
+          "alt": "Cover Tracks",
+          "aonid": 2407,
+          "game-obj": "Actions",
+          "name": "Cover Tracks",
+          "type": "link"
+        },
+        {
+          "alt": "imprecise",
+          "aonid": 412,
+          "game-obj": "Rules",
+          "name": "imprecise",
+          "type": "link"
+        },
+        {
+          "alt": "telepathy",
+          "aonid": 79,
+          "game-obj": "MonsterAbilities",
+          "name": "telepathy",
+          "type": "link"
+        },
+        {
+          "alt": "slowed 1",
+          "aonid": 92,
+          "game-obj": "Conditions",
+          "name": "slowed 1",
+          "type": "link"
+        },
+        {
+          "alt": "Break Curse",
+          "aonid": 5128,
+          "game-obj": "Feats",
+          "name": "Break Curse",
+          "type": "link"
+        },
+        {
+          "alt": "counteract",
+          "aonid": 371,
+          "game-obj": "Rules",
+          "name": "counteract",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "primal",
+          "aonid": 676,
+          "game-obj": "Traits",
+          "name": "primal",
+          "type": "link"
+        }
+      ],
+      "name": "Blight Abilities",
+      "sections": [
+        {
+          "name": "Additional Information",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #212: A Voice in the Blight pg. 84",
+                "aonid": 255,
+                "game-obj": "Sources",
+                "name": "Pathfinder #212: A Voice in the Blight pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #212: A Voice in the Blight",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "The \u201cCorruptors of Nature\u201d article that begins on page 76 of this volume presents much more information on blight ecology, society, and their domains, as well as notes on other types of blights beyond the swamp blight.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #212: A Voice in the Blight pg. 84",
+            "aonid": 255,
+            "game-obj": "Sources",
+            "name": "Pathfinder #212: A Voice in the Blight pg. 84",
+            "type": "link"
+          },
+          "name": "Pathfinder #212: A Voice in the Blight",
+          "page": 84,
+          "type": "source"
+        }
+      ],
+      "text": "All blights possess the following abilities. **Blight Domination** All blights can cast *dominate* as an innate primal spell but can target only animals, beasts, fungi, oozes, or plants that are located inside their cursed domain. If a creature dominated by this spell leaves the cursed domain, the effects of dominate immediately end, but as long as the dominated creature remains in the cursed domain, the duration is unlimited. When a blight targets a mindless fungi, ooze, or plant, its *dominate* spell loses the mental trait.  \n  \n**Cursed Domain** (curse, primal) Once per year, when in a terrain that is compatible with its type (such as a swamp for a swamp blight), the blight can infuse the land around it with its corrupted essence by performing a rite that takes one day. The region in a 5-mile radius becomes its cursed domain; this effect does not extend into incompatible terrain and does not move with the blight. The point at which the blight cursed the domain becomes its epicenter.  \n Within their cursed domain, a blight ignores all non-magical difficult terrain and always gains the benefits of the Cover Tracks action. Blights also have an imprecise sense for the locations of all creatures within their domain and can communicate with all sapient creatures they detect within their domain using telepathy. Each blight's cursed domain has additional properties specific to the blight's type. A blight outside of a cursed domain becomes slowed 1 until it returns to its own or another blight's cursed domain.  \n Removing this curse requires a character with the Break Curse feat (or a similar ability); this activity must be performed at the cursed domain's epicenter. If the blight that cursed the domain is dead, checks to counteract a cursed domain gain a +4 circumstance bonus.  \n  \n**Oversee Domain** [#] (concentrate, primal) The blight projects its senses to any point in its cursed domain, gaining a precise sense of its surroundings with a 500-foot radius until the end of its next turn. A blight can cast *dominate* through this sensory link. A blight can Sustain this ability, but cannot use it to extend its senses beyond the edges of its domain.  \n  \n**Rejuvenation** (primal) If a blight is slain within its cursed domain, its body melts into the surrounding environment and a new blight of the same type spontaneously forms in 1d10 days at the cursed domain's epicenter unless the curse is removed before then. The new blight retains all the memories of the previous blight.",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/pathfinder_215_to_blot_out_the_sun/vampire_strigoi.json
+++ b/monster_families/pathfinder_215_to_blot_out_the_sun/vampire_strigoi.json
@@ -439,491 +439,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Greater Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Greater Darkvision",
-                  "type": "link"
-                },
-                "name": "Greater Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Void Healing",
-                  "aonid": 83,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Void Healing",
-                  "type": "link"
-                },
-                "name": "Void Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 83,
-                  "edition": "remastered",
-                  "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "vitality",
-                      "aonid": 509,
-                      "game-obj": "Traits",
-                      "name": "vitality",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "healing",
-                      "aonid": 623,
-                      "game-obj": "Traits",
-                      "name": "healing",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Void Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "1.1",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "1.1",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Monster Core pg. 360",
-                        "aonid": 221,
-                        "game-obj": "Sources",
-                        "name": "Monster Core pg. 360",
-                        "type": "link"
-                      },
-                      "name": "Monster Core",
-                      "page": 360,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 145,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyze, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Coffin Restoration",
-                "subtype": "ability",
-                "text": "As with moroi vampires, a strigoi isn't destroyed at 0 HP. Instead, it falls unconscious and loses fast healing. If its body rests in its coffin for 1 hour, the strigoi gains 1 HP, after which its fast healing begins to function normally.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "void",
-                      "aonid": 510,
-                      "game-obj": "Traits",
-                      "name": "void",
-                      "type": "link"
-                    },
-                    "name": "void",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Strigoi Weaknesses",
-                "subtype": "ability",
-                "text": "All strigoi possess the following weaknesses:",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "levitate",
-                    "aonid": 170,
-                    "game-obj": "Spells",
-                    "name": "levitate",
-                    "type": "link"
-                  }
-                ],
-                "name": "Levitation",
-                "subtype": "ability",
-                "text": "Strigoi can cast *levitate* at will as a divine innate spell; when they do so, they appear to ascend or descend on a coiling mass of shadows.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "shadow",
-                      "aonid": 143,
-                      "game-obj": "Traits",
-                      "name": "shadow",
-                      "type": "link"
-                    },
-                    "name": "shadow",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magic",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "moderate Strike damage for a creature of its level",
-                    "aonid": 1018,
-                    "game-obj": "Rules",
-                    "name": "moderate Strike damage for a creature of its level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the creature had hands, its shadow solidifies around the fingers when it attacks, granting it a claw Strike that deals slashing damage, and has the agile and magic traits. The damage caused by its claws should be roughly the same as the moderate Strike damage for a creature of its level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The strigoi sinks their fangs into the targeted creature to drink its blood and draw out its vital essence. This requires an Athletics check against the creature's Fortitude DC if the creature is grabbed and is automatic for any of the other conditions. The creature becomes drained 1 and stupefied 1, and the strigoi regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Essence from a creature that's already drained or stupefied doesn't restore any HP, but increases either the creature's drained condition value or its stupefied condition value by 1 (whichever value is lesser is increased; if both values are equal, then the strigoi chooses which condition to increase the value of).",
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 20,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 33,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Essence",
-                "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the strigoi's reach",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grab",
-                "subtype": "ability",
-                "text": "The creature's claw attacks gain Grab. When it uses this ability, its shadowy claws seem almost to latch on to any shadows cast by the grabbed creature.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 45,
-                  "edition": "remastered",
-                  "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
-                  "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "grabbed",
-                      "aonid": 20,
-                      "game-obj": "Conditions",
-                      "name": "grabbed",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "restrained",
-                      "aonid": 33,
-                      "game-obj": "Conditions",
-                      "name": "restrained",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Grapple",
-                      "aonid": 35,
-                      "game-obj": "Actions",
-                      "name": "Grapple",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Grab",
-                  "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Rage of Elements pg. 232",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "Rage of Elements pg. 232",
-                        "type": "link"
-                      },
-                      "name": "Rage of Elements",
-                      "page": 232,
-                      "type": "source"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "stunned 1",
-                    "aonid": 36,
-                    "game-obj": "Conditions",
-                    "name": "stunned 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Shadow Form",
-                "subtype": "ability",
-                "text": "The strigoi reverts to pure shadow and absorbs its body and its gear into the darkness, or it shifts back to its physical form. In shadow form, the strigoi gains a climb Speed equal to its land Speed and can move through any gap that isn't airtight. However, it can only move along solid surfaces that aren't highly reflective, not liquid or mirrored surfaces. If the surface it's on is destroyed, the strigoi returns to physical form and is stunned 1. The strigoi loses fast healing while in shadow form but can remain in shadow form indefinitely.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "shadow",
-                      "aonid": 143,
-                      "game-obj": "Traits",
-                      "name": "shadow",
-                      "type": "link"
-                    },
-                    "name": "shadow",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Basic Strigoi Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -941,6 +461,209 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Greater Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Greater Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Void Healing",
+                "aonid": 83,
+                "game-obj": "MonsterAbilities",
+                "name": "Void Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 145,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              {
+                "alt": "levitate",
+                "aonid": 170,
+                "game-obj": "Spells",
+                "name": "levitate",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "magic",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magic",
+                "type": "link"
+              },
+              {
+                "alt": "moderate Strike damage for a creature of its level",
+                "aonid": 1018,
+                "game-obj": "Rules",
+                "name": "moderate Strike damage for a creature of its level",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 1",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              {
+                "alt": "stunned 1",
+                "aonid": 36,
+                "game-obj": "Conditions",
+                "name": "stunned 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -950,223 +673,89 @@
         ],
         "name": "Basic Strigoi Abilities",
         "subtype": "monster_family",
-        "text": "All strigoi gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the strigoi's theme.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "true vampire",
-                    "aonid": 480,
-                    "game-obj": "MonsterFamilies",
-                    "name": "true vampire",
-                    "type": "link"
-                  }
-                ],
-                "name": "Create Servitor",
-                "subtype": "ability",
-                "text": "As true vampire, but the victim must have been slain either by Domain of Dusk or Drink Essence. A victim that's 8th level or higher becomes a strigoi servant, while a lower-level victim instead becomes a moroi vampire.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "downtime",
-                      "aonid": 580,
-                      "game-obj": "Traits",
-                      "name": "downtime",
-                      "type": "link"
-                    },
-                    "name": "downtime",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The strigoi uses Shadow Form. They can take move actions to move toward their coffin even though they're at 0 HP. While at 0 HP in this form, the strigoi is unaffected by further damage. Once the strigoi reaches their coffin, or if they haven't done so within 2 hours, they automatically return to their physical form, unconscious.",
-                "name": "Shadow Escape",
-                "subtype": "ability",
-                "trigger": "The strigoi is reduced to 0 HP",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Fly Speed",
-                "subtype": "ability",
-                "text": "Instead of being able to cast *levitate* at will, a strigoi progenitor gains a fly Speed equal to their land Speed. When a strigoi progenitor flies, they manifest batlike wings made of shadow.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "void",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "effect": "With a wave of their hand, the strigoi calls forth vile ruination from the surrounding shadows, causing coils of darkness and shadowy bats, rats, and wolves to lash out at living targets in a 30-foot emanation. Living creatures in this area take 1d6 void damage + 1d6 void damage per 2 levels possessed by the strigoi with a basic Fortitude save against the DC of the strigoi's level. A creature that fails this save is also dazzled by the darkness for 1 round (or blinded for 1 round and then dazzled for 1 round on a critical failure).",
-                "frequency": "once per minute",
-                "links": [
-                  {
-                    "alt": "dazzled",
-                    "aonid": 65,
-                    "game-obj": "Conditions",
-                    "name": "dazzled",
-                    "type": "link"
-                  }
-                ],
-                "name": "Domain of Dusk",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "shadow",
-                      "aonid": 693,
-                      "game-obj": "Traits",
-                      "name": "shadow",
-                      "type": "link"
-                    },
-                    "name": "shadow",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "name": "Dominate",
-                "subtype": "ability",
-                "text": "As true vampire.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 579,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 631,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 727,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Drink Essence",
-                "subtype": "ability",
-                "text": "As strigoi, but the victim is drained 2 and stupefied 2 instead of 1.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Strigoi Progenitor Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "downtime",
+                "aonid": 580,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              {
+                "alt": "true vampire",
+                "aonid": 480,
+                "game-obj": "MonsterFamilies",
+                "name": "true vampire",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "shadow",
+                "aonid": 693,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              {
+                "alt": "dazzled",
+                "aonid": 65,
+                "game-obj": "Conditions",
+                "name": "dazzled",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1176,7 +765,6 @@
         ],
         "name": "Strigoi Progenitor Abilities",
         "subtype": "monster_family",
-        "text": "Powerful strigoi that form from the fusion of a strigoi from the Netherworld and a living host gain additional abilities as detailed below. A creature below level 13 is not a significant enough host to become a strigoi progenitor.",
         "type": "stat_block_section"
       }
     ],
@@ -1237,6 +825,1098 @@
         }
       ],
       "text": "|  |  |  |\n| --- | --- | --- |\n| **Starting Level** | **HP Decrease** | **Fast Healing/Resistance** |\n| 8-14 | -40 | 10 |\n| 15+ | -60 | 15 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Greater Darkvision",
+            "aonid": 12,
+            "game-obj": "MonsterAbilities",
+            "name": "Greater Darkvision",
+            "type": "link"
+          },
+          "name": "Greater Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Void Healing",
+            "aonid": 83,
+            "game-obj": "MonsterAbilities",
+            "name": "Void Healing",
+            "type": "link"
+          },
+          "name": "Void Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 83,
+            "edition": "remastered",
+            "game-id": "ebe30e9ccb052cef2a000a746b7233e9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              }
+            ],
+            "name": "Void Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "1.1",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "1.1",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Monster Core pg. 360",
+                  "aonid": 221,
+                  "game-obj": "Sources",
+                  "name": "Monster Core pg. 360",
+                  "type": "link"
+                },
+                "name": "Monster Core",
+                "page": 360,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with void healing draws health from void energy rather than vitality energy. It is damaged by vitality damage and is not healed by healing vitality effects. It does not take void damage, and it is healed by void effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 145,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "death effects, disease, paralyze, poison, sleep",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Coffin Restoration",
+          "subtype": "ability",
+          "text": "As with moroi vampires, a strigoi isn't destroyed at 0 HP. Instead, it falls unconscious and loses fast healing. If its body rests in its coffin for 1 hour, the strigoi gains 1 HP, after which its fast healing begins to function normally.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              "name": "void",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Strigoi Weaknesses",
+          "subtype": "ability",
+          "text": "All strigoi possess the following weaknesses:",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "levitate",
+              "aonid": 170,
+              "game-obj": "Spells",
+              "name": "levitate",
+              "type": "link"
+            }
+          ],
+          "name": "Levitation",
+          "subtype": "ability",
+          "text": "Strigoi can cast *levitate* at will as a divine innate spell; when they do so, they appear to ascend or descend on a coiling mass of shadows.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              "name": "shadow",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "magic",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magic",
+              "type": "link"
+            },
+            {
+              "alt": "moderate Strike damage for a creature of its level",
+              "aonid": 1018,
+              "game-obj": "Rules",
+              "name": "moderate Strike damage for a creature of its level",
+              "type": "link"
+            }
+          ],
+          "name": "Claws",
+          "subtype": "ability",
+          "text": "If the creature had hands, its shadow solidifies around the fingers when it attacks, granting it a claw Strike that deals slashing damage, and has the agile and magic traits. The damage caused by its claws should be roughly the same as the moderate Strike damage for a creature of its level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The strigoi sinks their fangs into the targeted creature to drink its blood and draw out its vital essence. This requires an Athletics check against the creature's Fortitude DC if the creature is grabbed and is automatic for any of the other conditions. The creature becomes drained 1 and stupefied 1, and the strigoi regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Essence from a creature that's already drained or stupefied doesn't restore any HP, but increases either the creature's drained condition value or its stupefied condition value by 1 (whichever value is lesser is increased; if both values are equal, then the strigoi chooses which condition to increase the value of).",
+          "links": [
+            {
+              "alt": "grabbed",
+              "aonid": 20,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 33,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied 1",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            }
+          ],
+          "name": "Drink Essence",
+          "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the strigoi's reach",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Grab",
+          "subtype": "ability",
+          "text": "The creature's claw attacks gain Grab. When it uses this ability, its shadowy claws seem almost to latch on to any shadows cast by the grabbed creature.",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 45,
+            "edition": "remastered",
+            "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
+            "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "Grapple",
+                "aonid": 35,
+                "game-obj": "Actions",
+                "name": "Grapple",
+                "type": "link"
+              }
+            ],
+            "name": "Grab",
+            "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "2.0",
+                  "aonid": 205,
+                  "game-obj": "Sources",
+                  "name": "2.0",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Rage of Elements pg. 232",
+                  "aonid": 205,
+                  "game-obj": "Sources",
+                  "name": "Rage of Elements pg. 232",
+                  "type": "link"
+                },
+                "name": "Rage of Elements",
+                "page": 232,
+                "type": "source"
+              }
+            ],
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "stunned 1",
+              "aonid": 36,
+              "game-obj": "Conditions",
+              "name": "stunned 1",
+              "type": "link"
+            }
+          ],
+          "name": "Shadow Form",
+          "subtype": "ability",
+          "text": "The strigoi reverts to pure shadow and absorbs its body and its gear into the darkness, or it shifts back to its physical form. In shadow form, the strigoi gains a climb Speed equal to its land Speed and can move through any gap that isn't airtight. However, it can only move along solid surfaces that aren't highly reflective, not liquid or mirrored surfaces. If the surface it's on is destroyed, the strigoi returns to physical form and is stunned 1. The strigoi loses fast healing while in shadow form but can remain in shadow form indefinitely.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              "name": "shadow",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "human",
+          "aonid": 90,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 91,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Greater Darkvision",
+          "aonid": 12,
+          "game-obj": "MonsterAbilities",
+          "name": "Greater Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Void Healing",
+          "aonid": 83,
+          "game-obj": "MonsterAbilities",
+          "name": "Void Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 40,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 126,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 145,
+          "game-obj": "Traits",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 38,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "shadow",
+          "aonid": 143,
+          "game-obj": "Traits",
+          "name": "shadow",
+          "type": "link"
+        },
+        {
+          "alt": "levitate",
+          "aonid": 170,
+          "game-obj": "Spells",
+          "name": "levitate",
+          "type": "link"
+        },
+        {
+          "alt": "agile",
+          "aonid": 170,
+          "game-obj": "Traits",
+          "name": "agile",
+          "type": "link"
+        },
+        {
+          "alt": "magic",
+          "aonid": 103,
+          "game-obj": "Traits",
+          "name": "magic",
+          "type": "link"
+        },
+        {
+          "alt": "moderate Strike damage for a creature of its level",
+          "aonid": 1018,
+          "game-obj": "Rules",
+          "name": "moderate Strike damage for a creature of its level",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "grabbed",
+          "aonid": 20,
+          "game-obj": "Conditions",
+          "name": "grabbed",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 28,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 33,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 38,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 3,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 10,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "stupefied 1",
+          "aonid": 37,
+          "game-obj": "Conditions",
+          "name": "stupefied 1",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 18,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "shadow",
+          "aonid": 143,
+          "game-obj": "Traits",
+          "name": "shadow",
+          "type": "link"
+        },
+        {
+          "alt": "stunned 1",
+          "aonid": 36,
+          "game-obj": "Conditions",
+          "name": "stunned 1",
+          "type": "link"
+        }
+      ],
+      "name": "Basic Strigoi Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #215: To Blot Out the Sun pg. 84",
+            "aonid": 259,
+            "game-obj": "Sources",
+            "name": "Pathfinder #215: To Blot Out the Sun pg. 84",
+            "type": "link"
+          },
+          "name": "Pathfinder #215: To Blot Out the Sun",
+          "page": 84,
+          "type": "source"
+        }
+      ],
+      "text": "All strigoi gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the strigoi's theme.  \n  \n**Greater Darkvision**  \n  \n**Void Healing**  \n  \n**Immunities** death effects, disease, paralyze, poison, sleep   \n  \n**Coffin Restoration** (divine, void) As with moroi vampires, a strigoi isn't destroyed at 0 HP. Instead, it falls unconscious and loses fast healing. If its body rests in its coffin for 1 hour, the strigoi gains 1 HP, after which its fast healing begins to function normally.  \n  \n**Strigoi Weaknesses** All strigoi possess the following weaknesses:**Levitation** [##] (divine,shadow) Strigoi can cast *levitate* at will as a divine innate spell; when they do so, they appear to ascend or descend on a coiling mass of shadows.  \n  \n**Claws** If the creature had hands, its shadow solidifies around the fingers when it attacks, granting it a claw Strike that deals slashing damage, and has the agile and magic traits. The damage caused by its claws should be roughly the same as the moderate Strike damage for a creature of its level.  \n  \n**Drink Essence** [#] (divine, necromancy) **Requirements** A grabbed, paralyzed, restrained, unconscious, or willing creature is within the strigoi's reach; **Effect** The strigoi sinks their fangs into the targeted creature to drink its blood and draw out its vital essence. This requires an Athletics check against the creature's Fortitude DC if the creature is grabbed and is automatic for any of the other conditions. The creature becomes drained 1 and stupefied 1, and the strigoi regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Essence from a creature that's already drained or stupefied doesn't restore any HP, but increases either the creature's drained condition value or its stupefied condition value by 1 (whichever value is lesser is increased; if both values are equal, then the strigoi chooses which condition to increase the value of).  \n A victim's drained condition decreases by 1 per week. A blood transfusion, which requires a successful DC 20 Medicine check and sufficient blood or a blood donor, reduces the drained value by 1 after 10 minutes.  \n A victim's stupefied condition decreases by 1 per day after performing daily preparations. If the daily preparations are done in full sunlight, the stupefied condition is removed entirely.  \n  \n**Grab** The creature's claw attacks gain Grab. When it uses this ability, its shadowy claws seem almost to latch on to any shadows cast by the grabbed creature.  \n  \n**Shadow Form** [#] (concentrate, divine, shadow) The strigoi reverts to pure shadow and absorbs its body and its gear into the darkness, or it shifts back to its physical form. In shadow form, the strigoi gains a climb Speed equal to its land Speed and can move through any gap that isn't airtight. However, it can only move along solid surfaces that aren't highly reflective, not liquid or mirrored surfaces. If the surface it's on is destroyed, the strigoi returns to physical form and is stunned 1. The strigoi loses fast healing while in shadow form but can remain in shadow form indefinitely.  \n A strigoi that is exposed to sunlight while in shadow form becomes slowed 2 and must attempt a DC 16 flat check at the end of each of its turns. If it fails this flat check, it is destroyed, the shadow vanishing with a blood-curdling wail.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "true vampire",
+              "aonid": 480,
+              "game-obj": "MonsterFamilies",
+              "name": "true vampire",
+              "type": "link"
+            }
+          ],
+          "name": "Create Servitor",
+          "subtype": "ability",
+          "text": "As true vampire, but the victim must have been slain either by Domain of Dusk or Drink Essence. A victim that's 8th level or higher becomes a strigoi servant, while a lower-level victim instead becomes a moroi vampire.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "downtime",
+                "aonid": 580,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              "name": "downtime",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The strigoi uses Shadow Form. They can take move actions to move toward their coffin even though they're at 0 HP. While at 0 HP in this form, the strigoi is unaffected by further damage. Once the strigoi reaches their coffin, or if they haven't done so within 2 hours, they automatically return to their physical form, unconscious.",
+          "name": "Shadow Escape",
+          "subtype": "ability",
+          "trigger": "The strigoi is reduced to 0 HP",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Fly Speed",
+          "subtype": "ability",
+          "text": "Instead of being able to cast *levitate* at will, a strigoi progenitor gains a fly Speed equal to their land Speed. When a strigoi progenitor flies, they manifest batlike wings made of shadow.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "void",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "effect": "With a wave of their hand, the strigoi calls forth vile ruination from the surrounding shadows, causing coils of darkness and shadowy bats, rats, and wolves to lash out at living targets in a 30-foot emanation. Living creatures in this area take 1d6 void damage + 1d6 void damage per 2 levels possessed by the strigoi with a basic Fortitude save against the DC of the strigoi's level. A creature that fails this save is also dazzled by the darkness for 1 round (or blinded for 1 round and then dazzled for 1 round on a critical failure).",
+          "frequency": "once per minute",
+          "links": [
+            {
+              "alt": "dazzled",
+              "aonid": 65,
+              "game-obj": "Conditions",
+              "name": "dazzled",
+              "type": "link"
+            }
+          ],
+          "name": "Domain of Dusk",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "shadow",
+                "aonid": 693,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              "name": "shadow",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "name": "Dominate",
+          "subtype": "ability",
+          "text": "As true vampire.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 579,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              "name": "incapacitation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 727,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Drink Essence",
+          "subtype": "ability",
+          "text": "As strigoi, but the victim is drained 2 and stupefied 2 instead of 1.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "downtime",
+          "aonid": 580,
+          "game-obj": "Traits",
+          "name": "downtime",
+          "type": "link"
+        },
+        {
+          "alt": "true vampire",
+          "aonid": 480,
+          "game-obj": "MonsterFamilies",
+          "name": "true vampire",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "shadow",
+          "aonid": 693,
+          "game-obj": "Traits",
+          "name": "shadow",
+          "type": "link"
+        },
+        {
+          "alt": "dazzled",
+          "aonid": 65,
+          "game-obj": "Conditions",
+          "name": "dazzled",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 579,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "incapacitation",
+          "aonid": 631,
+          "game-obj": "Traits",
+          "name": "incapacitation",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 727,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        }
+      ],
+      "name": "Strigoi Progenitor Abilities",
+      "sections": [
+        {
+          "name": "In Shadows",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "aonid": 259,
+                "game-obj": "Sources",
+                "name": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #215: To Blot Out the Sun",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "In their true form as a shadow without a body, a strigoi is more of a strange malevolent force akin to a soul than an actual creature. In this form, a strigoi is capable of thought and emotion and can communicate with the shadowy forms of other strigoi, but they lack any way to communicate or interact with the physical world. Countless strigoi exist in this manner in the Netherworld, patiently waiting for the ritual that allows mortals to invite them in to be discovered again.",
+          "type": "section"
+        },
+        {
+          "name": "Non-evil Strigoi",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "aonid": 259,
+                "game-obj": "Sources",
+                "name": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #215: To Blot Out the Sun",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "Non-evil strigoi are even more rare than non-evil moroi, but they can, in theory, exist. Those who do are often haunted by the loss of sights forever barred to them, such as the sun or their own reflection. To non-evil strigoi, these things do not inspire revulsion, but instead a deep, overwhelming shame and self-loathing.",
+          "type": "section"
+        },
+        {
+          "name": "Strange Wounds",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "aonid": 259,
+                "game-obj": "Sources",
+                "name": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #215: To Blot Out the Sun",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "Iconic puncture marks on the neck of a victim drained of blood are well known to vampire hunters, but the wounds left by strigoi are stranger. When a strigoi feeds on a living victim, the site of the wound becomes bleached of color, wrinkled, and strangely cold to the touch. These conditions fade if the wound heals; if a strigoi feeds enough to cause death by the drained condition, a creature leaves behind a withered gray husk of a bloodless body. Full autopsies on those slain in this manner reveal yet another unsettling curiosity: the brains of such victims are smooth, gray ovoids, the folds and fissures of gray matter fused together into a featureless mass.",
+          "type": "section"
+        },
+        {
+          "name": "Strigoi and the Sun",
+          "sources": [
+            {
+              "link": {
+                "alt": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "aonid": 259,
+                "game-obj": "Sources",
+                "name": "Pathfinder #215: To Blot Out the Sun pg. 84",
+                "type": "link"
+              },
+              "name": "Pathfinder #215: To Blot Out the Sun",
+              "page": 84,
+              "type": "source"
+            }
+          ],
+          "text": "As long as they\u2019re not in shadow form, strigoi are more inconvenienced by sunlight than harmed by it, but being rendered unconscious certainly puts them at a disadvantage. As long as they\u2019re in an area where there\u2019s little risk of direct sunlight, such as being inside a room without exterior windows or doors, or in an underground area, some strigoi remain active during the day, only retreating to their coffins in emergencies. In so doing, these strigoi have further blended into society\u2014there may be more of them than suspected!",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder #215: To Blot Out the Sun pg. 84",
+            "aonid": 259,
+            "game-obj": "Sources",
+            "name": "Pathfinder #215: To Blot Out the Sun pg. 84",
+            "type": "link"
+          },
+          "name": "Pathfinder #215: To Blot Out the Sun",
+          "page": 84,
+          "type": "source"
+        }
+      ],
+      "text": "Powerful strigoi that form from the fusion of a strigoi from the Netherworld and a living host gain additional abilities as detailed below. A creature below level 13 is not a significant enough host to become a strigoi progenitor.  \n  \n**Create Servitor** (divine, downtime) As true vampire, but the victim must have been slain either by Domain of Dusk or Drink Essence. A victim that's 8th level or higher becomes a strigoi servant, while a lower-level victim instead becomes a moroi vampire.  \n  \n**Shadow Escape** [-] **Trigger** The strigoi is reduced to 0 HP; **Effect** The strigoi uses Shadow Form. They can take move actions to move toward their coffin even though they're at 0 HP. While at 0 HP in this form, the strigoi is unaffected by further damage. Once the strigoi reaches their coffin, or if they haven't done so within 2 hours, they automatically return to their physical form, unconscious.   \n  \n**Fly Speed** Instead of being able to cast *levitate* at will, a strigoi progenitor gains a fly Speed equal to their land Speed. When a strigoi progenitor flies, they manifest batlike wings made of shadow.  \n  \n**Domain of Dusk** [##] (divine, shadow) **Frequency** once per minute; **Effect** With a wave of their hand, the strigoi calls forth vile ruination from the surrounding shadows, causing coils of darkness and shadowy bats, rats, and wolves to lash out at living targets in a 30-foot emanation. Living creatures in this area take 1d6 void damage + 1d6 void damage per 2 levels possessed by the strigoi with a basic Fortitude save against the DC of the strigoi's level. A creature that fails this save is also dazzled by the darkness for 1 round (or blinded for 1 round and then dazzled for 1 round on a critical failure).   \n  \n**Dominate** [##] (divine, incapacitation, mental, visual) As true vampire.   \n  \n**Drink Essence** As strigoi, but the victim is drained 2 and stupefied 2 instead of 1.",
       "type": "section"
     }
   ],

--- a/monster_families/pathfinder_adventure_path_219_lord_of_the_trinity_star/risen_runelord.json
+++ b/monster_families/pathfinder_adventure_path_219_lord_of_the_trinity_star/risen_runelord.json
@@ -77,2771 +77,1091 @@
         "changes": [
           {
             "change_category": "abilities",
-            "spells": [
+            "effects": [
               {
-                "name": "Envy Spells",
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispelling globe",
-                            "aonid": 1494,
-                            "game-obj": "Spells",
-                            "name": "dispelling globe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "\u2014 dispelling globe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "repulsion",
-                            "aonid": 1650,
-                            "game-obj": "Spells",
-                            "name": "repulsion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "repulsion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "banishment",
-                            "aonid": 1448,
-                            "game-obj": "Spells",
-                            "name": "banishment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "banishment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dispel magic",
-                            "aonid": 1493,
-                            "game-obj": "Spells",
-                            "name": "dispel magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dispel magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "veil of privacy",
-                            "aonid": 1739,
-                            "game-obj": "Spells",
-                            "name": "veil of privacy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "veil of privacy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "planar tether",
-                            "aonid": 1636,
-                            "game-obj": "Spells",
-                            "name": "planar tether",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "planar tether",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "resist energy",
-                            "aonid": 1651,
-                            "game-obj": "Spells",
-                            "name": "resist energy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "resist energy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "unfettered movement",
-                            "aonid": 1732,
-                            "game-obj": "Spells",
-                            "name": "unfettered movement",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "unfettered movement",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "clairaudience",
-                            "aonid": 1465,
-                            "game-obj": "Spells",
-                            "name": "clairaudience",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "clairaudience",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "levitate",
-                            "aonid": 1584,
-                            "game-obj": "Spells",
-                            "name": "levitate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "levitate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blur",
-                            "aonid": 1455,
-                            "game-obj": "Spells",
-                            "name": "blur",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blur",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "environmental endurance",
-                            "aonid": 1517,
-                            "game-obj": "Spells",
-                            "name": "environmental endurance",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "environmental endurance",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "see the unseen",
-                            "aonid": 1663,
-                            "game-obj": "Spells",
-                            "name": "see the unseen",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "see the unseen",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "charm",
-                            "aonid": 1463,
-                            "game-obj": "Spells",
-                            "name": "charm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "charm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_type": "Envy Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "operation": "add_items",
+                "source": "$.sections[?(@.name=='Risen Runelord Spells')].spells",
+                "target": "$.offense.offensive_actions"
+              }
+            ],
+            "links": [
+              {
+                "alt": "dispelling globe",
+                "aonid": 1494,
+                "game-obj": "Spells",
+                "name": "dispelling globe",
+                "type": "link"
               },
               {
-                "name": "Gluttony Spells",
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "summon undead",
-                            "aonid": 1706,
-                            "game-obj": "Spells",
-                            "name": "summon undead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "\u2014 summon undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vampiric exsanguination",
-                            "aonid": 1735,
-                            "game-obj": "Spells",
-                            "name": "vampiric exsanguination",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vampiric exsanguination",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "invoke spirits",
-                            "aonid": 1578,
-                            "game-obj": "Spells",
-                            "name": "invoke spirits",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "invoke spirits",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wave of despair",
-                            "aonid": 1757,
-                            "game-obj": "Spells",
-                            "name": "wave of despair",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wave of despair",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "grim tendrils",
-                            "aonid": 1548,
-                            "game-obj": "Spells",
-                            "name": "grim tendrils",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "grim tendrils",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fly",
-                            "aonid": 1534,
-                            "game-obj": "Spells",
-                            "name": "fly",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fly",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vision of death",
-                            "aonid": 1742,
-                            "game-obj": "Spells",
-                            "name": "vision of death",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vision of death",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "bind undead",
-                            "aonid": 1449,
-                            "game-obj": "Spells",
-                            "name": "bind undead",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "bind undead",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vampiric feast",
-                            "aonid": 1736,
-                            "game-obj": "Spells",
-                            "name": "vampiric feast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vampiric feast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blood vendetta",
-                            "aonid": 1454,
-                            "game-obj": "Spells",
-                            "name": "blood vendetta",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blood vendetta",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create food",
-                            "aonid": 1475,
-                            "game-obj": "Spells",
-                            "name": "create food",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create food",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ghostly carrier",
-                            "aonid": 1543,
-                            "game-obj": "Spells",
-                            "name": "ghostly carrier",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ghostly carrier",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enfeeble",
-                            "aonid": 1513,
-                            "game-obj": "Spells",
-                            "name": "enfeeble",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enfeeble",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "goblin pox",
-                            "aonid": 1545,
-                            "game-obj": "Spells",
-                            "name": "goblin pox",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "goblin pox",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "frostbite",
-                            "aonid": 1539,
-                            "game-obj": "Spells",
-                            "name": "frostbite",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "frostbite",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "void warp",
-                            "aonid": 1745,
-                            "game-obj": "Spells",
-                            "name": "void warp",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "void warp",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_type": "Gluttony Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "alt": "repulsion",
+                "aonid": 1650,
+                "game-obj": "Spells",
+                "name": "repulsion",
+                "type": "link"
               },
               {
-                "name": "Greed Spells",
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cursed metamorphosis",
-                            "aonid": 1479,
-                            "game-obj": "Spells",
-                            "name": "cursed metamorphosis",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "\u2014 cursed metamorphosis",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disintegrate",
-                            "aonid": 1492,
-                            "game-obj": "Spells",
-                            "name": "disintegrate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disintegrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "elemental form",
-                            "aonid": 1510,
-                            "game-obj": "Spells",
-                            "name": "elemental form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "elemental form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "impaling spike",
-                            "aonid": 1571,
-                            "game-obj": "Spells",
-                            "name": "impaling spike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "impaling spike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of stone",
-                            "aonid": 1751,
-                            "game-obj": "Spells",
-                            "name": "wall of stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "aerial form",
-                            "aonid": 1437,
-                            "game-obj": "Spells",
-                            "name": "aerial form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "aerial form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "creation",
-                            "aonid": 1477,
-                            "game-obj": "Spells",
-                            "name": "creation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "creation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fly",
-                            "aonid": 1534,
-                            "game-obj": "Spells",
-                            "name": "fly",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fly",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "insect form",
-                            "aonid": 1575,
-                            "game-obj": "Spells",
-                            "name": "insect form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "insect form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "one with stone",
-                            "aonid": 1619,
-                            "game-obj": "Spells",
-                            "name": "one with stone",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "one with stone",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of thorns",
-                            "aonid": 1752,
-                            "game-obj": "Spells",
-                            "name": "wall of thorns",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of thorns",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enlarge",
-                            "aonid": 1514,
-                            "game-obj": "Spells",
-                            "name": "enlarge",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enlarge",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "humanoid form",
-                            "aonid": 1560,
-                            "game-obj": "Spells",
-                            "name": "humanoid form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "humanoid form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shrink",
-                            "aonid": 1672,
-                            "game-obj": "Spells",
-                            "name": "shrink",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shrink",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fleet step",
-                            "aonid": 1531,
-                            "game-obj": "Spells",
-                            "name": "fleet step",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fleet step",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mending",
-                            "aonid": 1597,
-                            "game-obj": "Spells",
-                            "name": "mending",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mending",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "pest form",
-                            "aonid": 1626,
-                            "game-obj": "Spells",
-                            "name": "pest form",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "pest form",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gouging claw",
-                            "aonid": 1546,
-                            "game-obj": "Spells",
-                            "name": "gouging claw",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gouging claw",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "read aura",
-                            "aonid": 1646,
-                            "game-obj": "Spells",
-                            "name": "read aura",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "read aura",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "shield",
-                            "aonid": 1671,
-                            "game-obj": "Spells",
-                            "name": "shield",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "shield",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 1718,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_type": "Greed Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "alt": "banishment",
+                "aonid": 1448,
+                "game-obj": "Spells",
+                "name": "banishment",
+                "type": "link"
               },
               {
-                "name": "Lust Spells",
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dominate",
-                            "aonid": 1501,
-                            "game-obj": "Spells",
-                            "name": "dominate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "\u2014 dominate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "never mind",
-                            "aonid": 1614,
-                            "game-obj": "Spells",
-                            "name": "never mind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "never mind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mind probe",
-                            "aonid": 1601,
-                            "game-obj": "Spells",
-                            "name": "mind probe",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mind probe",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sleep",
-                            "aonid": 1675,
-                            "game-obj": "Spells",
-                            "name": "sleep",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sleep",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "subconscious suggestion",
-                            "aonid": 1692,
-                            "game-obj": "Spells",
-                            "name": "subconscious suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "subconscious suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "nightmare",
-                            "aonid": 1615,
-                            "game-obj": "Spells",
-                            "name": "nightmare",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "nightmare",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "suggestion",
-                            "aonid": 1693,
-                            "game-obj": "Spells",
-                            "name": "suggestion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "suggestion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dream message",
-                            "aonid": 1503,
-                            "game-obj": "Spells",
-                            "name": "dream message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dream message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "enthrall",
-                            "aonid": 1516,
-                            "game-obj": "Spells",
-                            "name": "enthrall",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "enthrall",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "paralyze",
-                            "aonid": 1622,
-                            "game-obj": "Spells",
-                            "name": "paralyze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "paralyze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blur",
-                            "aonid": 1455,
-                            "game-obj": "Spells",
-                            "name": "blur",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blur",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "laughing fit",
-                            "aonid": 1583,
-                            "game-obj": "Spells",
-                            "name": "laughing fit",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "laughing fit",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "stupefy",
-                            "aonid": 1691,
-                            "game-obj": "Spells",
-                            "name": "stupefy",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "stupefy",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "charm",
-                            "aonid": 1463,
-                            "game-obj": "Spells",
-                            "name": "charm",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "charm",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "command",
-                            "aonid": 1470,
-                            "game-obj": "Spells",
-                            "name": "command",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "command",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fear",
-                            "aonid": 1524,
-                            "game-obj": "Spells",
-                            "name": "fear",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fear",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "detect magic",
-                            "aonid": 1485,
-                            "game-obj": "Spells",
-                            "name": "detect magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "detect magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_type": "Lust Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "alt": "dispel magic",
+                "aonid": 1493,
+                "game-obj": "Spells",
+                "name": "dispel magic",
+                "type": "link"
               },
               {
-                "name": "Pride Spells",
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory creature",
-                            "aonid": 1567,
-                            "game-obj": "Spells",
-                            "name": "illusory creature",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "\u2014 illusory creature",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal calamity",
-                            "aonid": 1630,
-                            "game-obj": "Spells",
-                            "name": "phantasmal calamity",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal calamity",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "dizzying colors",
-                            "aonid": 1500,
-                            "game-obj": "Spells",
-                            "name": "dizzying colors",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "dizzying colors",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hallucination",
-                            "aonid": 1551,
-                            "game-obj": "Spells",
-                            "name": "hallucination",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hallucination",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory scene",
-                            "aonid": 1570,
-                            "game-obj": "Spells",
-                            "name": "illusory scene",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "illusory scene",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "invisibility",
-                            "aonid": 1577,
-                            "game-obj": "Spells",
-                            "name": "invisibility",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "invisibility",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mirage",
-                            "aonid": 1604,
-                            "game-obj": "Spells",
-                            "name": "mirage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mirage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "vision of death",
-                            "aonid": 1742,
-                            "game-obj": "Spells",
-                            "name": "vision of death",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "vision of death",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory disguise",
-                            "aonid": 1568,
-                            "game-obj": "Spells",
-                            "name": "illusory disguise",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "illusory disguise",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "hypnotize",
-                            "aonid": 1564,
-                            "game-obj": "Spells",
-                            "name": "hypnotize",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "hypnotize",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "paralyze",
-                            "aonid": 1622,
-                            "game-obj": "Spells",
-                            "name": "paralyze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "paralyze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blur",
-                            "aonid": 1455,
-                            "game-obj": "Spells",
-                            "name": "blur",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blur",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "darkness",
-                            "aonid": 1480,
-                            "game-obj": "Spells",
-                            "name": "darkness",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "darkness",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "revealing light",
-                            "aonid": 1653,
-                            "game-obj": "Spells",
-                            "name": "revealing light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "revealing light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disguise magic",
-                            "aonid": 1491,
-                            "game-obj": "Spells",
-                            "name": "disguise magic",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "disguise magic",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "illusory object",
-                            "aonid": 1569,
-                            "game-obj": "Spells",
-                            "name": "illusory object",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "illusory object",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "phantasmal minion",
-                            "aonid": 1631,
-                            "game-obj": "Spells",
-                            "name": "phantasmal minion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "phantasmal minion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "figment",
-                            "aonid": 1528,
-                            "game-obj": "Spells",
-                            "name": "figment",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "figment",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sigil",
-                            "aonid": 1673,
-                            "game-obj": "Spells",
-                            "name": "sigil",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sigil",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_type": "Pride Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "alt": "veil of privacy",
+                "aonid": 1739,
+                "game-obj": "Spells",
+                "name": "veil of privacy",
+                "type": "link"
               },
               {
-                "name": "Sloth Spells",
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "disintegrate",
-                            "aonid": 1492,
-                            "game-obj": "Spells",
-                            "name": "disintegrate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "\u2014 disintegrate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "teleport",
-                            "aonid": 1720,
-                            "game-obj": "Spells",
-                            "name": "teleport",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "teleport",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sleep",
-                            "aonid": 1675,
-                            "game-obj": "Spells",
-                            "name": "sleep",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sleep",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slither",
-                            "aonid": 1676,
-                            "game-obj": "Spells",
-                            "name": "slither",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slither",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "toxic cloud",
-                            "aonid": 1722,
-                            "game-obj": "Spells",
-                            "name": "toxic cloud",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "toxic cloud",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "confusion",
-                            "aonid": 1471,
-                            "game-obj": "Spells",
-                            "name": "confusion",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "confusion",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fly",
-                            "aonid": 1534,
-                            "game-obj": "Spells",
-                            "name": "fly",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fly",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "translocate",
-                            "aonid": 1724,
-                            "game-obj": "Spells",
-                            "name": "translocate",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "translocate",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "cozy cabin",
-                            "aonid": 1474,
-                            "game-obj": "Spells",
-                            "name": "cozy cabin",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "cozy cabin",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "slow",
-                            "aonid": 1677,
-                            "game-obj": "Spells",
-                            "name": "slow",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "slow",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of thorns",
-                            "aonid": 1752,
-                            "game-obj": "Spells",
-                            "name": "wall of thorns",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of thorns",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create food",
-                            "aonid": 1475,
-                            "game-obj": "Spells",
-                            "name": "create food",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create food",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "marvelous mount",
-                            "aonid": 1594,
-                            "game-obj": "Spells",
-                            "name": "marvelous mount",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "marvelous mount",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "mist",
-                            "aonid": 1606,
-                            "game-obj": "Spells",
-                            "name": "mist",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "mist",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "create water",
-                            "aonid": 1476,
-                            "game-obj": "Spells",
-                            "name": "create water",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "create water",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gentle landing",
-                            "aonid": 1542,
-                            "game-obj": "Spells",
-                            "name": "gentle landing",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gentle landing",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "sure strike",
-                            "aonid": 1709,
-                            "game-obj": "Spells",
-                            "name": "sure strike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "sure strike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "daze",
-                            "aonid": 1482,
-                            "game-obj": "Spells",
-                            "name": "daze",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "daze",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "message",
-                            "aonid": 1598,
-                            "game-obj": "Spells",
-                            "name": "message",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "message",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "prestidigitation",
-                            "aonid": 1639,
-                            "game-obj": "Spells",
-                            "name": "prestidigitation",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "prestidigitation",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic hand",
-                            "aonid": 1715,
-                            "game-obj": "Spells",
-                            "name": "telekinetic hand",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic hand",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_type": "Sloth Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "alt": "planar tether",
+                "aonid": 1636,
+                "game-obj": "Spells",
+                "name": "planar tether",
+                "type": "link"
               },
               {
-                "name": "Wrath Spells",
-                "spell_list": [
-                  {
-                    "level": 6,
-                    "level_text": "6th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "chain lightning",
-                            "aonid": 1462,
-                            "game-obj": "Spells",
-                            "name": "chain lightning",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "\u2014 chain lightning",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of force",
-                            "aonid": 1749,
-                            "game-obj": "Spells",
-                            "name": "wall of force",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of force",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 5,
-                    "level_text": "5th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "fireball",
-                            "aonid": 1530,
-                            "game-obj": "Spells",
-                            "name": "fireball",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "fireball",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "howling blizzard",
-                            "aonid": 1559,
-                            "game-obj": "Spells",
-                            "name": "howling blizzard",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "howling blizzard",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of ice",
-                            "aonid": 1750,
-                            "game-obj": "Spells",
-                            "name": "wall of ice",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of ice",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 4,
-                    "level_text": "4th",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "lightning bolt",
-                            "aonid": 1586,
-                            "game-obj": "Spells",
-                            "name": "lightning bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "lightning bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "thunderstrike",
-                            "aonid": 1721,
-                            "game-obj": "Spells",
-                            "name": "thunderstrike",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "thunderstrike",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of fire",
-                            "aonid": 1748,
-                            "game-obj": "Spells",
-                            "name": "wall of fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 3,
-                    "level_text": "3rd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "force barrage",
-                            "aonid": 1536,
-                            "game-obj": "Spells",
-                            "name": "force barrage",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "force barrage",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "haste",
-                            "aonid": 1553,
-                            "game-obj": "Spells",
-                            "name": "haste",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "haste",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "wall of wind",
-                            "aonid": 1753,
-                            "game-obj": "Spells",
-                            "name": "wall of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "wall of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 2,
-                    "level_text": "2nd",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "blazing bolt",
-                            "aonid": 1450,
-                            "game-obj": "Spells",
-                            "name": "blazing bolt",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "blazing bolt",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "noise blast",
-                            "aonid": 1616,
-                            "game-obj": "Spells",
-                            "name": "noise blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "noise blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic maneuver",
-                            "aonid": 1717,
-                            "game-obj": "Spells",
-                            "name": "telekinetic maneuver",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic maneuver",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "level": 1,
-                    "level_text": "1st",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "breathe fire",
-                            "aonid": 1457,
-                            "game-obj": "Spells",
-                            "name": "breathe fire",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "breathe fire",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "gust of wind",
-                            "aonid": 1550,
-                            "game-obj": "Spells",
-                            "name": "gust of wind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "gust of wind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "tailwind",
-                            "aonid": 1711,
-                            "game-obj": "Spells",
-                            "name": "tailwind",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "tailwind",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "cantrips": true,
-                    "level": 6,
-                    "level_text": "(6th)",
-                    "spells": [
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "caustic blast",
-                            "aonid": 1461,
-                            "game-obj": "Spells",
-                            "name": "caustic blast",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "caustic blast",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "electric arc",
-                            "aonid": 1509,
-                            "game-obj": "Spells",
-                            "name": "electric arc",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "electric arc",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "ignition",
-                            "aonid": 1565,
-                            "game-obj": "Spells",
-                            "name": "ignition",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "ignition",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "light",
-                            "aonid": 1585,
-                            "game-obj": "Spells",
-                            "name": "light",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "light",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      },
-                      {
-                        "count": 1,
-                        "links": [
-                          {
-                            "alt": "telekinetic projectile",
-                            "aonid": 1718,
-                            "game-obj": "Spells",
-                            "name": "telekinetic projectile",
-                            "type": "link"
-                          }
-                        ],
-                        "name": "telekinetic projectile",
-                        "subtype": "spell",
-                        "type": "stat_block_section"
-                      }
-                    ],
-                    "subtype": "spell_list",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "spell_type": "Wrath Spells",
-                "subtype": "spells",
-                "type": "stat_block_section"
+                "alt": "resist energy",
+                "aonid": 1651,
+                "game-obj": "Spells",
+                "name": "resist energy",
+                "type": "link"
+              },
+              {
+                "alt": "unfettered movement",
+                "aonid": 1732,
+                "game-obj": "Spells",
+                "name": "unfettered movement",
+                "type": "link"
+              },
+              {
+                "alt": "clairaudience",
+                "aonid": 1465,
+                "game-obj": "Spells",
+                "name": "clairaudience",
+                "type": "link"
+              },
+              {
+                "alt": "levitate",
+                "aonid": 1584,
+                "game-obj": "Spells",
+                "name": "levitate",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "blur",
+                "aonid": 1455,
+                "game-obj": "Spells",
+                "name": "blur",
+                "type": "link"
+              },
+              {
+                "alt": "environmental endurance",
+                "aonid": 1517,
+                "game-obj": "Spells",
+                "name": "environmental endurance",
+                "type": "link"
+              },
+              {
+                "alt": "see the unseen",
+                "aonid": 1663,
+                "game-obj": "Spells",
+                "name": "see the unseen",
+                "type": "link"
+              },
+              {
+                "alt": "charm",
+                "aonid": 1463,
+                "game-obj": "Spells",
+                "name": "charm",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "summon undead",
+                "aonid": 1706,
+                "game-obj": "Spells",
+                "name": "summon undead",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric exsanguination",
+                "aonid": 1735,
+                "game-obj": "Spells",
+                "name": "vampiric exsanguination",
+                "type": "link"
+              },
+              {
+                "alt": "invoke spirits",
+                "aonid": 1578,
+                "game-obj": "Spells",
+                "name": "invoke spirits",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
+              },
+              {
+                "alt": "wave of despair",
+                "aonid": 1757,
+                "game-obj": "Spells",
+                "name": "wave of despair",
+                "type": "link"
+              },
+              {
+                "alt": "grim tendrils",
+                "aonid": 1548,
+                "game-obj": "Spells",
+                "name": "grim tendrils",
+                "type": "link"
+              },
+              {
+                "alt": "fly",
+                "aonid": 1534,
+                "game-obj": "Spells",
+                "name": "fly",
+                "type": "link"
+              },
+              {
+                "alt": "vision of death",
+                "aonid": 1742,
+                "game-obj": "Spells",
+                "name": "vision of death",
+                "type": "link"
+              },
+              {
+                "alt": "bind undead",
+                "aonid": 1449,
+                "game-obj": "Spells",
+                "name": "bind undead",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "vampiric feast",
+                "aonid": 1736,
+                "game-obj": "Spells",
+                "name": "vampiric feast",
+                "type": "link"
+              },
+              {
+                "alt": "blood vendetta",
+                "aonid": 1454,
+                "game-obj": "Spells",
+                "name": "blood vendetta",
+                "type": "link"
+              },
+              {
+                "alt": "create food",
+                "aonid": 1475,
+                "game-obj": "Spells",
+                "name": "create food",
+                "type": "link"
+              },
+              {
+                "alt": "ghostly carrier",
+                "aonid": 1543,
+                "game-obj": "Spells",
+                "name": "ghostly carrier",
+                "type": "link"
+              },
+              {
+                "alt": "enfeeble",
+                "aonid": 1513,
+                "game-obj": "Spells",
+                "name": "enfeeble",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "goblin pox",
+                "aonid": 1545,
+                "game-obj": "Spells",
+                "name": "goblin pox",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "frostbite",
+                "aonid": 1539,
+                "game-obj": "Spells",
+                "name": "frostbite",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "void warp",
+                "aonid": 1745,
+                "game-obj": "Spells",
+                "name": "void warp",
+                "type": "link"
+              },
+              {
+                "alt": "cursed metamorphosis",
+                "aonid": 1479,
+                "game-obj": "Spells",
+                "name": "cursed metamorphosis",
+                "type": "link"
+              },
+              {
+                "alt": "disintegrate",
+                "aonid": 1492,
+                "game-obj": "Spells",
+                "name": "disintegrate",
+                "type": "link"
+              },
+              {
+                "alt": "elemental form",
+                "aonid": 1510,
+                "game-obj": "Spells",
+                "name": "elemental form",
+                "type": "link"
+              },
+              {
+                "alt": "impaling spike",
+                "aonid": 1571,
+                "game-obj": "Spells",
+                "name": "impaling spike",
+                "type": "link"
+              },
+              {
+                "alt": "wall of stone",
+                "aonid": 1751,
+                "game-obj": "Spells",
+                "name": "wall of stone",
+                "type": "link"
+              },
+              {
+                "alt": "aerial form",
+                "aonid": 1437,
+                "game-obj": "Spells",
+                "name": "aerial form",
+                "type": "link"
+              },
+              {
+                "alt": "creation",
+                "aonid": 1477,
+                "game-obj": "Spells",
+                "name": "creation",
+                "type": "link"
+              },
+              {
+                "alt": "fly",
+                "aonid": 1534,
+                "game-obj": "Spells",
+                "name": "fly",
+                "type": "link"
+              },
+              {
+                "alt": "insect form",
+                "aonid": 1575,
+                "game-obj": "Spells",
+                "name": "insect form",
+                "type": "link"
+              },
+              {
+                "alt": "one with stone",
+                "aonid": 1619,
+                "game-obj": "Spells",
+                "name": "one with stone",
+                "type": "link"
+              },
+              {
+                "alt": "wall of thorns",
+                "aonid": 1752,
+                "game-obj": "Spells",
+                "name": "wall of thorns",
+                "type": "link"
+              },
+              {
+                "alt": "enlarge",
+                "aonid": 1514,
+                "game-obj": "Spells",
+                "name": "enlarge",
+                "type": "link"
+              },
+              {
+                "alt": "humanoid form",
+                "aonid": 1560,
+                "game-obj": "Spells",
+                "name": "humanoid form",
+                "type": "link"
+              },
+              {
+                "alt": "shrink",
+                "aonid": 1672,
+                "game-obj": "Spells",
+                "name": "shrink",
+                "type": "link"
+              },
+              {
+                "alt": "fleet step",
+                "aonid": 1531,
+                "game-obj": "Spells",
+                "name": "fleet step",
+                "type": "link"
+              },
+              {
+                "alt": "mending",
+                "aonid": 1597,
+                "game-obj": "Spells",
+                "name": "mending",
+                "type": "link"
+              },
+              {
+                "alt": "pest form",
+                "aonid": 1626,
+                "game-obj": "Spells",
+                "name": "pest form",
+                "type": "link"
+              },
+              {
+                "alt": "gouging claw",
+                "aonid": 1546,
+                "game-obj": "Spells",
+                "name": "gouging claw",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "read aura",
+                "aonid": 1646,
+                "game-obj": "Spells",
+                "name": "read aura",
+                "type": "link"
+              },
+              {
+                "alt": "shield",
+                "aonid": 1671,
+                "game-obj": "Spells",
+                "name": "shield",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 1718,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 1501,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "never mind",
+                "aonid": 1614,
+                "game-obj": "Spells",
+                "name": "never mind",
+                "type": "link"
+              },
+              {
+                "alt": "mind probe",
+                "aonid": 1601,
+                "game-obj": "Spells",
+                "name": "mind probe",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 1675,
+                "game-obj": "Spells",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "subconscious suggestion",
+                "aonid": 1692,
+                "game-obj": "Spells",
+                "name": "subconscious suggestion",
+                "type": "link"
+              },
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "nightmare",
+                "aonid": 1615,
+                "game-obj": "Spells",
+                "name": "nightmare",
+                "type": "link"
+              },
+              {
+                "alt": "suggestion",
+                "aonid": 1693,
+                "game-obj": "Spells",
+                "name": "suggestion",
+                "type": "link"
+              },
+              {
+                "alt": "dream message",
+                "aonid": 1503,
+                "game-obj": "Spells",
+                "name": "dream message",
+                "type": "link"
+              },
+              {
+                "alt": "enthrall",
+                "aonid": 1516,
+                "game-obj": "Spells",
+                "name": "enthrall",
+                "type": "link"
+              },
+              {
+                "alt": "paralyze",
+                "aonid": 1622,
+                "game-obj": "Spells",
+                "name": "paralyze",
+                "type": "link"
+              },
+              {
+                "alt": "blur",
+                "aonid": 1455,
+                "game-obj": "Spells",
+                "name": "blur",
+                "type": "link"
+              },
+              {
+                "alt": "laughing fit",
+                "aonid": 1583,
+                "game-obj": "Spells",
+                "name": "laughing fit",
+                "type": "link"
+              },
+              {
+                "alt": "stupefy",
+                "aonid": 1691,
+                "game-obj": "Spells",
+                "name": "stupefy",
+                "type": "link"
+              },
+              {
+                "alt": "charm",
+                "aonid": 1463,
+                "game-obj": "Spells",
+                "name": "charm",
+                "type": "link"
+              },
+              {
+                "alt": "command",
+                "aonid": 1470,
+                "game-obj": "Spells",
+                "name": "command",
+                "type": "link"
+              },
+              {
+                "alt": "fear",
+                "aonid": 1524,
+                "game-obj": "Spells",
+                "name": "fear",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "detect magic",
+                "aonid": 1485,
+                "game-obj": "Spells",
+                "name": "detect magic",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
+              },
+              {
+                "alt": "illusory creature",
+                "aonid": 1567,
+                "game-obj": "Spells",
+                "name": "illusory creature",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal calamity",
+                "aonid": 1630,
+                "game-obj": "Spells",
+                "name": "phantasmal calamity",
+                "type": "link"
+              },
+              {
+                "alt": "dizzying colors",
+                "aonid": 1500,
+                "game-obj": "Spells",
+                "name": "dizzying colors",
+                "type": "link"
+              },
+              {
+                "alt": "hallucination",
+                "aonid": 1551,
+                "game-obj": "Spells",
+                "name": "hallucination",
+                "type": "link"
+              },
+              {
+                "alt": "illusory scene",
+                "aonid": 1570,
+                "game-obj": "Spells",
+                "name": "illusory scene",
+                "type": "link"
+              },
+              {
+                "alt": "invisibility",
+                "aonid": 1577,
+                "game-obj": "Spells",
+                "name": "invisibility",
+                "type": "link"
+              },
+              {
+                "alt": "mirage",
+                "aonid": 1604,
+                "game-obj": "Spells",
+                "name": "mirage",
+                "type": "link"
+              },
+              {
+                "alt": "vision of death",
+                "aonid": 1742,
+                "game-obj": "Spells",
+                "name": "vision of death",
+                "type": "link"
+              },
+              {
+                "alt": "illusory disguise",
+                "aonid": 1568,
+                "game-obj": "Spells",
+                "name": "illusory disguise",
+                "type": "link"
+              },
+              {
+                "alt": "hypnotize",
+                "aonid": 1564,
+                "game-obj": "Spells",
+                "name": "hypnotize",
+                "type": "link"
+              },
+              {
+                "alt": "paralyze",
+                "aonid": 1622,
+                "game-obj": "Spells",
+                "name": "paralyze",
+                "type": "link"
+              },
+              {
+                "alt": "blur",
+                "aonid": 1455,
+                "game-obj": "Spells",
+                "name": "blur",
+                "type": "link"
+              },
+              {
+                "alt": "darkness",
+                "aonid": 1480,
+                "game-obj": "Spells",
+                "name": "darkness",
+                "type": "link"
+              },
+              {
+                "alt": "revealing light",
+                "aonid": 1653,
+                "game-obj": "Spells",
+                "name": "revealing light",
+                "type": "link"
+              },
+              {
+                "alt": "disguise magic",
+                "aonid": 1491,
+                "game-obj": "Spells",
+                "name": "disguise magic",
+                "type": "link"
+              },
+              {
+                "alt": "illusory object",
+                "aonid": 1569,
+                "game-obj": "Spells",
+                "name": "illusory object",
+                "type": "link"
+              },
+              {
+                "alt": "phantasmal minion",
+                "aonid": 1631,
+                "game-obj": "Spells",
+                "name": "phantasmal minion",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "figment",
+                "aonid": 1528,
+                "game-obj": "Spells",
+                "name": "figment",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "sigil",
+                "aonid": 1673,
+                "game-obj": "Spells",
+                "name": "sigil",
+                "type": "link"
+              },
+              {
+                "alt": "disintegrate",
+                "aonid": 1492,
+                "game-obj": "Spells",
+                "name": "disintegrate",
+                "type": "link"
+              },
+              {
+                "alt": "teleport",
+                "aonid": 1720,
+                "game-obj": "Spells",
+                "name": "teleport",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 1675,
+                "game-obj": "Spells",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "slither",
+                "aonid": 1676,
+                "game-obj": "Spells",
+                "name": "slither",
+                "type": "link"
+              },
+              {
+                "alt": "toxic cloud",
+                "aonid": 1722,
+                "game-obj": "Spells",
+                "name": "toxic cloud",
+                "type": "link"
+              },
+              {
+                "alt": "confusion",
+                "aonid": 1471,
+                "game-obj": "Spells",
+                "name": "confusion",
+                "type": "link"
+              },
+              {
+                "alt": "fly",
+                "aonid": 1534,
+                "game-obj": "Spells",
+                "name": "fly",
+                "type": "link"
+              },
+              {
+                "alt": "translocate",
+                "aonid": 1724,
+                "game-obj": "Spells",
+                "name": "translocate",
+                "type": "link"
+              },
+              {
+                "alt": "cozy cabin",
+                "aonid": 1474,
+                "game-obj": "Spells",
+                "name": "cozy cabin",
+                "type": "link"
+              },
+              {
+                "alt": "slow",
+                "aonid": 1677,
+                "game-obj": "Spells",
+                "name": "slow",
+                "type": "link"
+              },
+              {
+                "alt": "wall of thorns",
+                "aonid": 1752,
+                "game-obj": "Spells",
+                "name": "wall of thorns",
+                "type": "link"
+              },
+              {
+                "alt": "create food",
+                "aonid": 1475,
+                "game-obj": "Spells",
+                "name": "create food",
+                "type": "link"
+              },
+              {
+                "alt": "marvelous mount",
+                "aonid": 1594,
+                "game-obj": "Spells",
+                "name": "marvelous mount",
+                "type": "link"
+              },
+              {
+                "alt": "mist",
+                "aonid": 1606,
+                "game-obj": "Spells",
+                "name": "mist",
+                "type": "link"
+              },
+              {
+                "alt": "create water",
+                "aonid": 1476,
+                "game-obj": "Spells",
+                "name": "create water",
+                "type": "link"
+              },
+              {
+                "alt": "gentle landing",
+                "aonid": 1542,
+                "game-obj": "Spells",
+                "name": "gentle landing",
+                "type": "link"
+              },
+              {
+                "alt": "sure strike",
+                "aonid": 1709,
+                "game-obj": "Spells",
+                "name": "sure strike",
+                "type": "link"
+              },
+              {
+                "alt": "daze",
+                "aonid": 1482,
+                "game-obj": "Spells",
+                "name": "daze",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "message",
+                "aonid": 1598,
+                "game-obj": "Spells",
+                "name": "message",
+                "type": "link"
+              },
+              {
+                "alt": "prestidigitation",
+                "aonid": 1639,
+                "game-obj": "Spells",
+                "name": "prestidigitation",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic hand",
+                "aonid": 1715,
+                "game-obj": "Spells",
+                "name": "telekinetic hand",
+                "type": "link"
+              },
+              {
+                "alt": "chain lightning",
+                "aonid": 1462,
+                "game-obj": "Spells",
+                "name": "chain lightning",
+                "type": "link"
+              },
+              {
+                "alt": "wall of force",
+                "aonid": 1749,
+                "game-obj": "Spells",
+                "name": "wall of force",
+                "type": "link"
+              },
+              {
+                "alt": "fireball",
+                "aonid": 1530,
+                "game-obj": "Spells",
+                "name": "fireball",
+                "type": "link"
+              },
+              {
+                "alt": "howling blizzard",
+                "aonid": 1559,
+                "game-obj": "Spells",
+                "name": "howling blizzard",
+                "type": "link"
+              },
+              {
+                "alt": "wall of ice",
+                "aonid": 1750,
+                "game-obj": "Spells",
+                "name": "wall of ice",
+                "type": "link"
+              },
+              {
+                "alt": "lightning bolt",
+                "aonid": 1586,
+                "game-obj": "Spells",
+                "name": "lightning bolt",
+                "type": "link"
+              },
+              {
+                "alt": "thunderstrike",
+                "aonid": 1721,
+                "game-obj": "Spells",
+                "name": "thunderstrike",
+                "type": "link"
+              },
+              {
+                "alt": "wall of fire",
+                "aonid": 1748,
+                "game-obj": "Spells",
+                "name": "wall of fire",
+                "type": "link"
+              },
+              {
+                "alt": "force barrage",
+                "aonid": 1536,
+                "game-obj": "Spells",
+                "name": "force barrage",
+                "type": "link"
+              },
+              {
+                "alt": "haste",
+                "aonid": 1553,
+                "game-obj": "Spells",
+                "name": "haste",
+                "type": "link"
+              },
+              {
+                "alt": "wall of wind",
+                "aonid": 1753,
+                "game-obj": "Spells",
+                "name": "wall of wind",
+                "type": "link"
+              },
+              {
+                "alt": "blazing bolt",
+                "aonid": 1450,
+                "game-obj": "Spells",
+                "name": "blazing bolt",
+                "type": "link"
+              },
+              {
+                "alt": "noise blast",
+                "aonid": 1616,
+                "game-obj": "Spells",
+                "name": "noise blast",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic maneuver",
+                "aonid": 1717,
+                "game-obj": "Spells",
+                "name": "telekinetic maneuver",
+                "type": "link"
+              },
+              {
+                "alt": "breathe fire",
+                "aonid": 1457,
+                "game-obj": "Spells",
+                "name": "breathe fire",
+                "type": "link"
+              },
+              {
+                "alt": "gust of wind",
+                "aonid": 1550,
+                "game-obj": "Spells",
+                "name": "gust of wind",
+                "type": "link"
+              },
+              {
+                "alt": "tailwind",
+                "aonid": 1711,
+                "game-obj": "Spells",
+                "name": "tailwind",
+                "type": "link"
+              },
+              {
+                "alt": "caustic blast",
+                "aonid": 1461,
+                "game-obj": "Spells",
+                "name": "caustic blast",
+                "type": "link"
+              },
+              {
+                "alt": "electric arc",
+                "aonid": 1509,
+                "game-obj": "Spells",
+                "name": "electric arc",
+                "type": "link"
+              },
+              {
+                "alt": "ignition",
+                "aonid": 1565,
+                "game-obj": "Spells",
+                "name": "ignition",
+                "type": "link"
+              },
+              {
+                "alt": "light",
+                "aonid": 1585,
+                "game-obj": "Spells",
+                "name": "light",
+                "type": "link"
+              },
+              {
+                "alt": "telekinetic projectile",
+                "aonid": 1718,
+                "game-obj": "Spells",
+                "name": "telekinetic projectile",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -2851,7 +1171,6 @@
         ],
         "name": "Risen Runelord Spells",
         "subtype": "monster_family",
-        "text": "A risen runelord's prepared spells depend upon their sinful legacy. When creating higher-level risen runelords, use these selections as thematic guidelines when selecting higher-rank spells. A risen runelord prepares arcane spells but doesn't require a spellbook to do so, nor can they learn new spells\u2014the spells they have prepared upon their creation are it.",
         "type": "stat_block_section"
       }
     ],
@@ -2859,6 +1178,3874 @@
   },
   "name": "Risen Runelord",
   "schema_version": 1.0,
+  "sections": [
+    {
+      "links": [
+        {
+          "alt": "dispelling globe",
+          "aonid": 1494,
+          "game-obj": "Spells",
+          "name": "dispelling globe",
+          "type": "link"
+        },
+        {
+          "alt": "repulsion",
+          "aonid": 1650,
+          "game-obj": "Spells",
+          "name": "repulsion",
+          "type": "link"
+        },
+        {
+          "alt": "banishment",
+          "aonid": 1448,
+          "game-obj": "Spells",
+          "name": "banishment",
+          "type": "link"
+        },
+        {
+          "alt": "dispel magic",
+          "aonid": 1493,
+          "game-obj": "Spells",
+          "name": "dispel magic",
+          "type": "link"
+        },
+        {
+          "alt": "veil of privacy",
+          "aonid": 1739,
+          "game-obj": "Spells",
+          "name": "veil of privacy",
+          "type": "link"
+        },
+        {
+          "alt": "planar tether",
+          "aonid": 1636,
+          "game-obj": "Spells",
+          "name": "planar tether",
+          "type": "link"
+        },
+        {
+          "alt": "resist energy",
+          "aonid": 1651,
+          "game-obj": "Spells",
+          "name": "resist energy",
+          "type": "link"
+        },
+        {
+          "alt": "unfettered movement",
+          "aonid": 1732,
+          "game-obj": "Spells",
+          "name": "unfettered movement",
+          "type": "link"
+        },
+        {
+          "alt": "clairaudience",
+          "aonid": 1465,
+          "game-obj": "Spells",
+          "name": "clairaudience",
+          "type": "link"
+        },
+        {
+          "alt": "levitate",
+          "aonid": 1584,
+          "game-obj": "Spells",
+          "name": "levitate",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "blur",
+          "aonid": 1455,
+          "game-obj": "Spells",
+          "name": "blur",
+          "type": "link"
+        },
+        {
+          "alt": "environmental endurance",
+          "aonid": 1517,
+          "game-obj": "Spells",
+          "name": "environmental endurance",
+          "type": "link"
+        },
+        {
+          "alt": "see the unseen",
+          "aonid": 1663,
+          "game-obj": "Spells",
+          "name": "see the unseen",
+          "type": "link"
+        },
+        {
+          "alt": "charm",
+          "aonid": 1463,
+          "game-obj": "Spells",
+          "name": "charm",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "summon undead",
+          "aonid": 1706,
+          "game-obj": "Spells",
+          "name": "summon undead",
+          "type": "link"
+        },
+        {
+          "alt": "vampiric exsanguination",
+          "aonid": 1735,
+          "game-obj": "Spells",
+          "name": "vampiric exsanguination",
+          "type": "link"
+        },
+        {
+          "alt": "invoke spirits",
+          "aonid": 1578,
+          "game-obj": "Spells",
+          "name": "invoke spirits",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        },
+        {
+          "alt": "wave of despair",
+          "aonid": 1757,
+          "game-obj": "Spells",
+          "name": "wave of despair",
+          "type": "link"
+        },
+        {
+          "alt": "grim tendrils",
+          "aonid": 1548,
+          "game-obj": "Spells",
+          "name": "grim tendrils",
+          "type": "link"
+        },
+        {
+          "alt": "fly",
+          "aonid": 1534,
+          "game-obj": "Spells",
+          "name": "fly",
+          "type": "link"
+        },
+        {
+          "alt": "vision of death",
+          "aonid": 1742,
+          "game-obj": "Spells",
+          "name": "vision of death",
+          "type": "link"
+        },
+        {
+          "alt": "bind undead",
+          "aonid": 1449,
+          "game-obj": "Spells",
+          "name": "bind undead",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "vampiric feast",
+          "aonid": 1736,
+          "game-obj": "Spells",
+          "name": "vampiric feast",
+          "type": "link"
+        },
+        {
+          "alt": "blood vendetta",
+          "aonid": 1454,
+          "game-obj": "Spells",
+          "name": "blood vendetta",
+          "type": "link"
+        },
+        {
+          "alt": "create food",
+          "aonid": 1475,
+          "game-obj": "Spells",
+          "name": "create food",
+          "type": "link"
+        },
+        {
+          "alt": "ghostly carrier",
+          "aonid": 1543,
+          "game-obj": "Spells",
+          "name": "ghostly carrier",
+          "type": "link"
+        },
+        {
+          "alt": "enfeeble",
+          "aonid": 1513,
+          "game-obj": "Spells",
+          "name": "enfeeble",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "goblin pox",
+          "aonid": 1545,
+          "game-obj": "Spells",
+          "name": "goblin pox",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "frostbite",
+          "aonid": 1539,
+          "game-obj": "Spells",
+          "name": "frostbite",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "void warp",
+          "aonid": 1745,
+          "game-obj": "Spells",
+          "name": "void warp",
+          "type": "link"
+        },
+        {
+          "alt": "cursed metamorphosis",
+          "aonid": 1479,
+          "game-obj": "Spells",
+          "name": "cursed metamorphosis",
+          "type": "link"
+        },
+        {
+          "alt": "disintegrate",
+          "aonid": 1492,
+          "game-obj": "Spells",
+          "name": "disintegrate",
+          "type": "link"
+        },
+        {
+          "alt": "elemental form",
+          "aonid": 1510,
+          "game-obj": "Spells",
+          "name": "elemental form",
+          "type": "link"
+        },
+        {
+          "alt": "impaling spike",
+          "aonid": 1571,
+          "game-obj": "Spells",
+          "name": "impaling spike",
+          "type": "link"
+        },
+        {
+          "alt": "wall of stone",
+          "aonid": 1751,
+          "game-obj": "Spells",
+          "name": "wall of stone",
+          "type": "link"
+        },
+        {
+          "alt": "aerial form",
+          "aonid": 1437,
+          "game-obj": "Spells",
+          "name": "aerial form",
+          "type": "link"
+        },
+        {
+          "alt": "creation",
+          "aonid": 1477,
+          "game-obj": "Spells",
+          "name": "creation",
+          "type": "link"
+        },
+        {
+          "alt": "fly",
+          "aonid": 1534,
+          "game-obj": "Spells",
+          "name": "fly",
+          "type": "link"
+        },
+        {
+          "alt": "insect form",
+          "aonid": 1575,
+          "game-obj": "Spells",
+          "name": "insect form",
+          "type": "link"
+        },
+        {
+          "alt": "one with stone",
+          "aonid": 1619,
+          "game-obj": "Spells",
+          "name": "one with stone",
+          "type": "link"
+        },
+        {
+          "alt": "wall of thorns",
+          "aonid": 1752,
+          "game-obj": "Spells",
+          "name": "wall of thorns",
+          "type": "link"
+        },
+        {
+          "alt": "enlarge",
+          "aonid": 1514,
+          "game-obj": "Spells",
+          "name": "enlarge",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid form",
+          "aonid": 1560,
+          "game-obj": "Spells",
+          "name": "humanoid form",
+          "type": "link"
+        },
+        {
+          "alt": "shrink",
+          "aonid": 1672,
+          "game-obj": "Spells",
+          "name": "shrink",
+          "type": "link"
+        },
+        {
+          "alt": "fleet step",
+          "aonid": 1531,
+          "game-obj": "Spells",
+          "name": "fleet step",
+          "type": "link"
+        },
+        {
+          "alt": "mending",
+          "aonid": 1597,
+          "game-obj": "Spells",
+          "name": "mending",
+          "type": "link"
+        },
+        {
+          "alt": "pest form",
+          "aonid": 1626,
+          "game-obj": "Spells",
+          "name": "pest form",
+          "type": "link"
+        },
+        {
+          "alt": "gouging claw",
+          "aonid": 1546,
+          "game-obj": "Spells",
+          "name": "gouging claw",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "read aura",
+          "aonid": 1646,
+          "game-obj": "Spells",
+          "name": "read aura",
+          "type": "link"
+        },
+        {
+          "alt": "shield",
+          "aonid": 1671,
+          "game-obj": "Spells",
+          "name": "shield",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 1718,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 1501,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "never mind",
+          "aonid": 1614,
+          "game-obj": "Spells",
+          "name": "never mind",
+          "type": "link"
+        },
+        {
+          "alt": "mind probe",
+          "aonid": 1601,
+          "game-obj": "Spells",
+          "name": "mind probe",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 1675,
+          "game-obj": "Spells",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "subconscious suggestion",
+          "aonid": 1692,
+          "game-obj": "Spells",
+          "name": "subconscious suggestion",
+          "type": "link"
+        },
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "nightmare",
+          "aonid": 1615,
+          "game-obj": "Spells",
+          "name": "nightmare",
+          "type": "link"
+        },
+        {
+          "alt": "suggestion",
+          "aonid": 1693,
+          "game-obj": "Spells",
+          "name": "suggestion",
+          "type": "link"
+        },
+        {
+          "alt": "dream message",
+          "aonid": 1503,
+          "game-obj": "Spells",
+          "name": "dream message",
+          "type": "link"
+        },
+        {
+          "alt": "enthrall",
+          "aonid": 1516,
+          "game-obj": "Spells",
+          "name": "enthrall",
+          "type": "link"
+        },
+        {
+          "alt": "paralyze",
+          "aonid": 1622,
+          "game-obj": "Spells",
+          "name": "paralyze",
+          "type": "link"
+        },
+        {
+          "alt": "blur",
+          "aonid": 1455,
+          "game-obj": "Spells",
+          "name": "blur",
+          "type": "link"
+        },
+        {
+          "alt": "laughing fit",
+          "aonid": 1583,
+          "game-obj": "Spells",
+          "name": "laughing fit",
+          "type": "link"
+        },
+        {
+          "alt": "stupefy",
+          "aonid": 1691,
+          "game-obj": "Spells",
+          "name": "stupefy",
+          "type": "link"
+        },
+        {
+          "alt": "charm",
+          "aonid": 1463,
+          "game-obj": "Spells",
+          "name": "charm",
+          "type": "link"
+        },
+        {
+          "alt": "command",
+          "aonid": 1470,
+          "game-obj": "Spells",
+          "name": "command",
+          "type": "link"
+        },
+        {
+          "alt": "fear",
+          "aonid": 1524,
+          "game-obj": "Spells",
+          "name": "fear",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "detect magic",
+          "aonid": 1485,
+          "game-obj": "Spells",
+          "name": "detect magic",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        },
+        {
+          "alt": "illusory creature",
+          "aonid": 1567,
+          "game-obj": "Spells",
+          "name": "illusory creature",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal calamity",
+          "aonid": 1630,
+          "game-obj": "Spells",
+          "name": "phantasmal calamity",
+          "type": "link"
+        },
+        {
+          "alt": "dizzying colors",
+          "aonid": 1500,
+          "game-obj": "Spells",
+          "name": "dizzying colors",
+          "type": "link"
+        },
+        {
+          "alt": "hallucination",
+          "aonid": 1551,
+          "game-obj": "Spells",
+          "name": "hallucination",
+          "type": "link"
+        },
+        {
+          "alt": "illusory scene",
+          "aonid": 1570,
+          "game-obj": "Spells",
+          "name": "illusory scene",
+          "type": "link"
+        },
+        {
+          "alt": "invisibility",
+          "aonid": 1577,
+          "game-obj": "Spells",
+          "name": "invisibility",
+          "type": "link"
+        },
+        {
+          "alt": "mirage",
+          "aonid": 1604,
+          "game-obj": "Spells",
+          "name": "mirage",
+          "type": "link"
+        },
+        {
+          "alt": "vision of death",
+          "aonid": 1742,
+          "game-obj": "Spells",
+          "name": "vision of death",
+          "type": "link"
+        },
+        {
+          "alt": "illusory disguise",
+          "aonid": 1568,
+          "game-obj": "Spells",
+          "name": "illusory disguise",
+          "type": "link"
+        },
+        {
+          "alt": "hypnotize",
+          "aonid": 1564,
+          "game-obj": "Spells",
+          "name": "hypnotize",
+          "type": "link"
+        },
+        {
+          "alt": "paralyze",
+          "aonid": 1622,
+          "game-obj": "Spells",
+          "name": "paralyze",
+          "type": "link"
+        },
+        {
+          "alt": "blur",
+          "aonid": 1455,
+          "game-obj": "Spells",
+          "name": "blur",
+          "type": "link"
+        },
+        {
+          "alt": "darkness",
+          "aonid": 1480,
+          "game-obj": "Spells",
+          "name": "darkness",
+          "type": "link"
+        },
+        {
+          "alt": "revealing light",
+          "aonid": 1653,
+          "game-obj": "Spells",
+          "name": "revealing light",
+          "type": "link"
+        },
+        {
+          "alt": "disguise magic",
+          "aonid": 1491,
+          "game-obj": "Spells",
+          "name": "disguise magic",
+          "type": "link"
+        },
+        {
+          "alt": "illusory object",
+          "aonid": 1569,
+          "game-obj": "Spells",
+          "name": "illusory object",
+          "type": "link"
+        },
+        {
+          "alt": "phantasmal minion",
+          "aonid": 1631,
+          "game-obj": "Spells",
+          "name": "phantasmal minion",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "figment",
+          "aonid": 1528,
+          "game-obj": "Spells",
+          "name": "figment",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "sigil",
+          "aonid": 1673,
+          "game-obj": "Spells",
+          "name": "sigil",
+          "type": "link"
+        },
+        {
+          "alt": "disintegrate",
+          "aonid": 1492,
+          "game-obj": "Spells",
+          "name": "disintegrate",
+          "type": "link"
+        },
+        {
+          "alt": "teleport",
+          "aonid": 1720,
+          "game-obj": "Spells",
+          "name": "teleport",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 1675,
+          "game-obj": "Spells",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "slither",
+          "aonid": 1676,
+          "game-obj": "Spells",
+          "name": "slither",
+          "type": "link"
+        },
+        {
+          "alt": "toxic cloud",
+          "aonid": 1722,
+          "game-obj": "Spells",
+          "name": "toxic cloud",
+          "type": "link"
+        },
+        {
+          "alt": "confusion",
+          "aonid": 1471,
+          "game-obj": "Spells",
+          "name": "confusion",
+          "type": "link"
+        },
+        {
+          "alt": "fly",
+          "aonid": 1534,
+          "game-obj": "Spells",
+          "name": "fly",
+          "type": "link"
+        },
+        {
+          "alt": "translocate",
+          "aonid": 1724,
+          "game-obj": "Spells",
+          "name": "translocate",
+          "type": "link"
+        },
+        {
+          "alt": "cozy cabin",
+          "aonid": 1474,
+          "game-obj": "Spells",
+          "name": "cozy cabin",
+          "type": "link"
+        },
+        {
+          "alt": "slow",
+          "aonid": 1677,
+          "game-obj": "Spells",
+          "name": "slow",
+          "type": "link"
+        },
+        {
+          "alt": "wall of thorns",
+          "aonid": 1752,
+          "game-obj": "Spells",
+          "name": "wall of thorns",
+          "type": "link"
+        },
+        {
+          "alt": "create food",
+          "aonid": 1475,
+          "game-obj": "Spells",
+          "name": "create food",
+          "type": "link"
+        },
+        {
+          "alt": "marvelous mount",
+          "aonid": 1594,
+          "game-obj": "Spells",
+          "name": "marvelous mount",
+          "type": "link"
+        },
+        {
+          "alt": "mist",
+          "aonid": 1606,
+          "game-obj": "Spells",
+          "name": "mist",
+          "type": "link"
+        },
+        {
+          "alt": "create water",
+          "aonid": 1476,
+          "game-obj": "Spells",
+          "name": "create water",
+          "type": "link"
+        },
+        {
+          "alt": "gentle landing",
+          "aonid": 1542,
+          "game-obj": "Spells",
+          "name": "gentle landing",
+          "type": "link"
+        },
+        {
+          "alt": "sure strike",
+          "aonid": 1709,
+          "game-obj": "Spells",
+          "name": "sure strike",
+          "type": "link"
+        },
+        {
+          "alt": "daze",
+          "aonid": 1482,
+          "game-obj": "Spells",
+          "name": "daze",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "message",
+          "aonid": 1598,
+          "game-obj": "Spells",
+          "name": "message",
+          "type": "link"
+        },
+        {
+          "alt": "prestidigitation",
+          "aonid": 1639,
+          "game-obj": "Spells",
+          "name": "prestidigitation",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic hand",
+          "aonid": 1715,
+          "game-obj": "Spells",
+          "name": "telekinetic hand",
+          "type": "link"
+        },
+        {
+          "alt": "chain lightning",
+          "aonid": 1462,
+          "game-obj": "Spells",
+          "name": "chain lightning",
+          "type": "link"
+        },
+        {
+          "alt": "wall of force",
+          "aonid": 1749,
+          "game-obj": "Spells",
+          "name": "wall of force",
+          "type": "link"
+        },
+        {
+          "alt": "fireball",
+          "aonid": 1530,
+          "game-obj": "Spells",
+          "name": "fireball",
+          "type": "link"
+        },
+        {
+          "alt": "howling blizzard",
+          "aonid": 1559,
+          "game-obj": "Spells",
+          "name": "howling blizzard",
+          "type": "link"
+        },
+        {
+          "alt": "wall of ice",
+          "aonid": 1750,
+          "game-obj": "Spells",
+          "name": "wall of ice",
+          "type": "link"
+        },
+        {
+          "alt": "lightning bolt",
+          "aonid": 1586,
+          "game-obj": "Spells",
+          "name": "lightning bolt",
+          "type": "link"
+        },
+        {
+          "alt": "thunderstrike",
+          "aonid": 1721,
+          "game-obj": "Spells",
+          "name": "thunderstrike",
+          "type": "link"
+        },
+        {
+          "alt": "wall of fire",
+          "aonid": 1748,
+          "game-obj": "Spells",
+          "name": "wall of fire",
+          "type": "link"
+        },
+        {
+          "alt": "force barrage",
+          "aonid": 1536,
+          "game-obj": "Spells",
+          "name": "force barrage",
+          "type": "link"
+        },
+        {
+          "alt": "haste",
+          "aonid": 1553,
+          "game-obj": "Spells",
+          "name": "haste",
+          "type": "link"
+        },
+        {
+          "alt": "wall of wind",
+          "aonid": 1753,
+          "game-obj": "Spells",
+          "name": "wall of wind",
+          "type": "link"
+        },
+        {
+          "alt": "blazing bolt",
+          "aonid": 1450,
+          "game-obj": "Spells",
+          "name": "blazing bolt",
+          "type": "link"
+        },
+        {
+          "alt": "noise blast",
+          "aonid": 1616,
+          "game-obj": "Spells",
+          "name": "noise blast",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic maneuver",
+          "aonid": 1717,
+          "game-obj": "Spells",
+          "name": "telekinetic maneuver",
+          "type": "link"
+        },
+        {
+          "alt": "breathe fire",
+          "aonid": 1457,
+          "game-obj": "Spells",
+          "name": "breathe fire",
+          "type": "link"
+        },
+        {
+          "alt": "gust of wind",
+          "aonid": 1550,
+          "game-obj": "Spells",
+          "name": "gust of wind",
+          "type": "link"
+        },
+        {
+          "alt": "tailwind",
+          "aonid": 1711,
+          "game-obj": "Spells",
+          "name": "tailwind",
+          "type": "link"
+        },
+        {
+          "alt": "caustic blast",
+          "aonid": 1461,
+          "game-obj": "Spells",
+          "name": "caustic blast",
+          "type": "link"
+        },
+        {
+          "alt": "electric arc",
+          "aonid": 1509,
+          "game-obj": "Spells",
+          "name": "electric arc",
+          "type": "link"
+        },
+        {
+          "alt": "ignition",
+          "aonid": 1565,
+          "game-obj": "Spells",
+          "name": "ignition",
+          "type": "link"
+        },
+        {
+          "alt": "light",
+          "aonid": 1585,
+          "game-obj": "Spells",
+          "name": "light",
+          "type": "link"
+        },
+        {
+          "alt": "telekinetic projectile",
+          "aonid": 1718,
+          "game-obj": "Spells",
+          "name": "telekinetic projectile",
+          "type": "link"
+        }
+      ],
+      "name": "Risen Runelord Spells",
+      "sources": [
+        {
+          "link": {
+            "alt": "Pathfinder Adventure Path #219: Lord of the Trinity Star pg. 90",
+            "aonid": 283,
+            "game-obj": "Sources",
+            "name": "Pathfinder Adventure Path #219: Lord of the Trinity Star pg. 90",
+            "type": "link"
+          },
+          "name": "Pathfinder Adventure Path #219: Lord of the Trinity Star",
+          "page": 90,
+          "type": "source"
+        }
+      ],
+      "spells": [
+        {
+          "name": "Envy Spells",
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispelling globe",
+                      "aonid": 1494,
+                      "game-obj": "Spells",
+                      "name": "dispelling globe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "\u2014 dispelling globe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "repulsion",
+                      "aonid": 1650,
+                      "game-obj": "Spells",
+                      "name": "repulsion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "repulsion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "banishment",
+                      "aonid": 1448,
+                      "game-obj": "Spells",
+                      "name": "banishment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "banishment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dispel magic",
+                      "aonid": 1493,
+                      "game-obj": "Spells",
+                      "name": "dispel magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dispel magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "veil of privacy",
+                      "aonid": 1739,
+                      "game-obj": "Spells",
+                      "name": "veil of privacy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "veil of privacy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "planar tether",
+                      "aonid": 1636,
+                      "game-obj": "Spells",
+                      "name": "planar tether",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "planar tether",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "resist energy",
+                      "aonid": 1651,
+                      "game-obj": "Spells",
+                      "name": "resist energy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "resist energy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "unfettered movement",
+                      "aonid": 1732,
+                      "game-obj": "Spells",
+                      "name": "unfettered movement",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "unfettered movement",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "clairaudience",
+                      "aonid": 1465,
+                      "game-obj": "Spells",
+                      "name": "clairaudience",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "clairaudience",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "levitate",
+                      "aonid": 1584,
+                      "game-obj": "Spells",
+                      "name": "levitate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "levitate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blur",
+                      "aonid": 1455,
+                      "game-obj": "Spells",
+                      "name": "blur",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blur",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "environmental endurance",
+                      "aonid": 1517,
+                      "game-obj": "Spells",
+                      "name": "environmental endurance",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "environmental endurance",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "see the unseen",
+                      "aonid": 1663,
+                      "game-obj": "Spells",
+                      "name": "see the unseen",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "see the unseen",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "charm",
+                      "aonid": 1463,
+                      "game-obj": "Spells",
+                      "name": "charm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "charm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_type": "Envy Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        },
+        {
+          "name": "Gluttony Spells",
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "summon undead",
+                      "aonid": 1706,
+                      "game-obj": "Spells",
+                      "name": "summon undead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "\u2014 summon undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vampiric exsanguination",
+                      "aonid": 1735,
+                      "game-obj": "Spells",
+                      "name": "vampiric exsanguination",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vampiric exsanguination",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "invoke spirits",
+                      "aonid": 1578,
+                      "game-obj": "Spells",
+                      "name": "invoke spirits",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "invoke spirits",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wave of despair",
+                      "aonid": 1757,
+                      "game-obj": "Spells",
+                      "name": "wave of despair",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wave of despair",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "grim tendrils",
+                      "aonid": 1548,
+                      "game-obj": "Spells",
+                      "name": "grim tendrils",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "grim tendrils",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fly",
+                      "aonid": 1534,
+                      "game-obj": "Spells",
+                      "name": "fly",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fly",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vision of death",
+                      "aonid": 1742,
+                      "game-obj": "Spells",
+                      "name": "vision of death",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vision of death",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "bind undead",
+                      "aonid": 1449,
+                      "game-obj": "Spells",
+                      "name": "bind undead",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "bind undead",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vampiric feast",
+                      "aonid": 1736,
+                      "game-obj": "Spells",
+                      "name": "vampiric feast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vampiric feast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blood vendetta",
+                      "aonid": 1454,
+                      "game-obj": "Spells",
+                      "name": "blood vendetta",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blood vendetta",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create food",
+                      "aonid": 1475,
+                      "game-obj": "Spells",
+                      "name": "create food",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create food",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ghostly carrier",
+                      "aonid": 1543,
+                      "game-obj": "Spells",
+                      "name": "ghostly carrier",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ghostly carrier",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enfeeble",
+                      "aonid": 1513,
+                      "game-obj": "Spells",
+                      "name": "enfeeble",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enfeeble",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "goblin pox",
+                      "aonid": 1545,
+                      "game-obj": "Spells",
+                      "name": "goblin pox",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "goblin pox",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "frostbite",
+                      "aonid": 1539,
+                      "game-obj": "Spells",
+                      "name": "frostbite",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "frostbite",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "void warp",
+                      "aonid": 1745,
+                      "game-obj": "Spells",
+                      "name": "void warp",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "void warp",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_type": "Gluttony Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        },
+        {
+          "name": "Greed Spells",
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cursed metamorphosis",
+                      "aonid": 1479,
+                      "game-obj": "Spells",
+                      "name": "cursed metamorphosis",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "\u2014 cursed metamorphosis",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disintegrate",
+                      "aonid": 1492,
+                      "game-obj": "Spells",
+                      "name": "disintegrate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disintegrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "elemental form",
+                      "aonid": 1510,
+                      "game-obj": "Spells",
+                      "name": "elemental form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "elemental form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "impaling spike",
+                      "aonid": 1571,
+                      "game-obj": "Spells",
+                      "name": "impaling spike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "impaling spike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of stone",
+                      "aonid": 1751,
+                      "game-obj": "Spells",
+                      "name": "wall of stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "aerial form",
+                      "aonid": 1437,
+                      "game-obj": "Spells",
+                      "name": "aerial form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "aerial form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "creation",
+                      "aonid": 1477,
+                      "game-obj": "Spells",
+                      "name": "creation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "creation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fly",
+                      "aonid": 1534,
+                      "game-obj": "Spells",
+                      "name": "fly",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fly",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "insect form",
+                      "aonid": 1575,
+                      "game-obj": "Spells",
+                      "name": "insect form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "insect form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "one with stone",
+                      "aonid": 1619,
+                      "game-obj": "Spells",
+                      "name": "one with stone",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "one with stone",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of thorns",
+                      "aonid": 1752,
+                      "game-obj": "Spells",
+                      "name": "wall of thorns",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of thorns",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enlarge",
+                      "aonid": 1514,
+                      "game-obj": "Spells",
+                      "name": "enlarge",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enlarge",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "humanoid form",
+                      "aonid": 1560,
+                      "game-obj": "Spells",
+                      "name": "humanoid form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "humanoid form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shrink",
+                      "aonid": 1672,
+                      "game-obj": "Spells",
+                      "name": "shrink",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shrink",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fleet step",
+                      "aonid": 1531,
+                      "game-obj": "Spells",
+                      "name": "fleet step",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fleet step",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mending",
+                      "aonid": 1597,
+                      "game-obj": "Spells",
+                      "name": "mending",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mending",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "pest form",
+                      "aonid": 1626,
+                      "game-obj": "Spells",
+                      "name": "pest form",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "pest form",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gouging claw",
+                      "aonid": 1546,
+                      "game-obj": "Spells",
+                      "name": "gouging claw",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gouging claw",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "read aura",
+                      "aonid": 1646,
+                      "game-obj": "Spells",
+                      "name": "read aura",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "read aura",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "shield",
+                      "aonid": 1671,
+                      "game-obj": "Spells",
+                      "name": "shield",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "shield",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 1718,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_type": "Greed Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        },
+        {
+          "name": "Lust Spells",
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dominate",
+                      "aonid": 1501,
+                      "game-obj": "Spells",
+                      "name": "dominate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "\u2014 dominate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "never mind",
+                      "aonid": 1614,
+                      "game-obj": "Spells",
+                      "name": "never mind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "never mind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mind probe",
+                      "aonid": 1601,
+                      "game-obj": "Spells",
+                      "name": "mind probe",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mind probe",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sleep",
+                      "aonid": 1675,
+                      "game-obj": "Spells",
+                      "name": "sleep",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sleep",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "subconscious suggestion",
+                      "aonid": 1692,
+                      "game-obj": "Spells",
+                      "name": "subconscious suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "subconscious suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "nightmare",
+                      "aonid": 1615,
+                      "game-obj": "Spells",
+                      "name": "nightmare",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "nightmare",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "suggestion",
+                      "aonid": 1693,
+                      "game-obj": "Spells",
+                      "name": "suggestion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "suggestion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dream message",
+                      "aonid": 1503,
+                      "game-obj": "Spells",
+                      "name": "dream message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dream message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "enthrall",
+                      "aonid": 1516,
+                      "game-obj": "Spells",
+                      "name": "enthrall",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "enthrall",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "paralyze",
+                      "aonid": 1622,
+                      "game-obj": "Spells",
+                      "name": "paralyze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "paralyze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blur",
+                      "aonid": 1455,
+                      "game-obj": "Spells",
+                      "name": "blur",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blur",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "laughing fit",
+                      "aonid": 1583,
+                      "game-obj": "Spells",
+                      "name": "laughing fit",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "laughing fit",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "stupefy",
+                      "aonid": 1691,
+                      "game-obj": "Spells",
+                      "name": "stupefy",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "stupefy",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "charm",
+                      "aonid": 1463,
+                      "game-obj": "Spells",
+                      "name": "charm",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "charm",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "command",
+                      "aonid": 1470,
+                      "game-obj": "Spells",
+                      "name": "command",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "command",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fear",
+                      "aonid": 1524,
+                      "game-obj": "Spells",
+                      "name": "fear",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fear",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "detect magic",
+                      "aonid": 1485,
+                      "game-obj": "Spells",
+                      "name": "detect magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "detect magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_type": "Lust Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        },
+        {
+          "name": "Pride Spells",
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory creature",
+                      "aonid": 1567,
+                      "game-obj": "Spells",
+                      "name": "illusory creature",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "\u2014 illusory creature",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal calamity",
+                      "aonid": 1630,
+                      "game-obj": "Spells",
+                      "name": "phantasmal calamity",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal calamity",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "dizzying colors",
+                      "aonid": 1500,
+                      "game-obj": "Spells",
+                      "name": "dizzying colors",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "dizzying colors",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hallucination",
+                      "aonid": 1551,
+                      "game-obj": "Spells",
+                      "name": "hallucination",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hallucination",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory scene",
+                      "aonid": 1570,
+                      "game-obj": "Spells",
+                      "name": "illusory scene",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "illusory scene",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "invisibility",
+                      "aonid": 1577,
+                      "game-obj": "Spells",
+                      "name": "invisibility",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "invisibility",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mirage",
+                      "aonid": 1604,
+                      "game-obj": "Spells",
+                      "name": "mirage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mirage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "vision of death",
+                      "aonid": 1742,
+                      "game-obj": "Spells",
+                      "name": "vision of death",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "vision of death",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory disguise",
+                      "aonid": 1568,
+                      "game-obj": "Spells",
+                      "name": "illusory disguise",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "illusory disguise",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "hypnotize",
+                      "aonid": 1564,
+                      "game-obj": "Spells",
+                      "name": "hypnotize",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "hypnotize",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "paralyze",
+                      "aonid": 1622,
+                      "game-obj": "Spells",
+                      "name": "paralyze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "paralyze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blur",
+                      "aonid": 1455,
+                      "game-obj": "Spells",
+                      "name": "blur",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blur",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "darkness",
+                      "aonid": 1480,
+                      "game-obj": "Spells",
+                      "name": "darkness",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "darkness",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "revealing light",
+                      "aonid": 1653,
+                      "game-obj": "Spells",
+                      "name": "revealing light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "revealing light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disguise magic",
+                      "aonid": 1491,
+                      "game-obj": "Spells",
+                      "name": "disguise magic",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "disguise magic",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "illusory object",
+                      "aonid": 1569,
+                      "game-obj": "Spells",
+                      "name": "illusory object",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "illusory object",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "phantasmal minion",
+                      "aonid": 1631,
+                      "game-obj": "Spells",
+                      "name": "phantasmal minion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "phantasmal minion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "figment",
+                      "aonid": 1528,
+                      "game-obj": "Spells",
+                      "name": "figment",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "figment",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sigil",
+                      "aonid": 1673,
+                      "game-obj": "Spells",
+                      "name": "sigil",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sigil",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_type": "Pride Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        },
+        {
+          "name": "Sloth Spells",
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "disintegrate",
+                      "aonid": 1492,
+                      "game-obj": "Spells",
+                      "name": "disintegrate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "\u2014 disintegrate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "teleport",
+                      "aonid": 1720,
+                      "game-obj": "Spells",
+                      "name": "teleport",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "teleport",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sleep",
+                      "aonid": 1675,
+                      "game-obj": "Spells",
+                      "name": "sleep",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sleep",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slither",
+                      "aonid": 1676,
+                      "game-obj": "Spells",
+                      "name": "slither",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slither",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "toxic cloud",
+                      "aonid": 1722,
+                      "game-obj": "Spells",
+                      "name": "toxic cloud",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "toxic cloud",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "confusion",
+                      "aonid": 1471,
+                      "game-obj": "Spells",
+                      "name": "confusion",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "confusion",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fly",
+                      "aonid": 1534,
+                      "game-obj": "Spells",
+                      "name": "fly",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fly",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "translocate",
+                      "aonid": 1724,
+                      "game-obj": "Spells",
+                      "name": "translocate",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "translocate",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "cozy cabin",
+                      "aonid": 1474,
+                      "game-obj": "Spells",
+                      "name": "cozy cabin",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "cozy cabin",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "slow",
+                      "aonid": 1677,
+                      "game-obj": "Spells",
+                      "name": "slow",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "slow",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of thorns",
+                      "aonid": 1752,
+                      "game-obj": "Spells",
+                      "name": "wall of thorns",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of thorns",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create food",
+                      "aonid": 1475,
+                      "game-obj": "Spells",
+                      "name": "create food",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create food",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "marvelous mount",
+                      "aonid": 1594,
+                      "game-obj": "Spells",
+                      "name": "marvelous mount",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "marvelous mount",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "mist",
+                      "aonid": 1606,
+                      "game-obj": "Spells",
+                      "name": "mist",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "mist",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "create water",
+                      "aonid": 1476,
+                      "game-obj": "Spells",
+                      "name": "create water",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "create water",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gentle landing",
+                      "aonid": 1542,
+                      "game-obj": "Spells",
+                      "name": "gentle landing",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gentle landing",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "sure strike",
+                      "aonid": 1709,
+                      "game-obj": "Spells",
+                      "name": "sure strike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "sure strike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "daze",
+                      "aonid": 1482,
+                      "game-obj": "Spells",
+                      "name": "daze",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "daze",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "message",
+                      "aonid": 1598,
+                      "game-obj": "Spells",
+                      "name": "message",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "message",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "prestidigitation",
+                      "aonid": 1639,
+                      "game-obj": "Spells",
+                      "name": "prestidigitation",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "prestidigitation",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic hand",
+                      "aonid": 1715,
+                      "game-obj": "Spells",
+                      "name": "telekinetic hand",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic hand",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_type": "Sloth Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        },
+        {
+          "name": "Wrath Spells",
+          "spell_list": [
+            {
+              "level": 6,
+              "level_text": "6th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "chain lightning",
+                      "aonid": 1462,
+                      "game-obj": "Spells",
+                      "name": "chain lightning",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "\u2014 chain lightning",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of force",
+                      "aonid": 1749,
+                      "game-obj": "Spells",
+                      "name": "wall of force",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of force",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 5,
+              "level_text": "5th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "fireball",
+                      "aonid": 1530,
+                      "game-obj": "Spells",
+                      "name": "fireball",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "fireball",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "howling blizzard",
+                      "aonid": 1559,
+                      "game-obj": "Spells",
+                      "name": "howling blizzard",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "howling blizzard",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of ice",
+                      "aonid": 1750,
+                      "game-obj": "Spells",
+                      "name": "wall of ice",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of ice",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 4,
+              "level_text": "4th",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "lightning bolt",
+                      "aonid": 1586,
+                      "game-obj": "Spells",
+                      "name": "lightning bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "lightning bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "thunderstrike",
+                      "aonid": 1721,
+                      "game-obj": "Spells",
+                      "name": "thunderstrike",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "thunderstrike",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of fire",
+                      "aonid": 1748,
+                      "game-obj": "Spells",
+                      "name": "wall of fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 3,
+              "level_text": "3rd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "force barrage",
+                      "aonid": 1536,
+                      "game-obj": "Spells",
+                      "name": "force barrage",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "force barrage",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "haste",
+                      "aonid": 1553,
+                      "game-obj": "Spells",
+                      "name": "haste",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "haste",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "wall of wind",
+                      "aonid": 1753,
+                      "game-obj": "Spells",
+                      "name": "wall of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "wall of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 2,
+              "level_text": "2nd",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "blazing bolt",
+                      "aonid": 1450,
+                      "game-obj": "Spells",
+                      "name": "blazing bolt",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "blazing bolt",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "noise blast",
+                      "aonid": 1616,
+                      "game-obj": "Spells",
+                      "name": "noise blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "noise blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic maneuver",
+                      "aonid": 1717,
+                      "game-obj": "Spells",
+                      "name": "telekinetic maneuver",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic maneuver",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "level": 1,
+              "level_text": "1st",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "breathe fire",
+                      "aonid": 1457,
+                      "game-obj": "Spells",
+                      "name": "breathe fire",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "breathe fire",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "gust of wind",
+                      "aonid": 1550,
+                      "game-obj": "Spells",
+                      "name": "gust of wind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "gust of wind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "tailwind",
+                      "aonid": 1711,
+                      "game-obj": "Spells",
+                      "name": "tailwind",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "tailwind",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            },
+            {
+              "cantrips": true,
+              "level": 6,
+              "level_text": "(6th)",
+              "spells": [
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "caustic blast",
+                      "aonid": 1461,
+                      "game-obj": "Spells",
+                      "name": "caustic blast",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "caustic blast",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "electric arc",
+                      "aonid": 1509,
+                      "game-obj": "Spells",
+                      "name": "electric arc",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "electric arc",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "ignition",
+                      "aonid": 1565,
+                      "game-obj": "Spells",
+                      "name": "ignition",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "ignition",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "light",
+                      "aonid": 1585,
+                      "game-obj": "Spells",
+                      "name": "light",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "light",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                },
+                {
+                  "count": 1,
+                  "links": [
+                    {
+                      "alt": "telekinetic projectile",
+                      "aonid": 1718,
+                      "game-obj": "Spells",
+                      "name": "telekinetic projectile",
+                      "type": "link"
+                    }
+                  ],
+                  "name": "telekinetic projectile",
+                  "subtype": "spell",
+                  "type": "stat_block_section"
+                }
+              ],
+              "subtype": "spell_list",
+              "type": "stat_block_section"
+            }
+          ],
+          "spell_type": "Wrath Spells",
+          "subtype": "spells",
+          "type": "stat_block_section"
+        }
+      ],
+      "text": "A risen runelord's prepared spells depend upon their sinful legacy. When creating higher-level risen runelords, use these selections as thematic guidelines when selecting higher-rank spells. A risen runelord prepares arcane spells but doesn't require a spellbook to do so, nor can they learn new spells\u2014the spells they have prepared upon their creation are it. **Envy Spells**\u2014**6th** *dispelling globe*, *repulsion*; **5th** *banishment*, *dispel magic*, *veil of privacy*; **4th** *planar tether*, *resist energy*, *unfettered movement*; **3rd** *clairaudience*, *levitate*, *slow*; **2nd** *blur*, *environmental endurance*, *see the unseen*; **1st** *charm*, *command*, *fear*; **Cantrips (6th)** *daze*, *figment*, *light*, *read aura*, *shield*  \n  \n**Gluttony Spells**\u2014**6th** *summon undead*, *vampiric exsanguination*; **5th** *invoke spirits*, *toxic cloud*, *wave of despair*; **4th** *grim tendrils*, *fly*, *vision of death*; **3rd** *bind undead*, *slow*, *vampiric feast*; **2nd** *blood vendetta*, *create food*, *ghostly carrier*; **1st** *enfeeble*, *fear*, *goblin pox*; **Cantrips (6th)** *figment*, *frostbite*, *light*, *read aura*, *void warp*  \n  \n**Greed Spells**\u2014**6th** *cursed metamorphosis*, *disintegrate*; **5th** *elemental form*, *impaling spike*, *wall of stone*; **4th** *aerial form*, *creation*, *fly*; **3rd** *insect form*, *one with stone*, *wall of thorns*; **2nd** *enlarge*, *humanoid form*, *shrink*; **1st** *fleet step*, *mending*, *pest form*; **Cantrips (6th)** *gouging claw*, *light*, *read aura*, *shield*, *telekinetic projectile*  \n  \n**Lust Spells**\u2014**6th** *dominate*, *never mind*; **5th** *mind probe*, *sleep*, *subconscious suggestion*; **4th** *confusion*, *nightmare*, *suggestion*; **3rd** *dream message*, *enthrall*, *paralyze*; **2nd** *blur*, *laughing fit*, *stupefy*; **1st** *charm*, *command*, *fear*; **Cantrips (6th)** *daze*, *detect magic*, *light*, *prestidigitation*, *telekinetic hand*  \n  \n**Pride Spells**\u2014**6th** *illusory creature*, *phantasmal calamity*; **5th** *dizzying colors*, *hallucination*, *illusory scene*; **4th** *invisibility*, *mirage*, *vision of death*; **3rd** *illusory disguise*, *hypnotize*, *paralyze*; **2nd** *blur*, *darkness*, *revealing light*; **1st** *disguise magic*, *illusory object*, *phantasmal minion*; **Cantrips (6th)** *daze*, *figment*, *light*, *prestidigitation*, *sigil*  \n  \n**Sloth Spells**\u2014**6th** *disintegrate*, *teleport*; **5th** *sleep*, *slither*, *toxic cloud*; **4th** *confusion*, *fly*, *translocate*; **3rd** *cozy cabin*, *slow*, *wall of thorns*; **2nd** *create food*, *marvelous mount*, *mist*; **1st** *create water*, *gentle landing*, *sure strike*; **Cantrips (6th)** *daze*, *light*, *message*, *prestidigitation*, *telekinetic hand*  \n  \n**Wrath Spells**\u2014**6th** *chain lightning*, *wall of force*; **5th** *fireball*, *howling blizzard*, *wall of ice*; **4th** *lightning bolt*, *thunderstrike*, *wall of fire*; **3rd** *force barrage*, *haste*, *wall of wind*; **2nd** *blazing bolt*, *noise blast*, *telekinetic maneuver*; **1st** *breathe fire*, *gust of wind*, *tailwind*; **Cantrips (6th)** *caustic blast*, *electric arc*, *ignition*, *light*, *telekinetic projectile*",
+      "type": "section"
+    }
+  ],
   "sources": [
     {
       "link": {

--- a/monster_families/shadows_at_sundown/vampire_strigoi.json
+++ b/monster_families/shadows_at_sundown/vampire_strigoi.json
@@ -19,11 +19,6 @@
         "type": "section"
       },
       {
-        "name": "Bestiary",
-        "text": "**Daemon, Guardian from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.  \n **Dark Creeper from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.  \n **Dark Stalker from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.  \n **Dragon, Faerie from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.  \n **Genie, Marid from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.  \n **Mite from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian Livingstone and Mark Barnes.  \n **Pathfinder Bestiary (Second Edition)** \u00a9 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims, Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer.",
-        "type": "section"
-      },
-      {
         "name": "Bestiary 2",
         "text": "**Angel, Monadic Deva from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Angel, Movanic Deva from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Aurumvorax from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Basidirond from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Blindheim from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Roger Musson.   \n**The Book of Fiends** \u00a9 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.   \n**Armies of the Abyss** \u00a9 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.   \n**The Avatar's Handbook** \u00a9 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.   \n**Book of the Righteous** \u00a9 2002, Aaron Loeb.   \n**Legions of Hell** \u00a9 2001, Green Ronin Publishing; Author: Chris Pramas.   \n**The Unholy Warrior's Handbook** \u00a9 2003, Green Ronin Publishing; Author: Robert J. Schwalb.   \n**Carbuncle from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.   \n**Cave Fisher from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Lawrence Schick.   \n**Daemon, Derghodaemon from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Daemon, Piscodaemon from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Dark Creeper from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.   \n**Dark Stalker from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.   \n**Demon, Nabasu from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Demon, Shadow from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.   \n**Dracolisk from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Froghemoth from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Genie, Marid from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Grippli from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Korred from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Necrophidius from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Tillbrook.   \n**Nereid from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Quickling from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Quickwood from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.   \n**Scythe Tree from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene.   \n**Skulk from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.   \n**Soul Eater from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.   \n**Troll, Two-Headed from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Oliver Charles MacDonald.   \n**Yellow Musk Creeper from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.   \n**Yellow Musk Zombie from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.   \n**Pathfinder Core Rulebook (Second Edition)** \u00a9 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.   \n**Pathfinder Bestiary 2 (Second Edition)** \u00a9 2020, Paizo Inc.; Authors: Alexander Augunas, Dennis Baker, Jesse Benner, Joseph Blomquist, Logan Bonner, Paris Crenshaw, Adam Daigle, Jesse Decker, Darrin Drader, Brian Duckwitz, Robert N. Emerson, Scott Fernandez, Keith Garrett, Scott Gladstein, Matthew Goodall, T.H. Gulliver, BJ Hensley, Tim Hitchcock, Vanessa Hoskins, James Jacobs, Brian R. James, Jason Keeley, John Laffan, Lyz Liddell, Colm Lundberg, Ron Lundeen, Jason Nelson, Randy Price, Jessica Redekop, Patrick Renie, Alistair Rigg, Alex Riggs, David N. Ross, David Schwartz, Mark Seifter, Amber Stewart, Jeffrey Swank, Russ Taylor, and Jason Tondro.",
         "type": "section"
@@ -60,6 +55,11 @@
       {
         "name": "Expressly Designated Licensed Material",
         "text": "The following elements are owned by the Licensor and would otherwise constitute Reserved Material and are hereby designated as Licensed Material: [None].",
+        "type": "section"
+      },
+      {
+        "name": "Bestiary",
+        "text": "**Daemon, Guardian from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.  \n **Dark Creeper from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.  \n **Dark Stalker from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.  \n **Dragon, Faerie from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.  \n **Genie, Marid from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.  \n **Mite from the Tome of Horrors Complete** \u00a9 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian Livingstone and Mark Barnes.  \n **Pathfinder Bestiary (Second Edition)** \u00a9 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims, Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer.",
         "type": "section"
       }
     ],
@@ -455,503 +455,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Greater Darkvision",
-                  "aonid": 12,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Greater Darkvision",
-                  "type": "link"
-                },
-                "name": "Greater Darkvision",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "link": {
-                  "alt": "Negative Healing",
-                  "aonid": 42,
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "type": "link"
-                },
-                "name": "Negative Healing",
-                "subtype": "ability",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "aonid": 42,
-                  "game-id": "26efbc8d7d89662ed2ef5191e0001427",
-                  "game-obj": "MonsterAbilities",
-                  "name": "Negative Healing",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Bestiary 2 pg. 305",
-                        "aonid": 32,
-                        "game-obj": "Sources",
-                        "name": "Bestiary 2 pg. 305",
-                        "type": "link"
-                      },
-                      "name": "Bestiary 2",
-                      "page": 305,
-                      "type": "source"
-                    }
-                  ],
-                  "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "death",
-                    "aonid": 40,
-                    "game-obj": "Traits",
-                    "name": "death",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 46,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 126,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sleep",
-                    "aonid": 145,
-                    "game-obj": "Traits",
-                    "name": "sleep",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "death effects, disease, paralyze, poison, sleep",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  }
-                ],
-                "name": "Coffin Restoration",
-                "subtype": "ability",
-                "text": "As with moroi vampires, a strigoi isn't destroyed at 0 HP. Instead, it falls unconscious and loses fast healing. If its body rests in its coffin for 1 hour, the strigoi gains 1 HP, after which its fast healing begins to function normally.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "negative",
-                      "aonid": 118,
-                      "game-obj": "Traits",
-                      "name": "negative",
-                      "type": "link"
-                    },
-                    "name": "negative",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Strigoi Weaknesses",
-                "subtype": "ability",
-                "text": "All strigoi possess the following weaknesses:",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "levitate",
-                    "aonid": 170,
-                    "game-obj": "Spells",
-                    "name": "levitate",
-                    "type": "link"
-                  }
-                ],
-                "name": "Levitation",
-                "subtype": "ability",
-                "text": "Strigoi can cast *levitate* at will as a divine innate spell; when they do so, they appear to ascend or descend on a coiling mass of shadows.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "evocation",
-                      "aonid": 65,
-                      "game-obj": "Traits",
-                      "name": "evocation",
-                      "type": "link"
-                    },
-                    "name": "evocation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "shadow",
-                      "aonid": 143,
-                      "game-obj": "Traits",
-                      "name": "shadow",
-                      "type": "link"
-                    },
-                    "name": "shadow",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "agile",
-                    "aonid": 170,
-                    "game-obj": "Traits",
-                    "name": "agile",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "magic",
-                    "aonid": 103,
-                    "game-obj": "Traits",
-                    "name": "magic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "moderate Strike damage for a creature of its level",
-                    "aonid": 1018,
-                    "game-obj": "Rules",
-                    "name": "moderate Strike damage for a creature of its level",
-                    "type": "link"
-                  }
-                ],
-                "name": "Claws",
-                "subtype": "ability",
-                "text": "If the creature had hands, its shadow solidifies around the fingers when it attacks, granting it a claw Strike that deals slashing damage, and has the agile and magic traits. The damage caused by its claws should be roughly the same as the moderate Strike damage for a creature of its level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The strigoi sinks their fangs into the targeted creature to drink its blood and draw out its vital essence. This requires an Athletics check against the creature's Fortitude DC if the creature is grabbed and is automatic for any of the other conditions. The creature becomes drained 1 and stupefied 1, and the strigoi regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Essence from a creature that's already drained or stupefied doesn't restore any HP, but increases either the creature's drained condition value or its stupefied condition value by 1 (whichever value is lesser is increased; if both values are equal, then the strigoi chooses which condition to increase the value of).",
-                "links": [
-                  {
-                    "alt": "grabbed",
-                    "aonid": 20,
-                    "game-obj": "Conditions",
-                    "name": "grabbed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 28,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "restrained",
-                    "aonid": 33,
-                    "game-obj": "Conditions",
-                    "name": "restrained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 38,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Athletics",
-                    "aonid": 3,
-                    "game-obj": "Skills",
-                    "name": "Athletics",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained 1",
-                    "aonid": 10,
-                    "game-obj": "Conditions",
-                    "name": "drained 1",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "stupefied 1",
-                    "aonid": 37,
-                    "game-obj": "Conditions",
-                    "name": "stupefied 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Drink Essence",
-                "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the strigoi's reach",
-                "subtype": "ability",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "Grab",
-                    "aonid": 18,
-                    "game-obj": "MonsterAbilities",
-                    "name": "Grab",
-                    "type": "link"
-                  }
-                ],
-                "name": "Grab",
-                "subtype": "ability",
-                "text": "The creature's claw attacks gain Grab. When it uses this ability, its shadowy claws seem almost to latch on to any shadows cast by the grabbed creature.",
-                "type": "stat_block_section",
-                "universal_monster_ability": {
-                  "ability_type": "universal_monster_ability",
-                  "action_type": {
-                    "name": "One Action",
-                    "subtype": "action_type",
-                    "type": "stat_block_section"
-                  },
-                  "aonid": 45,
-                  "edition": "remastered",
-                  "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
-                  "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
-                  "game-obj": "MonsterAbilities",
-                  "links": [
-                    {
-                      "alt": "grabbed",
-                      "aonid": 20,
-                      "game-obj": "Conditions",
-                      "name": "grabbed",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "restrained",
-                      "aonid": 33,
-                      "game-obj": "Conditions",
-                      "name": "restrained",
-                      "type": "link"
-                    },
-                    {
-                      "alt": "Grapple",
-                      "aonid": 35,
-                      "game-obj": "Actions",
-                      "name": "Grapple",
-                      "type": "link"
-                    }
-                  ],
-                  "name": "Grab",
-                  "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
-                  "sources": [
-                    {
-                      "errata": {
-                        "alt": "2.0",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "2.0",
-                        "type": "link"
-                      },
-                      "link": {
-                        "alt": "Rage of Elements pg. 232",
-                        "aonid": 205,
-                        "game-obj": "Sources",
-                        "name": "Rage of Elements pg. 232",
-                        "type": "link"
-                      },
-                      "name": "Rage of Elements",
-                      "page": 232,
-                      "type": "source"
-                    }
-                  ],
-                  "type": "ability"
-                }
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "stunned 1",
-                    "aonid": 36,
-                    "game-obj": "Conditions",
-                    "name": "stunned 1",
-                    "type": "link"
-                  }
-                ],
-                "name": "Shadow Form",
-                "subtype": "ability",
-                "text": "The strigoi reverts to pure shadow and absorbs its body and its gear into the darkness, or it shifts back to its physical form. In shadow form, the strigoi gains a climb Speed equal to its land Speed and can move through any gap that isn't airtight. However, it can only move along solid surfaces that aren't highly reflective, not liquid or mirrored surfaces. If the surface it's on is destroyed, the strigoi returns to physical form and is stunned 1. The strigoi loses fast healing while in shadow form but can remain in shadow form indefinitely.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 32,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "shadow",
-                      "aonid": 143,
-                      "game-obj": "Traits",
-                      "name": "shadow",
-                      "type": "link"
-                    },
-                    "name": "shadow",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "transmutation",
-                      "aonid": 157,
-                      "game-obj": "Traits",
-                      "name": "transmutation",
-                      "type": "link"
-                    },
-                    "name": "transmutation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Basic Strigoi Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -969,6 +477,230 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "Greater Darkvision",
+                "aonid": 12,
+                "game-obj": "MonsterAbilities",
+                "name": "Greater Darkvision",
+                "type": "link"
+              },
+              {
+                "alt": "Negative Healing",
+                "aonid": 42,
+                "game-obj": "MonsterAbilities",
+                "name": "Negative Healing",
+                "type": "link"
+              },
+              {
+                "alt": "death",
+                "aonid": 40,
+                "game-obj": "Traits",
+                "name": "death",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 46,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 126,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sleep",
+                "aonid": 145,
+                "game-obj": "Traits",
+                "name": "sleep",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "negative",
+                "aonid": 118,
+                "game-obj": "Traits",
+                "name": "negative",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              {
+                "alt": "levitate",
+                "aonid": 170,
+                "game-obj": "Spells",
+                "name": "levitate",
+                "type": "link"
+              },
+              {
+                "alt": "agile",
+                "aonid": 170,
+                "game-obj": "Traits",
+                "name": "agile",
+                "type": "link"
+              },
+              {
+                "alt": "magic",
+                "aonid": 103,
+                "game-obj": "Traits",
+                "name": "magic",
+                "type": "link"
+              },
+              {
+                "alt": "moderate Strike damage for a creature of its level",
+                "aonid": 1018,
+                "game-obj": "Rules",
+                "name": "moderate Strike damage for a creature of its level",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 28,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 38,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "Athletics",
+                "aonid": 3,
+                "game-obj": "Skills",
+                "name": "Athletics",
+                "type": "link"
+              },
+              {
+                "alt": "drained 1",
+                "aonid": 10,
+                "game-obj": "Conditions",
+                "name": "drained 1",
+                "type": "link"
+              },
+              {
+                "alt": "stupefied 1",
+                "aonid": 37,
+                "game-obj": "Conditions",
+                "name": "stupefied 1",
+                "type": "link"
+              },
+              {
+                "alt": "Grab",
+                "aonid": 18,
+                "game-obj": "MonsterAbilities",
+                "name": "Grab",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              {
+                "alt": "stunned 1",
+                "aonid": 36,
+                "game-obj": "Conditions",
+                "name": "stunned 1",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -978,294 +710,138 @@
         ],
         "name": "Basic Strigoi Abilities",
         "subtype": "monster_family",
-        "text": "All strigoi gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the strigoi's theme.",
         "type": "stat_block_section"
       },
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "The strigoi progenitor resists all physical damage except magical silver weapons or magical weapons that shed at least 5 feet of bright light.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "interaction",
-                "ability_type": "ability",
-                "name": "Fly Speed",
-                "subtype": "ability",
-                "text": "Instead of being able to *levitate* at will, a strigoi progenitor gains a fly Speed equal to their land Speed. When a strigoi progenitor flies, it manifests batlike wings made of shadow.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Create Spawn",
-                "subtype": "ability",
-                "text": "If a creature dies after being reduced to 0 HP by Domain of Dusk or Drink Essence, the strigoi can turn this victim into a vampire by donating some of its own blood to the victim and burying the victim in earth for 3 nights. If the new vampire is lower level than its creator, it is under the creator's control. A victim that is 8th level or higher becomes a strigoi servant, while a lower-level victim instead becomes a moroi vampire. If a vampire controls too many spawn at once (as determined by the GM), strong-willed spawn can free themselves by succeeding at a Will saving throw against the vampire's Will DC.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "downtime",
-                      "aonid": 49,
-                      "game-obj": "Traits",
-                      "name": "downtime",
-                      "type": "link"
-                    },
-                    "name": "downtime",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "necromancy",
-                      "aonid": 117,
-                      "game-obj": "Traits",
-                      "name": "necromancy",
-                      "type": "link"
-                    },
-                    "name": "necromancy",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "reactive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Free Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The strigoi uses Shadow Form. It can take move actions to move toward its coffin even though it's at 0 HP. While at 0 HP in this form, the strigoi is unaffected by further damage. Once the strigoi reaches its coffin, or if it hasn't done so within 2 hours, it automatically returns to its physical form, unconscious.",
-                "name": "Shadow Escape",
-                "subtype": "ability",
-                "trigger": "The strigoi is reduced to 0 HP",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "area": [
-                  {
-                    "shape": "emanation",
-                    "size": 30,
-                    "subtype": "area",
-                    "text": "30-foot emanation",
-                    "type": "stat_block_section",
-                    "unit": "feet"
-                  }
-                ],
-                "damage": [
-                  {
-                    "damage_type": "negative",
-                    "formula": "1d6",
-                    "subtype": "attack_damage",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "links": [
-                  {
-                    "alt": "basic",
-                    "aonid": 329,
-                    "game-obj": "Rules",
-                    "name": "basic",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "DC of the strigoi's level",
-                    "aonid": 554,
-                    "game-obj": "Rules",
-                    "name": "DC of the strigoi's level",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "dazzled",
-                    "aonid": 7,
-                    "game-obj": "Conditions",
-                    "name": "dazzled",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "blinded",
-                    "aonid": 1,
-                    "game-obj": "Conditions",
-                    "name": "blinded",
-                    "type": "link"
-                  }
-                ],
-                "name": "Domain of Dusk",
-                "subtype": "ability",
-                "text": "With a wave of its hand, the strigoi calls fourth vile ruination from the surrounding shadows, causing coils of darkness and shadowy bats, rats, and wolves to lash out at living targets in a 30-foot emanation. Living creatures in this area take 1d6 negative damage +1d6 per 2 levels possessed by the strigoi (basic Fortitude save against the DC of the strigoi's level). A creature that fails this save is also dazzled for 1 round (or blinded for 1 round and then dazzled for 1 round) by the darkness. The strigoi progenitor can't use Domain of Dusk for 1 minute.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "conjuration",
-                      "aonid": 33,
-                      "game-obj": "Traits",
-                      "name": "conjuration",
-                      "type": "link"
-                    },
-                    "name": "conjuration",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "shadow",
-                      "aonid": 143,
-                      "game-obj": "Traits",
-                      "name": "shadow",
-                      "type": "link"
-                    },
-                    "name": "shadow",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "dominate",
-                    "aonid": 87,
-                    "game-obj": "Spells",
-                    "name": "dominate",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "visual",
-                    "aonid": 163,
-                    "game-obj": "Traits",
-                    "name": "visual",
-                    "type": "link"
-                  }
-                ],
-                "name": "Dominate",
-                "subtype": "ability",
-                "text": "The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "divine",
-                      "aonid": 48,
-                      "game-obj": "Traits",
-                      "name": "divine",
-                      "type": "link"
-                    },
-                    "name": "divine",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "enchantment",
-                      "aonid": 61,
-                      "game-obj": "Traits",
-                      "name": "enchantment",
-                      "type": "link"
-                    },
-                    "name": "enchantment",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 93,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 106,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "visual",
-                      "aonid": 163,
-                      "game-obj": "Traits",
-                      "name": "visual",
-                      "type": "link"
-                    },
-                    "name": "visual",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "name": "Drink Essence",
-                "subtype": "ability",
-                "text": "As a typical strigoi, but the victim is drained 2 and stupefied 2 instead of 1.",
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Strigoi Progenitor Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
+              }
+            ],
+            "links": [
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "downtime",
+                "aonid": 49,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              {
+                "alt": "conjuration",
+                "aonid": 33,
+                "game-obj": "Traits",
+                "name": "conjuration",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              {
+                "alt": "basic",
+                "aonid": 329,
+                "game-obj": "Rules",
+                "name": "basic",
+                "type": "link"
+              },
+              {
+                "alt": "DC of the strigoi's level",
+                "aonid": 554,
+                "game-obj": "Rules",
+                "name": "DC of the strigoi's level",
+                "type": "link"
+              },
+              {
+                "alt": "dazzled",
+                "aonid": 7,
+                "game-obj": "Conditions",
+                "name": "dazzled",
+                "type": "link"
+              },
+              {
+                "alt": "blinded",
+                "aonid": 1,
+                "game-obj": "Conditions",
+                "name": "blinded",
+                "type": "link"
+              },
+              {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              {
+                "alt": "dominate",
+                "aonid": 87,
+                "game-obj": "Spells",
+                "name": "dominate",
+                "type": "link"
+              },
+              {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -1275,7 +851,6 @@
         ],
         "name": "Strigoi Progenitor Abilities",
         "subtype": "monster_family",
-        "text": "Powerful strigoi that form from the fusion of a strigoi from the Shadow Plane and a living host gain additional abilities as detailed below. A creature below level 13 is not a significant enough host to become a strigoi progenitor.",
         "type": "stat_block_section"
       }
     ],
@@ -1336,6 +911,1269 @@
         }
       ],
       "text": "|  |  |  |\n| --- | --- | --- |\n| **Starting Level** | **HP Decrease** | **Fast Healing/Resistance** |\n| 8-14 | -40 | 10 |\n| 15+ | -60 | 15 |",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Greater Darkvision",
+            "aonid": 12,
+            "game-obj": "MonsterAbilities",
+            "name": "Greater Darkvision",
+            "type": "link"
+          },
+          "name": "Greater Darkvision",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "link": {
+            "alt": "Negative Healing",
+            "aonid": 42,
+            "game-obj": "MonsterAbilities",
+            "name": "Negative Healing",
+            "type": "link"
+          },
+          "name": "Negative Healing",
+          "subtype": "ability",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "aonid": 42,
+            "game-id": "26efbc8d7d89662ed2ef5191e0001427",
+            "game-obj": "MonsterAbilities",
+            "name": "Negative Healing",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "2.0",
+                  "aonid": 32,
+                  "game-obj": "Sources",
+                  "name": "2.0",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Bestiary 2 pg. 305",
+                  "aonid": 32,
+                  "game-obj": "Sources",
+                  "name": "Bestiary 2 pg. 305",
+                  "type": "link"
+                },
+                "name": "Bestiary 2",
+                "page": 305,
+                "type": "source"
+              }
+            ],
+            "text": "A creature with negative healing draws health from negative energy rather than positive energy. It is damaged by positive damage and is not healed by positive healing effects. It does not take negative damage, and it is healed by negative effects that heal undead.",
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "death",
+              "aonid": 40,
+              "game-obj": "Traits",
+              "name": "death",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 46,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 126,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sleep",
+              "aonid": 145,
+              "game-obj": "Traits",
+              "name": "sleep",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "death effects, disease, paralyze, poison, sleep",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Coffin Restoration",
+          "subtype": "ability",
+          "text": "As with moroi vampires, a strigoi isn't destroyed at 0 HP. Instead, it falls unconscious and loses fast healing. If its body rests in its coffin for 1 hour, the strigoi gains 1 HP, after which its fast healing begins to function normally.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "negative",
+                "aonid": 118,
+                "game-obj": "Traits",
+                "name": "negative",
+                "type": "link"
+              },
+              "name": "negative",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Strigoi Weaknesses",
+          "subtype": "ability",
+          "text": "All strigoi possess the following weaknesses:",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "levitate",
+              "aonid": 170,
+              "game-obj": "Spells",
+              "name": "levitate",
+              "type": "link"
+            }
+          ],
+          "name": "Levitation",
+          "subtype": "ability",
+          "text": "Strigoi can cast *levitate* at will as a divine innate spell; when they do so, they appear to ascend or descend on a coiling mass of shadows.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "evocation",
+                "aonid": 65,
+                "game-obj": "Traits",
+                "name": "evocation",
+                "type": "link"
+              },
+              "name": "evocation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              "name": "shadow",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "agile",
+              "aonid": 170,
+              "game-obj": "Traits",
+              "name": "agile",
+              "type": "link"
+            },
+            {
+              "alt": "magic",
+              "aonid": 103,
+              "game-obj": "Traits",
+              "name": "magic",
+              "type": "link"
+            },
+            {
+              "alt": "moderate Strike damage for a creature of its level",
+              "aonid": 1018,
+              "game-obj": "Rules",
+              "name": "moderate Strike damage for a creature of its level",
+              "type": "link"
+            }
+          ],
+          "name": "Claws",
+          "subtype": "ability",
+          "text": "If the creature had hands, its shadow solidifies around the fingers when it attacks, granting it a claw Strike that deals slashing damage, and has the agile and magic traits. The damage caused by its claws should be roughly the same as the moderate Strike damage for a creature of its level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The strigoi sinks their fangs into the targeted creature to drink its blood and draw out its vital essence. This requires an Athletics check against the creature's Fortitude DC if the creature is grabbed and is automatic for any of the other conditions. The creature becomes drained 1 and stupefied 1, and the strigoi regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Essence from a creature that's already drained or stupefied doesn't restore any HP, but increases either the creature's drained condition value or its stupefied condition value by 1 (whichever value is lesser is increased; if both values are equal, then the strigoi chooses which condition to increase the value of).",
+          "links": [
+            {
+              "alt": "grabbed",
+              "aonid": 20,
+              "game-obj": "Conditions",
+              "name": "grabbed",
+              "type": "link"
+            },
+            {
+              "alt": "paralyzed",
+              "aonid": 28,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "restrained",
+              "aonid": 33,
+              "game-obj": "Conditions",
+              "name": "restrained",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "Athletics",
+              "aonid": 3,
+              "game-obj": "Skills",
+              "name": "Athletics",
+              "type": "link"
+            },
+            {
+              "alt": "drained 1",
+              "aonid": 10,
+              "game-obj": "Conditions",
+              "name": "drained 1",
+              "type": "link"
+            },
+            {
+              "alt": "stupefied 1",
+              "aonid": 37,
+              "game-obj": "Conditions",
+              "name": "stupefied 1",
+              "type": "link"
+            }
+          ],
+          "name": "Drink Essence",
+          "requirement": "A grabbed, paralyzed, restrained, unconscious, or willing creature is within the strigoi's reach",
+          "subtype": "ability",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "Grab",
+              "aonid": 18,
+              "game-obj": "MonsterAbilities",
+              "name": "Grab",
+              "type": "link"
+            }
+          ],
+          "name": "Grab",
+          "subtype": "ability",
+          "text": "The creature's claw attacks gain Grab. When it uses this ability, its shadowy claws seem almost to latch on to any shadows cast by the grabbed creature.",
+          "type": "stat_block_section",
+          "universal_monster_ability": {
+            "ability_type": "universal_monster_ability",
+            "action_type": {
+              "name": "One Action",
+              "subtype": "action_type",
+              "type": "stat_block_section"
+            },
+            "aonid": 45,
+            "edition": "remastered",
+            "effect": "If used after a Strike, the monster attempts to Grapple the creature using the body part it attacked with. This attempt neither applies nor counts toward the creature's multiple attack penalty.  \n  \n The monster can instead use Grab and choose one creature it's grabbing or restraining with an appendage that has Grab to automatically extend that condition to the end of the monster's next turn.",
+            "game-id": "dfef42b0053f2a80ead602bf5321d1a9",
+            "game-obj": "MonsterAbilities",
+            "links": [
+              {
+                "alt": "grabbed",
+                "aonid": 20,
+                "game-obj": "Conditions",
+                "name": "grabbed",
+                "type": "link"
+              },
+              {
+                "alt": "restrained",
+                "aonid": 33,
+                "game-obj": "Conditions",
+                "name": "restrained",
+                "type": "link"
+              },
+              {
+                "alt": "Grapple",
+                "aonid": 35,
+                "game-obj": "Actions",
+                "name": "Grapple",
+                "type": "link"
+              }
+            ],
+            "name": "Grab",
+            "requirement": "The monster's last action was a successful Strike that lists Grab in its damage entry, or the monster has a creature grabbed or restrained",
+            "sources": [
+              {
+                "errata": {
+                  "alt": "2.0",
+                  "aonid": 205,
+                  "game-obj": "Sources",
+                  "name": "2.0",
+                  "type": "link"
+                },
+                "link": {
+                  "alt": "Rage of Elements pg. 232",
+                  "aonid": 205,
+                  "game-obj": "Sources",
+                  "name": "Rage of Elements pg. 232",
+                  "type": "link"
+                },
+                "name": "Rage of Elements",
+                "page": 232,
+                "type": "source"
+              }
+            ],
+            "type": "ability"
+          }
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "stunned 1",
+              "aonid": 36,
+              "game-obj": "Conditions",
+              "name": "stunned 1",
+              "type": "link"
+            }
+          ],
+          "name": "Shadow Form",
+          "subtype": "ability",
+          "text": "The strigoi reverts to pure shadow and absorbs its body and its gear into the darkness, or it shifts back to its physical form. In shadow form, the strigoi gains a climb Speed equal to its land Speed and can move through any gap that isn't airtight. However, it can only move along solid surfaces that aren't highly reflective, not liquid or mirrored surfaces. If the surface it's on is destroyed, the strigoi returns to physical form and is stunned 1. The strigoi loses fast healing while in shadow form but can remain in shadow form indefinitely.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 32,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              "name": "shadow",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "transmutation",
+                "aonid": 157,
+                "game-obj": "Traits",
+                "name": "transmutation",
+                "type": "link"
+              },
+              "name": "transmutation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "human",
+          "aonid": 90,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 91,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "Greater Darkvision",
+          "aonid": 12,
+          "game-obj": "MonsterAbilities",
+          "name": "Greater Darkvision",
+          "type": "link"
+        },
+        {
+          "alt": "Negative Healing",
+          "aonid": 42,
+          "game-obj": "MonsterAbilities",
+          "name": "Negative Healing",
+          "type": "link"
+        },
+        {
+          "alt": "death",
+          "aonid": 40,
+          "game-obj": "Traits",
+          "name": "death",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 46,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 126,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "sleep",
+          "aonid": 145,
+          "game-obj": "Traits",
+          "name": "sleep",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "negative",
+          "aonid": 118,
+          "game-obj": "Traits",
+          "name": "negative",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 38,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "evocation",
+          "aonid": 65,
+          "game-obj": "Traits",
+          "name": "evocation",
+          "type": "link"
+        },
+        {
+          "alt": "shadow",
+          "aonid": 143,
+          "game-obj": "Traits",
+          "name": "shadow",
+          "type": "link"
+        },
+        {
+          "alt": "levitate",
+          "aonid": 170,
+          "game-obj": "Spells",
+          "name": "levitate",
+          "type": "link"
+        },
+        {
+          "alt": "agile",
+          "aonid": 170,
+          "game-obj": "Traits",
+          "name": "agile",
+          "type": "link"
+        },
+        {
+          "alt": "magic",
+          "aonid": 103,
+          "game-obj": "Traits",
+          "name": "magic",
+          "type": "link"
+        },
+        {
+          "alt": "moderate Strike damage for a creature of its level",
+          "aonid": 1018,
+          "game-obj": "Rules",
+          "name": "moderate Strike damage for a creature of its level",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "grabbed",
+          "aonid": 20,
+          "game-obj": "Conditions",
+          "name": "grabbed",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 28,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "restrained",
+          "aonid": 33,
+          "game-obj": "Conditions",
+          "name": "restrained",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 38,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "Athletics",
+          "aonid": 3,
+          "game-obj": "Skills",
+          "name": "Athletics",
+          "type": "link"
+        },
+        {
+          "alt": "drained 1",
+          "aonid": 10,
+          "game-obj": "Conditions",
+          "name": "drained 1",
+          "type": "link"
+        },
+        {
+          "alt": "stupefied 1",
+          "aonid": 37,
+          "game-obj": "Conditions",
+          "name": "stupefied 1",
+          "type": "link"
+        },
+        {
+          "alt": "Grab",
+          "aonid": 18,
+          "game-obj": "MonsterAbilities",
+          "name": "Grab",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 32,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "shadow",
+          "aonid": 143,
+          "game-obj": "Traits",
+          "name": "shadow",
+          "type": "link"
+        },
+        {
+          "alt": "transmutation",
+          "aonid": 157,
+          "game-obj": "Traits",
+          "name": "transmutation",
+          "type": "link"
+        },
+        {
+          "alt": "stunned 1",
+          "aonid": 36,
+          "game-obj": "Conditions",
+          "name": "stunned 1",
+          "type": "link"
+        }
+      ],
+      "name": "Basic Strigoi Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Shadows at Sundown pg. 60",
+            "aonid": 121,
+            "game-obj": "Sources",
+            "name": "Shadows at Sundown pg. 60",
+            "type": "link"
+          },
+          "name": "Shadows at Sundown",
+          "page": 60,
+          "type": "source"
+        }
+      ],
+      "text": "All strigoi gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life as a living creature, such as human and humanoid. You might also need to adjust abilities that conflict with the strigoi's theme.  \n  \n**Greater Darkvision**  \n  \n**Negative Healing**  \n  \n**Immunities** death effects, disease, paralyze, poison, sleep **Coffin Restoration** (divine, necromancy, negative) As with moroi vampires, a strigoi isn't destroyed at 0 HP. Instead, it falls unconscious and loses fast healing. If its body rests in its coffin for 1 hour, the strigoi gains 1 HP, after which its fast healing begins to function normally.  \n  \n**Strigoi Weaknesses** All strigoi possess the following weaknesses:**Levitation** [##] (divine, evocation, shadow) Strigoi can cast *levitate* at will as a divine innate spell; when they do so, they appear to ascend or descend on a coiling mass of shadows.  \n  \n**Claws** If the creature had hands, its shadow solidifies around the fingers when it attacks, granting it a claw Strike that deals slashing damage, and has the agile and magic traits. The damage caused by its claws should be roughly the same as the moderate Strike damage for a creature of its level.  \n  \n**Drink Essence** [#] (divine, necromancy) **Requirements** A grabbed, paralyzed, restrained, unconscious, or willing creature is within the strigoi's reach; **Effect** The strigoi sinks their fangs into the targeted creature to drink its blood and draw out its vital essence. This requires an Athletics check against the creature's Fortitude DC if the creature is grabbed and is automatic for any of the other conditions. The creature becomes drained 1 and stupefied 1, and the strigoi regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Essence from a creature that's already drained or stupefied doesn't restore any HP, but increases either the creature's drained condition value or its stupefied condition value by 1 (whichever value is lesser is increased; if both values are equal, then the strigoi chooses which condition to increase the value of).  \n A victim's drained condition decreases by 1 per week. A blood transfusion, which requires a successful DC 20 Medicine check and sufficient blood or a blood donor, reduces the drained value by 1 after 10 minutes.  \n A victim's stupefied condition decreases by 1 per day after performing daily preparations. If the daily preparations are done in full sunlight, the stupefied condition is removed entirely.  \n  \n**Grab** The creature's claw attacks gain Grab. When it uses this ability, its shadowy claws seem almost to latch on to any shadows cast by the grabbed creature.  \n  \n**Shadow Form** [#] (concentrate, divine, shadow, transmutation) The strigoi reverts to pure shadow and absorbs its body and its gear into the darkness, or it shifts back to its physical form. In shadow form, the strigoi gains a climb Speed equal to its land Speed and can move through any gap that isn't airtight. However, it can only move along solid surfaces that aren't highly reflective, not liquid or mirrored surfaces. If the surface it's on is destroyed, the strigoi returns to physical form and is stunned 1. The strigoi loses fast healing while in shadow form but can remain in shadow form indefinitely.  \n A strigoi that is exposed to sunlight while in shadow form becomes slowed 2 and must attempt a DC 16 flat check at the end of each of its turns. If it fails this flat check, it is destroyed, the shadow vanishing with a blood-curdling wail.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "name": "Resistances",
+          "subtype": "ability",
+          "text": "The strigoi progenitor resists all physical damage except magical silver weapons or magical weapons that shed at least 5 feet of bright light.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "interaction",
+          "ability_type": "ability",
+          "name": "Fly Speed",
+          "subtype": "ability",
+          "text": "Instead of being able to *levitate* at will, a strigoi progenitor gains a fly Speed equal to their land Speed. When a strigoi progenitor flies, it manifests batlike wings made of shadow.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Create Spawn",
+          "subtype": "ability",
+          "text": "If a creature dies after being reduced to 0 HP by Domain of Dusk or Drink Essence, the strigoi can turn this victim into a vampire by donating some of its own blood to the victim and burying the victim in earth for 3 nights. If the new vampire is lower level than its creator, it is under the creator's control. A victim that is 8th level or higher becomes a strigoi servant, while a lower-level victim instead becomes a moroi vampire. If a vampire controls too many spawn at once (as determined by the GM), strong-willed spawn can free themselves by succeeding at a Will saving throw against the vampire's Will DC.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "downtime",
+                "aonid": 49,
+                "game-obj": "Traits",
+                "name": "downtime",
+                "type": "link"
+              },
+              "name": "downtime",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "necromancy",
+                "aonid": 117,
+                "game-obj": "Traits",
+                "name": "necromancy",
+                "type": "link"
+              },
+              "name": "necromancy",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "reactive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Free Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The strigoi uses Shadow Form. It can take move actions to move toward its coffin even though it's at 0 HP. While at 0 HP in this form, the strigoi is unaffected by further damage. Once the strigoi reaches its coffin, or if it hasn't done so within 2 hours, it automatically returns to its physical form, unconscious.",
+          "name": "Shadow Escape",
+          "subtype": "ability",
+          "trigger": "The strigoi is reduced to 0 HP",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "area": [
+            {
+              "shape": "emanation",
+              "size": 30,
+              "subtype": "area",
+              "text": "30-foot emanation",
+              "type": "stat_block_section",
+              "unit": "feet"
+            }
+          ],
+          "damage": [
+            {
+              "damage_type": "negative",
+              "formula": "1d6",
+              "subtype": "attack_damage",
+              "type": "stat_block_section"
+            }
+          ],
+          "links": [
+            {
+              "alt": "basic",
+              "aonid": 329,
+              "game-obj": "Rules",
+              "name": "basic",
+              "type": "link"
+            },
+            {
+              "alt": "DC of the strigoi's level",
+              "aonid": 554,
+              "game-obj": "Rules",
+              "name": "DC of the strigoi's level",
+              "type": "link"
+            },
+            {
+              "alt": "dazzled",
+              "aonid": 7,
+              "game-obj": "Conditions",
+              "name": "dazzled",
+              "type": "link"
+            },
+            {
+              "alt": "blinded",
+              "aonid": 1,
+              "game-obj": "Conditions",
+              "name": "blinded",
+              "type": "link"
+            }
+          ],
+          "name": "Domain of Dusk",
+          "subtype": "ability",
+          "text": "With a wave of its hand, the strigoi calls fourth vile ruination from the surrounding shadows, causing coils of darkness and shadowy bats, rats, and wolves to lash out at living targets in a 30-foot emanation. Living creatures in this area take 1d6 negative damage +1d6 per 2 levels possessed by the strigoi (basic Fortitude save against the DC of the strigoi's level). A creature that fails this save is also dazzled for 1 round (or blinded for 1 round and then dazzled for 1 round) by the darkness. The strigoi progenitor can't use Domain of Dusk for 1 minute.",
+          "traits": [
+            {
+              "link": {
+                "alt": "conjuration",
+                "aonid": 33,
+                "game-obj": "Traits",
+                "name": "conjuration",
+                "type": "link"
+              },
+              "name": "conjuration",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "shadow",
+                "aonid": 143,
+                "game-obj": "Traits",
+                "name": "shadow",
+                "type": "link"
+              },
+              "name": "shadow",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "dominate",
+              "aonid": 87,
+              "game-obj": "Spells",
+              "name": "dominate",
+              "type": "link"
+            },
+            {
+              "alt": "visual",
+              "aonid": 163,
+              "game-obj": "Traits",
+              "name": "visual",
+              "type": "link"
+            }
+          ],
+          "name": "Dominate",
+          "subtype": "ability",
+          "text": "The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.",
+          "traits": [
+            {
+              "link": {
+                "alt": "divine",
+                "aonid": 48,
+                "game-obj": "Traits",
+                "name": "divine",
+                "type": "link"
+              },
+              "name": "divine",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "enchantment",
+                "aonid": 61,
+                "game-obj": "Traits",
+                "name": "enchantment",
+                "type": "link"
+              },
+              "name": "enchantment",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "incapacitation",
+                "aonid": 93,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              "name": "incapacitation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 106,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "visual",
+                "aonid": 163,
+                "game-obj": "Traits",
+                "name": "visual",
+                "type": "link"
+              },
+              "name": "visual",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "name": "Drink Essence",
+          "subtype": "ability",
+          "text": "As a typical strigoi, but the victim is drained 2 and stupefied 2 instead of 1.",
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "downtime",
+          "aonid": 49,
+          "game-obj": "Traits",
+          "name": "downtime",
+          "type": "link"
+        },
+        {
+          "alt": "necromancy",
+          "aonid": 117,
+          "game-obj": "Traits",
+          "name": "necromancy",
+          "type": "link"
+        },
+        {
+          "alt": "conjuration",
+          "aonid": 33,
+          "game-obj": "Traits",
+          "name": "conjuration",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "shadow",
+          "aonid": 143,
+          "game-obj": "Traits",
+          "name": "shadow",
+          "type": "link"
+        },
+        {
+          "alt": "basic",
+          "aonid": 329,
+          "game-obj": "Rules",
+          "name": "basic",
+          "type": "link"
+        },
+        {
+          "alt": "DC of the strigoi's level",
+          "aonid": 554,
+          "game-obj": "Rules",
+          "name": "DC of the strigoi's level",
+          "type": "link"
+        },
+        {
+          "alt": "dazzled",
+          "aonid": 7,
+          "game-obj": "Conditions",
+          "name": "dazzled",
+          "type": "link"
+        },
+        {
+          "alt": "blinded",
+          "aonid": 1,
+          "game-obj": "Conditions",
+          "name": "blinded",
+          "type": "link"
+        },
+        {
+          "alt": "divine",
+          "aonid": 48,
+          "game-obj": "Traits",
+          "name": "divine",
+          "type": "link"
+        },
+        {
+          "alt": "enchantment",
+          "aonid": 61,
+          "game-obj": "Traits",
+          "name": "enchantment",
+          "type": "link"
+        },
+        {
+          "alt": "incapacitation",
+          "aonid": 93,
+          "game-obj": "Traits",
+          "name": "incapacitation",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 106,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 163,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        },
+        {
+          "alt": "dominate",
+          "aonid": 87,
+          "game-obj": "Spells",
+          "name": "dominate",
+          "type": "link"
+        },
+        {
+          "alt": "visual",
+          "aonid": 163,
+          "game-obj": "Traits",
+          "name": "visual",
+          "type": "link"
+        }
+      ],
+      "name": "Strigoi Progenitor Abilities",
+      "sections": [
+        {
+          "name": "In Shadows",
+          "sources": [
+            {
+              "link": {
+                "alt": "Shadows at Sundown pg. 60",
+                "aonid": 121,
+                "game-obj": "Sources",
+                "name": "Shadows at Sundown pg. 60",
+                "type": "link"
+              },
+              "name": "Shadows at Sundown",
+              "page": 60,
+              "type": "source"
+            }
+          ],
+          "text": "In their true form as a shadow without a body, a strigoi is capable of thought and emotion and can communicate with the shadowy forms of other strigoi, but lacks any way to interact with the physical world. Countless strigoi exist in this manner on the Shadow Plane, patiently waiting for the ritual that allows mortals to invite them into reality to be discovered again.",
+          "type": "section"
+        },
+        {
+          "name": "Strange Wounds",
+          "sources": [
+            {
+              "link": {
+                "alt": "Shadows at Sundown pg. 60",
+                "aonid": 121,
+                "game-obj": "Sources",
+                "name": "Shadows at Sundown pg. 60",
+                "type": "link"
+              },
+              "name": "Shadows at Sundown",
+              "page": 60,
+              "type": "source"
+            }
+          ],
+          "text": "Iconic puncture marks on the neck of a victim drained of blood are well known to vampire hunters, but the wounds left by strigoi are stranger. When a strigoi feeds on a living victim, the site of the wound becomes bleached of color, wrinkled, and strangely cold to the touch. These conditions fade if the wound heals; if a strigoi feeds enough to cause death by the drained condition, a creature leaves behind a withered gray husk of a bloodless body. Full autopsies on those slain in this manner reveal yet another unsettling curiosity: the brains of such victims are smooth, gray ovoids, the folds and fissures of gray matter fused together into a featureless mass.",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "unconscious",
+              "aonid": 38,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            }
+          ],
+          "name": "Strigoi and the Sun",
+          "sources": [
+            {
+              "link": {
+                "alt": "Shadows at Sundown pg. 60",
+                "aonid": 121,
+                "game-obj": "Sources",
+                "name": "Shadows at Sundown pg. 60",
+                "type": "link"
+              },
+              "name": "Shadows at Sundown",
+              "page": 60,
+              "type": "source"
+            }
+          ],
+          "text": "As long as they're not in shadow form, strigoi are more inconvenienced by sunlight than they are harmed by it, but being rendered unconscious certainly puts them at a disadvantage. As long as they're in an area where there's little risk of direct sunlight, such as being inside a room without exterior windows or doors, or in an underground area, some strigoi remain active during the day, only retreating to their coffins in emergencies. In so doing, these strigoi have further blended into society\u2014there may be more of them than suspected!",
+          "type": "section"
+        },
+        {
+          "links": [
+            {
+              "alt": "strigoi servant",
+              "aonid": 1955,
+              "game-obj": "Monsters",
+              "name": "strigoi servant",
+              "type": "link"
+            }
+          ],
+          "name": "Strigoi Servants",
+          "sources": [
+            {
+              "link": {
+                "alt": "Shadows at Sundown pg. 60",
+                "aonid": 121,
+                "game-obj": "Sources",
+                "name": "Shadows at Sundown pg. 60",
+                "type": "link"
+              },
+              "name": "Shadows at Sundown",
+              "page": 60,
+              "type": "source"
+            }
+          ],
+          "text": "When a strigoi creates a spawn from a creature that's not powerful enough to play host to a strigoi progenitor, the resulting strigoi is often referred to simply as a strigoi servant. Statistics for a typical strigoi servant appear on page 25 of this adventure. Strigoi servants who escape servitude work hard to establish their own power, but rarely escape the mindset of existing only to serve their creator.",
+          "type": "section"
+        }
+      ],
+      "sources": [
+        {
+          "link": {
+            "alt": "Shadows at Sundown pg. 60",
+            "aonid": 121,
+            "game-obj": "Sources",
+            "name": "Shadows at Sundown pg. 60",
+            "type": "link"
+          },
+          "name": "Shadows at Sundown",
+          "page": 60,
+          "type": "source"
+        }
+      ],
+      "text": "Powerful strigoi that form from the fusion of a strigoi from the Shadow Plane and a living host gain additional abilities as detailed below. A creature below level 13 is not a significant enough host to become a strigoi progenitor.  \n  \n**Resistances** The strigoi progenitor resists all physical damage except magical silver weapons or magical weapons that shed at least 5 feet of bright light.  \n  \n**Fly Speed** Instead of being able to *levitate* at will, a strigoi progenitor gains a fly Speed equal to their land Speed. When a strigoi progenitor flies, it manifests batlike wings made of shadow.  \n  \n**Create Spawn** (divine, downtime, necromancy) If a creature dies after being reduced to 0 HP by Domain of Dusk or Drink Essence, the strigoi can turn this victim into a vampire by donating some of its own blood to the victim and burying the victim in earth for 3 nights. If the new vampire is lower level than its creator, it is under the creator's control. A victim that is 8th level or higher becomes a strigoi servant, while a lower-level victim instead becomes a moroi vampire. If a vampire controls too many spawn at once (as determined by the GM), strong-willed spawn can free themselves by succeeding at a Will saving throw against the vampire's Will DC.  \n  \n**Shadow Escape** [-] **Trigger** The strigoi is reduced to 0 HP; **Effect** The strigoi uses Shadow Form. It can take move actions to move toward its coffin even though it's at 0 HP. While at 0 HP in this form, the strigoi is unaffected by further damage. Once the strigoi reaches its coffin, or if it hasn't done so within 2 hours, it automatically returns to its physical form, unconscious.  \n  \n**Domain of Dusk** [##] (conjuration, divine, shadow) With a wave of its hand, the strigoi calls fourth vile ruination from the surrounding shadows, causing coils of darkness and shadowy bats, rats, and wolves to lash out at living targets in a 30-foot emanation. Living creatures in this area take 1d6 negative damage +1d6 per 2 levels possessed by the strigoi (basic Fortitude save against the DC of the strigoi's level). A creature that fails this save is also dazzled for 1 round (or blinded for 1 round and then dazzled for 1 round) by the darkness. The strigoi progenitor can't use Domain of Dusk for 1 minute.  \n  \n**Dominate** [##] (divine, enchantment, incapacitation, mental, visual) The vampire can cast *dominate* at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait. The save DC uses the DC of the vampire's level, and a creature that succeeds is temporarily immune to that vampire's Dominate for 24 hours. Fully destroying the vampire ends the domination, but merely reducing the vampire to 0 HP is insufficient to break the spell.   \n  \n**Drink Essence** As a typical strigoi, but the victim is drained 2 and stupefied 2 instead of 1.",
       "type": "section"
     },
     {

--- a/monster_families/shining_kingdoms/failed_prophet.json
+++ b/monster_families/shining_kingdoms/failed_prophet.json
@@ -178,402 +178,11 @@
       {
         "changes": [
           {
-            "abilities": [
-              {
-                "ability_category": "special_sense",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "imprecise sense",
-                    "aonid": 2407,
-                    "game-obj": "Rules",
-                    "name": "imprecise sense",
-                    "type": "link"
-                  }
-                ],
-                "name": "Wealthsense",
-                "range": {
-                  "range": 60,
-                  "subtype": "range",
-                  "text": "range of 60 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "The failed prophet can detect concentrations of coinage and other valuables as an imprecise sense with a range of 60 feet. The failed prophet detects any creature carrying coins and treasure totaling at least the average cost of a consumable item of the failed prophet\u2019s level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "bleed",
-                    "aonid": 86,
-                    "game-obj": "Conditions",
-                    "name": "bleed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "death effects",
-                    "aonid": 2331,
-                    "game-obj": "Rules",
-                    "name": "death effects",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "disease",
-                    "aonid": 578,
-                    "game-obj": "Traits",
-                    "name": "disease",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "doomed",
-                    "aonid": 67,
-                    "game-obj": "Conditions",
-                    "name": "doomed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "drained",
-                    "aonid": 68,
-                    "game-obj": "Conditions",
-                    "name": "drained",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "fatigued",
-                    "aonid": 73,
-                    "game-obj": "Conditions",
-                    "name": "fatigued",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "healing",
-                    "aonid": 623,
-                    "game-obj": "Traits",
-                    "name": "healing",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "nonlethal",
-                    "aonid": 661,
-                    "game-obj": "Traits",
-                    "name": "nonlethal",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "poison",
-                    "aonid": 669,
-                    "game-obj": "Traits",
-                    "name": "poison",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "sickened",
-                    "aonid": 91,
-                    "game-obj": "Conditions",
-                    "name": "sickened",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unconscious",
-                    "aonid": 95,
-                    "game-obj": "Conditions",
-                    "name": "unconscious",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "vitality",
-                    "aonid": 509,
-                    "game-obj": "Traits",
-                    "name": "vitality",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "void",
-                    "aonid": 510,
-                    "game-obj": "Traits",
-                    "name": "void",
-                    "type": "link"
-                  }
-                ],
-                "name": "Immunities",
-                "subtype": "ability",
-                "text": "bleed, death effects, disease, doomed, drained, fatigued, healing, nonlethal attacks, paralyzed, poison, sickened, unconscious, vitality, void",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "spirit",
-                    "aonid": 737,
-                    "game-obj": "Traits",
-                    "name": "spirit",
-                    "type": "link"
-                  }
-                ],
-                "name": "Weakness",
-                "subtype": "ability",
-                "text": "spirit 10; this weakness increases to 15 at 15th level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "hp_automatic",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "cold",
-                    "aonid": 555,
-                    "game-obj": "Traits",
-                    "name": "cold",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "electricity",
-                    "aonid": 586,
-                    "game-obj": "Traits",
-                    "name": "electricity",
-                    "type": "link"
-                  }
-                ],
-                "name": "Resistances",
-                "subtype": "ability",
-                "text": "cold 10, electricity 10, and physical 10 (except magical bludgeoning); these resistances increase to 15 at 15th level",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Broken Mindscape",
-                "range": {
-                  "range": 30,
-                  "subtype": "range",
-                  "text": "30 feet",
-                  "type": "stat_block_section",
-                  "unit": "feet"
-                },
-                "subtype": "ability",
-                "text": "A creature entering the aura or starting its turn in the aura must attempt a Will save. Use the moderate spell DC for the failed prophet\u2019s level (GM Core 121).",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "aura",
-                      "aonid": 542,
-                      "game-obj": "Traits",
-                      "name": "aura",
-                      "type": "link"
-                    },
-                    "name": "aura",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "illusion",
-                      "aonid": 629,
-                      "game-obj": "Traits",
-                      "name": "illusion",
-                      "type": "link"
-                    },
-                    "name": "illusion",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "incapacitation",
-                      "aonid": 631,
-                      "game-obj": "Traits",
-                      "name": "incapacitation",
-                      "type": "link"
-                    },
-                    "name": "incapacitation",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  },
-                  {
-                    "link": {
-                      "alt": "mental",
-                      "aonid": 647,
-                      "game-obj": "Traits",
-                      "name": "mental",
-                      "type": "link"
-                    },
-                    "name": "mental",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Success",
-                "subtype": "ability",
-                "text": "The creature is unaffected and becomes immune to broken mindscape for 1 minute.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "stunned",
-                    "aonid": 93,
-                    "game-obj": "Conditions",
-                    "name": "stunned",
-                    "type": "link"
-                  }
-                ],
-                "name": "Success",
-                "subtype": "ability",
-                "text": "The creature is stunned 1 as disjointed visions of the failed prophet\u2019s mindscape assail its senses.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "paralyzed",
-                    "aonid": 85,
-                    "game-obj": "Conditions",
-                    "name": "paralyzed",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "mental",
-                    "aonid": 647,
-                    "game-obj": "Traits",
-                    "name": "mental",
-                    "type": "link"
-                  }
-                ],
-                "name": "Failure",
-                "subtype": "ability",
-                "text": "The creature\u2019s mind is pulled into the failed prophet\u2019s mindscape. It\u2019s paralyzed for 1 round. While paralyzed, the creature can take any actions with the mental or spirit traits, or that deal mental or spirit damage, as though those actions were purely mental. Such actions only have line of effect to the originating failed prophet and other creatures currently paralyzed by broken mindscape, though they treat all such creatures as though they were adjacent.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_type": "ability",
-                "name": "Critical Failure",
-                "subtype": "ability",
-                "text": "As failure, but the duration is 1 minute or until the failed prophet is destroyed, whichever happens first.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "automatic",
-                "ability_type": "ability",
-                "name": "Taboos",
-                "subtype": "ability",
-                "text": "Despite the failed prophet\u2019s transformed body, a lifelong adherence to the strictures of the Prophecies of Kalistrade has ingrained the philosophical prohibitions into their soul. Whenever a failed prophet is critically hit by an unarmed attack, is critically hit by or critically fails a save against a touch spell, or is exposed to a disease or poison effect (even though immune), they take a \u20132 status penalty to their AC, attack bonuses, DCs, Perception, saving throws, and skill modifiers for 1 minute. Breaking other Kalistocratic taboos can also trigger this penalty at the GM\u2019s discretion.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "links": [
-                  {
-                    "alt": "magical",
-                    "aonid": 644,
-                    "game-obj": "Traits",
-                    "name": "magical",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "Strike attack bonus",
-                    "aonid": 2896,
-                    "game-obj": "Rules",
-                    "name": "Strike attack bonus",
-                    "type": "link"
-                  }
-                ],
-                "name": "Fists",
-                "subtype": "ability",
-                "text": "Failed prophets have a fist unarmed Strike that deals bludgeoning damage. This attack has the magical trait, reach 5 feet longer than the base creature, and triggers Greedy Grab. Use the high Strike attack bonus and moderate Strike damage of the failed prophet\u2019s level.",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "One Action",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "effect": "The failed prophet attempts a Thievery check against the target\u2019s Reflex DC. On a success, the failed prophet pilfers coins and gems from the target with a total value as indicated in the table, to a maximum of what the target is carrying. Valuables in unlocked containers on the target\u2019s person can be taken just as easily as those carried. On a critical success, the failed prophet steals double that amount. The failed prophet gains a number of temporary Hit Points equal to the value stolen that last for 1 minute.",
-                "links": [
-                  {
-                    "alt": "Strike",
-                    "aonid": 2306,
-                    "game-obj": "Actions",
-                    "name": "Strike",
-                    "type": "link"
-                  }
-                ],
-                "name": "Greedy Grab",
-                "requirement": "The failed prophet\u2019s last action was a successful fist Strike that dealt damage",
-                "subtype": "ability",
-                "type": "stat_block_section"
-              },
-              {
-                "ability_category": "offensive",
-                "ability_type": "ability",
-                "action_type": {
-                  "name": "Two Actions",
-                  "subtype": "action_type",
-                  "type": "stat_block_section"
-                },
-                "links": [
-                  {
-                    "alt": "spirit",
-                    "aonid": 737,
-                    "game-obj": "Traits",
-                    "name": "spirit",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "prophet\u2019s level",
-                    "aonid": 2899,
-                    "game-obj": "Rules",
-                    "name": "prophet\u2019s level",
-                    "type": "link"
-                  },
-                  {
-                    "alt": "unlimited use area damage",
-                    "aonid": 2910,
-                    "game-obj": "Rules",
-                    "name": "unlimited use area damage",
-                    "type": "link"
-                  }
-                ],
-                "name": "This Is My Reality!",
-                "subtype": "ability",
-                "text": "The failed prophet exerts control over their crumbling mindscape to inflict harm upon those trapped within. This can take the form of falling debris, natural disasters, or anything else the failed prophet can imagine. No matter the form, each creature currently paralyzed by the failed prophet\u2019s broken mindscape takes spirit damage with a basic Will save. The save DC uses the high spell DC for the failed prophet\u2019s level and the unlimited use area damage for the failed prophet\u2019s level.",
-                "traits": [
-                  {
-                    "link": {
-                      "alt": "concentrate",
-                      "aonid": 561,
-                      "game-obj": "Traits",
-                      "name": "concentrate",
-                      "type": "link"
-                    },
-                    "name": "concentrate",
-                    "subtype": "trait",
-                    "type": "stat_block_section"
-                  }
-                ],
-                "type": "stat_block_section"
-              }
-            ],
             "change_category": "abilities",
             "effects": [
               {
                 "operation": "add_items",
-                "source": "$.monster_family.subtypes[*].changes[*].abilities",
+                "source": "$.sections[?(@.name=='Failed Prophet Abilities')].abilities",
                 "target": "$.defense.automatic_abilities"
               }
             ],
@@ -591,6 +200,223 @@
                 "game-obj": "Traits",
                 "name": "humanoid",
                 "type": "link"
+              },
+              {
+                "alt": "imprecise sense",
+                "aonid": 2407,
+                "game-obj": "Rules",
+                "name": "imprecise sense",
+                "type": "link"
+              },
+              {
+                "alt": "bleed",
+                "aonid": 86,
+                "game-obj": "Conditions",
+                "name": "bleed",
+                "type": "link"
+              },
+              {
+                "alt": "death effects",
+                "aonid": 2331,
+                "game-obj": "Rules",
+                "name": "death effects",
+                "type": "link"
+              },
+              {
+                "alt": "disease",
+                "aonid": 578,
+                "game-obj": "Traits",
+                "name": "disease",
+                "type": "link"
+              },
+              {
+                "alt": "doomed",
+                "aonid": 67,
+                "game-obj": "Conditions",
+                "name": "doomed",
+                "type": "link"
+              },
+              {
+                "alt": "drained",
+                "aonid": 68,
+                "game-obj": "Conditions",
+                "name": "drained",
+                "type": "link"
+              },
+              {
+                "alt": "fatigued",
+                "aonid": 73,
+                "game-obj": "Conditions",
+                "name": "fatigued",
+                "type": "link"
+              },
+              {
+                "alt": "healing",
+                "aonid": 623,
+                "game-obj": "Traits",
+                "name": "healing",
+                "type": "link"
+              },
+              {
+                "alt": "nonlethal",
+                "aonid": 661,
+                "game-obj": "Traits",
+                "name": "nonlethal",
+                "type": "link"
+              },
+              {
+                "alt": "poison",
+                "aonid": 669,
+                "game-obj": "Traits",
+                "name": "poison",
+                "type": "link"
+              },
+              {
+                "alt": "sickened",
+                "aonid": 91,
+                "game-obj": "Conditions",
+                "name": "sickened",
+                "type": "link"
+              },
+              {
+                "alt": "unconscious",
+                "aonid": 95,
+                "game-obj": "Conditions",
+                "name": "unconscious",
+                "type": "link"
+              },
+              {
+                "alt": "vitality",
+                "aonid": 509,
+                "game-obj": "Traits",
+                "name": "vitality",
+                "type": "link"
+              },
+              {
+                "alt": "void",
+                "aonid": 510,
+                "game-obj": "Traits",
+                "name": "void",
+                "type": "link"
+              },
+              {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              {
+                "alt": "cold",
+                "aonid": 555,
+                "game-obj": "Traits",
+                "name": "cold",
+                "type": "link"
+              },
+              {
+                "alt": "electricity",
+                "aonid": 586,
+                "game-obj": "Traits",
+                "name": "electricity",
+                "type": "link"
+              },
+              {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "stunned",
+                "aonid": 93,
+                "game-obj": "Conditions",
+                "name": "stunned",
+                "type": "link"
+              },
+              {
+                "alt": "paralyzed",
+                "aonid": 85,
+                "game-obj": "Conditions",
+                "name": "paralyzed",
+                "type": "link"
+              },
+              {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              {
+                "alt": "magical",
+                "aonid": 644,
+                "game-obj": "Traits",
+                "name": "magical",
+                "type": "link"
+              },
+              {
+                "alt": "Strike attack bonus",
+                "aonid": 2896,
+                "game-obj": "Rules",
+                "name": "Strike attack bonus",
+                "type": "link"
+              },
+              {
+                "alt": "Strike",
+                "aonid": 2306,
+                "game-obj": "Actions",
+                "name": "Strike",
+                "type": "link"
+              },
+              {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              {
+                "alt": "spirit",
+                "aonid": 737,
+                "game-obj": "Traits",
+                "name": "spirit",
+                "type": "link"
+              },
+              {
+                "alt": "prophet\u2019s level",
+                "aonid": 2899,
+                "game-obj": "Rules",
+                "name": "prophet\u2019s level",
+                "type": "link"
+              },
+              {
+                "alt": "unlimited use area damage",
+                "aonid": 2910,
+                "game-obj": "Rules",
+                "name": "unlimited use area damage",
+                "type": "link"
               }
             ],
             "subtype": "change",
@@ -600,7 +426,6 @@
         ],
         "name": "Failed Prophet Abilities",
         "subtype": "monster_family",
-        "text": "Failed prophets gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life prior to the transformation, such as human or humanoid.",
         "type": "stat_block_section"
       }
     ],
@@ -626,6 +451,649 @@
         }
       ],
       "text": "To create a failed prophet, apply the following steps to any living creature of at least 10th level that has failed to properly perform the Kalistocrat death ritual.",
+      "type": "section"
+    },
+    {
+      "abilities": [
+        {
+          "ability_category": "special_sense",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "imprecise sense",
+              "aonid": 2407,
+              "game-obj": "Rules",
+              "name": "imprecise sense",
+              "type": "link"
+            }
+          ],
+          "name": "Wealthsense",
+          "range": {
+            "range": 60,
+            "subtype": "range",
+            "text": "range of 60 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "The failed prophet can detect concentrations of coinage and other valuables as an imprecise sense with a range of 60 feet. The failed prophet detects any creature carrying coins and treasure totaling at least the average cost of a consumable item of the failed prophet\u2019s level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "bleed",
+              "aonid": 86,
+              "game-obj": "Conditions",
+              "name": "bleed",
+              "type": "link"
+            },
+            {
+              "alt": "death effects",
+              "aonid": 2331,
+              "game-obj": "Rules",
+              "name": "death effects",
+              "type": "link"
+            },
+            {
+              "alt": "disease",
+              "aonid": 578,
+              "game-obj": "Traits",
+              "name": "disease",
+              "type": "link"
+            },
+            {
+              "alt": "doomed",
+              "aonid": 67,
+              "game-obj": "Conditions",
+              "name": "doomed",
+              "type": "link"
+            },
+            {
+              "alt": "drained",
+              "aonid": 68,
+              "game-obj": "Conditions",
+              "name": "drained",
+              "type": "link"
+            },
+            {
+              "alt": "fatigued",
+              "aonid": 73,
+              "game-obj": "Conditions",
+              "name": "fatigued",
+              "type": "link"
+            },
+            {
+              "alt": "healing",
+              "aonid": 623,
+              "game-obj": "Traits",
+              "name": "healing",
+              "type": "link"
+            },
+            {
+              "alt": "nonlethal",
+              "aonid": 661,
+              "game-obj": "Traits",
+              "name": "nonlethal",
+              "type": "link"
+            },
+            {
+              "alt": "poison",
+              "aonid": 669,
+              "game-obj": "Traits",
+              "name": "poison",
+              "type": "link"
+            },
+            {
+              "alt": "sickened",
+              "aonid": 91,
+              "game-obj": "Conditions",
+              "name": "sickened",
+              "type": "link"
+            },
+            {
+              "alt": "unconscious",
+              "aonid": 95,
+              "game-obj": "Conditions",
+              "name": "unconscious",
+              "type": "link"
+            },
+            {
+              "alt": "vitality",
+              "aonid": 509,
+              "game-obj": "Traits",
+              "name": "vitality",
+              "type": "link"
+            },
+            {
+              "alt": "void",
+              "aonid": 510,
+              "game-obj": "Traits",
+              "name": "void",
+              "type": "link"
+            }
+          ],
+          "name": "Immunities",
+          "subtype": "ability",
+          "text": "bleed, death effects, disease, doomed, drained, fatigued, healing, nonlethal attacks, paralyzed, poison, sickened, unconscious, vitality, void",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "spirit",
+              "aonid": 737,
+              "game-obj": "Traits",
+              "name": "spirit",
+              "type": "link"
+            }
+          ],
+          "name": "Weakness",
+          "subtype": "ability",
+          "text": "spirit 10; this weakness increases to 15 at 15th level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "hp_automatic",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "cold",
+              "aonid": 555,
+              "game-obj": "Traits",
+              "name": "cold",
+              "type": "link"
+            },
+            {
+              "alt": "electricity",
+              "aonid": 586,
+              "game-obj": "Traits",
+              "name": "electricity",
+              "type": "link"
+            }
+          ],
+          "name": "Resistances",
+          "subtype": "ability",
+          "text": "cold 10, electricity 10, and physical 10 (except magical bludgeoning); these resistances increase to 15 at 15th level",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Broken Mindscape",
+          "range": {
+            "range": 30,
+            "subtype": "range",
+            "text": "30 feet",
+            "type": "stat_block_section",
+            "unit": "feet"
+          },
+          "subtype": "ability",
+          "text": "A creature entering the aura or starting its turn in the aura must attempt a Will save. Use the moderate spell DC for the failed prophet\u2019s level (GM Core 121).",
+          "traits": [
+            {
+              "link": {
+                "alt": "aura",
+                "aonid": 542,
+                "game-obj": "Traits",
+                "name": "aura",
+                "type": "link"
+              },
+              "name": "aura",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "illusion",
+                "aonid": 629,
+                "game-obj": "Traits",
+                "name": "illusion",
+                "type": "link"
+              },
+              "name": "illusion",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "incapacitation",
+                "aonid": 631,
+                "game-obj": "Traits",
+                "name": "incapacitation",
+                "type": "link"
+              },
+              "name": "incapacitation",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            },
+            {
+              "link": {
+                "alt": "mental",
+                "aonid": 647,
+                "game-obj": "Traits",
+                "name": "mental",
+                "type": "link"
+              },
+              "name": "mental",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Success",
+          "subtype": "ability",
+          "text": "The creature is unaffected and becomes immune to broken mindscape for 1 minute.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "stunned",
+              "aonid": 93,
+              "game-obj": "Conditions",
+              "name": "stunned",
+              "type": "link"
+            }
+          ],
+          "name": "Success",
+          "subtype": "ability",
+          "text": "The creature is stunned 1 as disjointed visions of the failed prophet\u2019s mindscape assail its senses.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "paralyzed",
+              "aonid": 85,
+              "game-obj": "Conditions",
+              "name": "paralyzed",
+              "type": "link"
+            },
+            {
+              "alt": "mental",
+              "aonid": 647,
+              "game-obj": "Traits",
+              "name": "mental",
+              "type": "link"
+            }
+          ],
+          "name": "Failure",
+          "subtype": "ability",
+          "text": "The creature\u2019s mind is pulled into the failed prophet\u2019s mindscape. It\u2019s paralyzed for 1 round. While paralyzed, the creature can take any actions with the mental or spirit traits, or that deal mental or spirit damage, as though those actions were purely mental. Such actions only have line of effect to the originating failed prophet and other creatures currently paralyzed by broken mindscape, though they treat all such creatures as though they were adjacent.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_type": "ability",
+          "name": "Critical Failure",
+          "subtype": "ability",
+          "text": "As failure, but the duration is 1 minute or until the failed prophet is destroyed, whichever happens first.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "automatic",
+          "ability_type": "ability",
+          "name": "Taboos",
+          "subtype": "ability",
+          "text": "Despite the failed prophet\u2019s transformed body, a lifelong adherence to the strictures of the Prophecies of Kalistrade has ingrained the philosophical prohibitions into their soul. Whenever a failed prophet is critically hit by an unarmed attack, is critically hit by or critically fails a save against a touch spell, or is exposed to a disease or poison effect (even though immune), they take a \u20132 status penalty to their AC, attack bonuses, DCs, Perception, saving throws, and skill modifiers for 1 minute. Breaking other Kalistocratic taboos can also trigger this penalty at the GM\u2019s discretion.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "links": [
+            {
+              "alt": "magical",
+              "aonid": 644,
+              "game-obj": "Traits",
+              "name": "magical",
+              "type": "link"
+            },
+            {
+              "alt": "Strike attack bonus",
+              "aonid": 2896,
+              "game-obj": "Rules",
+              "name": "Strike attack bonus",
+              "type": "link"
+            }
+          ],
+          "name": "Fists",
+          "subtype": "ability",
+          "text": "Failed prophets have a fist unarmed Strike that deals bludgeoning damage. This attack has the magical trait, reach 5 feet longer than the base creature, and triggers Greedy Grab. Use the high Strike attack bonus and moderate Strike damage of the failed prophet\u2019s level.",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "One Action",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "effect": "The failed prophet attempts a Thievery check against the target\u2019s Reflex DC. On a success, the failed prophet pilfers coins and gems from the target with a total value as indicated in the table, to a maximum of what the target is carrying. Valuables in unlocked containers on the target\u2019s person can be taken just as easily as those carried. On a critical success, the failed prophet steals double that amount. The failed prophet gains a number of temporary Hit Points equal to the value stolen that last for 1 minute.",
+          "links": [
+            {
+              "alt": "Strike",
+              "aonid": 2306,
+              "game-obj": "Actions",
+              "name": "Strike",
+              "type": "link"
+            }
+          ],
+          "name": "Greedy Grab",
+          "requirement": "The failed prophet\u2019s last action was a successful fist Strike that dealt damage",
+          "subtype": "ability",
+          "type": "stat_block_section"
+        },
+        {
+          "ability_category": "offensive",
+          "ability_type": "ability",
+          "action_type": {
+            "name": "Two Actions",
+            "subtype": "action_type",
+            "type": "stat_block_section"
+          },
+          "links": [
+            {
+              "alt": "spirit",
+              "aonid": 737,
+              "game-obj": "Traits",
+              "name": "spirit",
+              "type": "link"
+            },
+            {
+              "alt": "prophet\u2019s level",
+              "aonid": 2899,
+              "game-obj": "Rules",
+              "name": "prophet\u2019s level",
+              "type": "link"
+            },
+            {
+              "alt": "unlimited use area damage",
+              "aonid": 2910,
+              "game-obj": "Rules",
+              "name": "unlimited use area damage",
+              "type": "link"
+            }
+          ],
+          "name": "This Is My Reality!",
+          "subtype": "ability",
+          "text": "The failed prophet exerts control over their crumbling mindscape to inflict harm upon those trapped within. This can take the form of falling debris, natural disasters, or anything else the failed prophet can imagine. No matter the form, each creature currently paralyzed by the failed prophet\u2019s broken mindscape takes spirit damage with a basic Will save. The save DC uses the high spell DC for the failed prophet\u2019s level and the unlimited use area damage for the failed prophet\u2019s level.",
+          "traits": [
+            {
+              "link": {
+                "alt": "concentrate",
+                "aonid": 561,
+                "game-obj": "Traits",
+                "name": "concentrate",
+                "type": "link"
+              },
+              "name": "concentrate",
+              "subtype": "trait",
+              "type": "stat_block_section"
+            }
+          ],
+          "type": "stat_block_section"
+        }
+      ],
+      "links": [
+        {
+          "alt": "human",
+          "aonid": 627,
+          "game-obj": "Traits",
+          "name": "human",
+          "type": "link"
+        },
+        {
+          "alt": "humanoid",
+          "aonid": 628,
+          "game-obj": "Traits",
+          "name": "humanoid",
+          "type": "link"
+        },
+        {
+          "alt": "imprecise sense",
+          "aonid": 2407,
+          "game-obj": "Rules",
+          "name": "imprecise sense",
+          "type": "link"
+        },
+        {
+          "alt": "bleed",
+          "aonid": 86,
+          "game-obj": "Conditions",
+          "name": "bleed",
+          "type": "link"
+        },
+        {
+          "alt": "death effects",
+          "aonid": 2331,
+          "game-obj": "Rules",
+          "name": "death effects",
+          "type": "link"
+        },
+        {
+          "alt": "disease",
+          "aonid": 578,
+          "game-obj": "Traits",
+          "name": "disease",
+          "type": "link"
+        },
+        {
+          "alt": "doomed",
+          "aonid": 67,
+          "game-obj": "Conditions",
+          "name": "doomed",
+          "type": "link"
+        },
+        {
+          "alt": "drained",
+          "aonid": 68,
+          "game-obj": "Conditions",
+          "name": "drained",
+          "type": "link"
+        },
+        {
+          "alt": "fatigued",
+          "aonid": 73,
+          "game-obj": "Conditions",
+          "name": "fatigued",
+          "type": "link"
+        },
+        {
+          "alt": "healing",
+          "aonid": 623,
+          "game-obj": "Traits",
+          "name": "healing",
+          "type": "link"
+        },
+        {
+          "alt": "nonlethal",
+          "aonid": 661,
+          "game-obj": "Traits",
+          "name": "nonlethal",
+          "type": "link"
+        },
+        {
+          "alt": "poison",
+          "aonid": 669,
+          "game-obj": "Traits",
+          "name": "poison",
+          "type": "link"
+        },
+        {
+          "alt": "sickened",
+          "aonid": 91,
+          "game-obj": "Conditions",
+          "name": "sickened",
+          "type": "link"
+        },
+        {
+          "alt": "unconscious",
+          "aonid": 95,
+          "game-obj": "Conditions",
+          "name": "unconscious",
+          "type": "link"
+        },
+        {
+          "alt": "vitality",
+          "aonid": 509,
+          "game-obj": "Traits",
+          "name": "vitality",
+          "type": "link"
+        },
+        {
+          "alt": "void",
+          "aonid": 510,
+          "game-obj": "Traits",
+          "name": "void",
+          "type": "link"
+        },
+        {
+          "alt": "spirit",
+          "aonid": 737,
+          "game-obj": "Traits",
+          "name": "spirit",
+          "type": "link"
+        },
+        {
+          "alt": "cold",
+          "aonid": 555,
+          "game-obj": "Traits",
+          "name": "cold",
+          "type": "link"
+        },
+        {
+          "alt": "electricity",
+          "aonid": 586,
+          "game-obj": "Traits",
+          "name": "electricity",
+          "type": "link"
+        },
+        {
+          "alt": "aura",
+          "aonid": 542,
+          "game-obj": "Traits",
+          "name": "aura",
+          "type": "link"
+        },
+        {
+          "alt": "illusion",
+          "aonid": 629,
+          "game-obj": "Traits",
+          "name": "illusion",
+          "type": "link"
+        },
+        {
+          "alt": "incapacitation",
+          "aonid": 631,
+          "game-obj": "Traits",
+          "name": "incapacitation",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "stunned",
+          "aonid": 93,
+          "game-obj": "Conditions",
+          "name": "stunned",
+          "type": "link"
+        },
+        {
+          "alt": "paralyzed",
+          "aonid": 85,
+          "game-obj": "Conditions",
+          "name": "paralyzed",
+          "type": "link"
+        },
+        {
+          "alt": "mental",
+          "aonid": 647,
+          "game-obj": "Traits",
+          "name": "mental",
+          "type": "link"
+        },
+        {
+          "alt": "magical",
+          "aonid": 644,
+          "game-obj": "Traits",
+          "name": "magical",
+          "type": "link"
+        },
+        {
+          "alt": "Strike attack bonus",
+          "aonid": 2896,
+          "game-obj": "Rules",
+          "name": "Strike attack bonus",
+          "type": "link"
+        },
+        {
+          "alt": "Strike",
+          "aonid": 2306,
+          "game-obj": "Actions",
+          "name": "Strike",
+          "type": "link"
+        },
+        {
+          "alt": "concentrate",
+          "aonid": 561,
+          "game-obj": "Traits",
+          "name": "concentrate",
+          "type": "link"
+        },
+        {
+          "alt": "spirit",
+          "aonid": 737,
+          "game-obj": "Traits",
+          "name": "spirit",
+          "type": "link"
+        },
+        {
+          "alt": "prophet\u2019s level",
+          "aonid": 2899,
+          "game-obj": "Rules",
+          "name": "prophet\u2019s level",
+          "type": "link"
+        },
+        {
+          "alt": "unlimited use area damage",
+          "aonid": 2910,
+          "game-obj": "Rules",
+          "name": "unlimited use area damage",
+          "type": "link"
+        }
+      ],
+      "name": "Failed Prophet Abilities",
+      "sources": [
+        {
+          "link": {
+            "alt": "Shining Kingdoms pg. 180",
+            "aonid": 265,
+            "game-obj": "Sources",
+            "name": "Shining Kingdoms pg. 180",
+            "type": "link"
+          },
+          "name": "Shining Kingdoms",
+          "page": 180,
+          "type": "source"
+        }
+      ],
+      "text": "Failed prophets gain the following abilities. If the base creature has any abilities that specifically come from it being a living creature, it loses them. It also loses any traits that represented its life prior to the transformation, such as human or humanoid.  \n  \n**Wealthsense** The failed prophet can detect concentrations of coinage and other valuables as an imprecise sense with a range of 60 feet. The failed prophet detects any creature carrying coins and treasure totaling at least the average cost of a consumable item of the failed prophet\u2019s level.  \n  \n**Immunities** bleed, death effects, disease, doomed, drained, fatigued, healing, nonlethal attacks, paralyzed, poison, sickened, unconscious, vitality, void   \n  \n**Weakness** spirit 10; this weakness increases to 15 at 15th level.   \n  \n**Resistances** cold 10, electricity 10, and physical 10 (except magical bludgeoning); these resistances increase to 15 at 15th level   \n  \n**Broken Mindscape** (aura, illusion, incapacitation, mental) 30 feet. A creature entering the aura or starting its turn in the aura must attempt a Will save. Use the moderate spell DC for the failed prophet\u2019s level (GM Core 121).  \n  \n**Critical Success** The creature is unaffected and becomes immune to broken mindscape for 1 minute.  \n**Success** The creature is stunned 1 as disjointed visions of the failed prophet\u2019s mindscape assail its senses.  \n**Failure** The creature\u2019s mind is pulled into the failed prophet\u2019s mindscape. It\u2019s paralyzed for 1 round. While paralyzed, the creature can take any actions with the mental or spirit traits, or that deal mental or spirit damage, as though those actions were purely mental. Such actions only have line of effect to the originating failed prophet and other creatures currently paralyzed by broken mindscape, though they treat all such creatures as though they were adjacent.  \n**Critical Failure** As failure, but the duration is 1 minute or until the failed prophet is destroyed, whichever happens first.  \n  \n**Taboos** Despite the failed prophet\u2019s transformed body, a lifelong adherence to the strictures of the Prophecies of Kalistrade has ingrained the philosophical prohibitions into their soul. Whenever a failed prophet is critically hit by an unarmed attack, is critically hit by or critically fails a save against a touch spell, or is exposed to a disease or poison effect (even though immune), they take a \u20132 status penalty to their AC, attack bonuses, DCs, Perception, saving throws, and skill modifiers for 1 minute. Breaking other Kalistocratic taboos can also trigger this penalty at the GM\u2019s discretion.  \n  \n**Fists** Failed prophets have a fist unarmed Strike that deals bludgeoning damage. This attack has the magical trait, reach 5 feet longer than the base creature, and triggers Greedy Grab. Use the high Strike attack bonus and moderate Strike damage of the failed prophet\u2019s level.  \n  \n**Greedy Grab** [#] **Requirements** The failed prophet\u2019s last action was a successful fist Strike that dealt damage; **Effect** The failed prophet attempts a Thievery check against the target\u2019s Reflex DC. On a success, the failed prophet pilfers coins and gems from the target with a total value as indicated in the table, to a maximum of what the target is carrying. Valuables in unlocked containers on the target\u2019s person can be taken just as easily as those carried. On a critical success, the failed prophet steals double that amount. The failed prophet gains a number of temporary Hit Points equal to the value stolen that last for 1 minute.  \n\n\n|  |  |\n| --- | --- |\n| **Level** | **Value Stolen** |\n| 10-12 | 5d10 gp |\n| 13-15 | 6d10 gp |\n| 16-18 | 7d10 gp |\n| 19-20  | 8d10 gp |\n\n  \n**This Is My Reality!** [##] (concentrate) The failed prophet exerts control over their crumbling mindscape to inflict harm upon those trapped within. This can take the form of falling debris, natural disasters, or anything else the failed prophet can imagine. No matter the form, each creature currently paralyzed by the failed prophet\u2019s broken mindscape takes spirit damage with a basic Will save. The save DC uses the high spell DC for the failed prophet\u2019s level and the unlimited use area damage for the failed prophet\u2019s level.",
       "type": "section"
     }
   ],

--- a/monster_template.schema.1.0.json
+++ b/monster_template.schema.1.0.json
@@ -506,7 +506,7 @@
           "type": "string"
         },
         "item": {
-          "type": "object"
+          "type": ["object", "string"]
         },
         "minimum": {
           "type": "integer"

--- a/monster_templates/bestiary/elite.json
+++ b/monster_templates/bestiary/elite.json
@@ -65,6 +65,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": 2
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": 2
           },
@@ -143,6 +148,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "+4 damage (Elite, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/bestiary/weak.json
+++ b/monster_templates/bestiary/weak.json
@@ -65,6 +65,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": -2
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": -2
           },
@@ -138,6 +143,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "-4 damage (Weak, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/dark_archive/experimental_cryptids.json
+++ b/monster_templates/dark_archive/experimental_cryptids.json
@@ -326,6 +326,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": 1
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": 1
           },
@@ -404,6 +409,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "+2 damage (Experimental Cryptid, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/dark_archive/mutant_cryptids.json
+++ b/monster_templates/dark_archive/mutant_cryptids.json
@@ -255,6 +255,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": 1
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": 1
           },
@@ -333,6 +338,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "+2 damage (Mutant Cryptid, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/dark_archive/primeval_cryptid.json
+++ b/monster_templates/dark_archive/primeval_cryptid.json
@@ -462,6 +462,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": 1
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": 1
           },
@@ -540,6 +545,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "+2 damage (Primeval Cryptid, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/dark_archive/rumored_cryptid.json
+++ b/monster_templates/dark_archive/rumored_cryptid.json
@@ -374,6 +374,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": 1
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": 1
           },
@@ -452,6 +457,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "+2 damage (Rumored Cryptid, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/howl_of_the_wild/broodpiercer.json
+++ b/monster_templates/howl_of_the_wild/broodpiercer.json
@@ -215,6 +215,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": 1
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": 1
           },
@@ -293,6 +298,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "+2 damage (Broodpiercer, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/monster_core/elite.json
+++ b/monster_templates/monster_core/elite.json
@@ -107,6 +107,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": 2
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": 2
           },
@@ -185,6 +190,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "+4 damage (Elite, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",

--- a/monster_templates/monster_core/weak.json
+++ b/monster_templates/monster_core/weak.json
@@ -107,6 +107,11 @@
           },
           {
             "operation": "adjustment",
+            "target": "$.offense.offensive_actions[*].spells.spell_attack",
+            "value": -2
+          },
+          {
+            "operation": "adjustment",
             "target": "$.defense.automatic_abilities[*].saving_throw[*].dc",
             "value": -2
           },
@@ -185,6 +190,11 @@
             },
             "operation": "add_item",
             "target": "$.offense.offensive_actions[*].ability.damage"
+          },
+          {
+            "item": "-4 damage (Weak, limited use)",
+            "operation": "add_item",
+            "target": "$.offense.offensive_actions[*].spells.notes"
           }
         ],
         "subtype": "change",


### PR DESCRIPTION
## Summary
- Monster template JSON updated with spell_attack adjustments and spell damage notes for elite/weak/cryptid templates (9 files)
- Monster family JSON regenerated with preserved section text and abilities (154 files)
- Updated monster_family schema to allow spells on sections

Companion to devonjones/PFSRD2-Parser#103

## Test plan
- [ ] All template JSON validates against schema
- [ ] All family JSON validates against schema
- [ ] Spot-check Ghoul/Lich family sections for text + abilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)